### PR TITLE
refactor(prompt): add history key property

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -22,6 +22,7 @@
 - [Universal Keybindings](./universal-keybindings.md)
 - [Components](./components/index.md)
   - [File Explorer](./components/file-explorer.md)
+  - [Prompt](./components/prompt.md)
 - [Recipes](./recipes.md)
 - [Themes](./themes.md)
 - [Configurations](./configurations.md)

--- a/docs/src/components/prompt.md
+++ b/docs/src/components/prompt.md
@@ -1,0 +1,34 @@
+# Prompt
+
+The prompt is one of the most commonly used components in Ki, this is because
+unlike other editors, it is also the picker!
+
+## History
+
+Every kind of prompt has its own history.
+
+For example, the search prompt stores the history of searches.
+
+Unlike the usual prompts, however, the historical entries of a prompt are shown below the current line,
+starting with the most recent entry.
+
+To navigate to historical entries, use [Normal Mode](../normal-mode/index.md).
+
+`enter` is overridden to mean select the current item, it works in both Insert Mode and Normal mode.
+
+## Groups
+
+The items of a prompt can be grouped, for example, the items of the file picker are grouped by their
+parent folder.
+
+The group name of each item is also matched by the search query, in a disjunctive manner, i.e. an item
+will be matched if either its group name **or** its own name satisfies the search query.
+
+## Behaviour
+
+The prompt has two behaviours:
+
+| Kind   | Behavior                                  | Examples                     |
+| ------ | ----------------------------------------- | ---------------------------- |
+| Picker | Select current matching item upon `enter` | symbol picker, file picker   |
+| Prompt | Use current search query upon `enter`     | search prompt, rename prompt |

--- a/src/components/file_explorer.rs
+++ b/src/components/file_explorer.rs
@@ -347,7 +347,7 @@ impl Component for FileExplorer {
                     ),
                     Keymap::new(
                         "m",
-                        "Move file".to_string(),
+                        "Move path".to_string(),
                         Dispatch::OpenMoveFilePrompt(node.path.clone()),
                     ),
                     Keymap::new("r", "Refresh".to_string(), Dispatch::RefreshFileExplorer),
@@ -420,7 +420,7 @@ mod test_file_explorer {
     }
 
     #[test]
-    fn move_file() -> anyhow::Result<()> {
+    fn move_path() -> anyhow::Result<()> {
         execute_test(|s| {
             Box::new([
                 App(OpenFile(s.main_rs())),
@@ -428,7 +428,7 @@ mod test_file_explorer {
                 Expect(ComponentCount(1)),
                 App(HandleKeyEvents(keys!("space m").to_vec())),
                 Expect(ComponentCount(2)),
-                Expect(CurrentComponentTitle("Move file")),
+                Expect(CurrentComponentTitle("Move path")),
                 Editor(Insert("/hello/world.rs".to_string())),
                 App(HandleKeyEvent(key!("enter"))),
                 Expect(ComponentCount(2)),


### PR DESCRIPTION
This is to standardize the bookkeeping code,
instead of each kind of prompt storing their own history.

For example, the local search config histories.

After this refactor, every prompt has their own history.