### PR TITLE
fix(lsp/signature help): incorrect cursor input

### DIFF
--- a/src/components/editor.rs
+++ b/src/components/editor.rs
@@ -1169,13 +1169,11 @@ impl Editor {
     }
 
     pub(crate) fn get_request_params(&self) -> Option<RequestParams> {
-        let component_id = self.id();
         let position = self.get_cursor_position().ok()?;
         self.path().map(|path| RequestParams {
             path,
             position,
             context: ResponseContext {
-                component_id,
                 scope: None,
                 description: None,
             },

--- a/src/components/editor.rs
+++ b/src/components/editor.rs
@@ -1263,10 +1263,7 @@ impl Editor {
         )?);
         self.mode = Mode::Insert;
         self.cursor_direction = Direction::Start;
-        Ok(self
-            .get_request_params()
-            .map(|params| Dispatches::one(Dispatch::RequestSignatureHelp(params)))
-            .unwrap_or_default())
+        Ok(Dispatches::one(Dispatch::RequestSignatureHelp))
     }
 
     pub(crate) fn enter_normal_mode(&mut self) -> anyhow::Result<()> {

--- a/src/components/editor_keymap_legend.rs
+++ b/src/components/editor_keymap_legend.rs
@@ -18,7 +18,6 @@ use crate::{
 };
 
 use super::{
-    component::Component,
     editor::{Direction, DispatchEditor, Editor, HandleEventResult, SurroundKind},
     keymap_legend::{Keymap, KeymapLegendBody, KeymapLegendConfig, Keymaps},
     suggestive_editor::Info,
@@ -653,15 +652,11 @@ impl Editor {
                                     )
                                 }),
                             )
-                            .chain(self.editor().get_request_params().map(|params| {
-                                Keymap::new(
-                                    "s",
-                                    "Symbols".to_string(),
-                                    Dispatch::RequestDocumentSymbols(
-                                        params.set_description("Symbols"),
-                                    ),
-                                )
-                            }))
+                            .chain(Some(Keymap::new(
+                                "s",
+                                "Symbols".to_string(),
+                                Dispatch::RequestDocumentSymbols,
+                            )))
                             .chain(Some(Keymap::new(
                                 "t",
                                 "Theme".to_string(),
@@ -857,64 +852,44 @@ impl Editor {
             }
         };
         let lsp_keymaps = {
-            let keymaps = Keymaps::new(
-                &self
-                    .get_request_params()
-                    .map(|params| {
-                        let params = params.set_kind(Some(scope));
-                        [
-                            Keymap::new(
-                                "d",
-                                "Definitions".to_string(),
-                                Dispatch::RequestDefinitions(
-                                    params.clone().set_description("Definitions"),
-                                ),
-                            ),
-                            Keymap::new(
-                                "D",
-                                "Declarations".to_string(),
-                                Dispatch::RequestDeclarations(
-                                    params.clone().set_description("Declarations"),
-                                ),
-                            ),
-                            Keymap::new(
-                                "i",
-                                "Implementations".to_string(),
-                                Dispatch::RequestImplementations(
-                                    params.clone().set_description("Implementations"),
-                                ),
-                            ),
-                            Keymap::new(
-                                "r",
-                                "References".to_string(),
-                                Dispatch::RequestReferences {
-                                    params: params.clone().set_description("References"),
-                                    include_declaration: false,
-                                },
-                            ),
-                            Keymap::new(
-                                "R",
-                                "References (include declaration)".to_string(),
-                                Dispatch::RequestReferences {
-                                    params: params
-                                        .clone()
-                                        .set_description("References (include declaration)"),
-                                    include_declaration: true,
-                                },
-                            ),
-                            Keymap::new(
-                                "t",
-                                "Type Definitions".to_string(),
-                                Dispatch::RequestTypeDefinitions(
-                                    params.clone().set_description("Type Definitions"),
-                                ),
-                            ),
-                        ]
-                        .into_iter()
-                        .collect_vec()
-                    })
-                    .unwrap_or_default(),
-            );
+            let keymaps = Keymaps::new(&[
+                Keymap::new(
+                    "d",
+                    "Definitions".to_string(),
+                    Dispatch::RequestDefinitions(scope),
+                ),
+                Keymap::new(
+                    "D",
+                    "Declarations".to_string(),
+                    Dispatch::RequestDeclarations(scope),
+                ),
+                Keymap::new(
+                    "i",
+                    "Implementations".to_string(),
+                    Dispatch::RequestImplementations(scope),
+                ),
+                Keymap::new(
+                    "r",
+                    "References".to_string(),
+                    Dispatch::RequestReferences {
+                        include_declaration: false,
+                        scope,
+                    },
+                ),
+                Keymap::new(
+                    "R",
+                    "References (include declaration)".to_string(),
+                    Dispatch::RequestReferences {
+                        include_declaration: true,
+                        scope,
+                    },
+                ),
+                Keymap::new(
+                    "t",
+                    "Type Definitions".to_string(),
+                    Dispatch::RequestTypeDefinitions(scope),
+                ),
+            ]);
 
             KeymapLegendSection {
                 title: "LSP".to_string(),

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -185,17 +185,6 @@ impl Layout {
         }
     }
 
-    pub(crate) fn get_suggestive_editor(
-        &self,
-        component_id: ComponentId,
-    ) -> Result<Rc<RefCell<SuggestiveEditor>>, anyhow::Error> {
-        self.background_suggestive_editors
-            .iter()
-            .find(|(_, editor)| editor.borrow().id() == component_id)
-            .map(|(_, editor)| editor.clone())
-            .ok_or_else(|| anyhow!("Couldn't find component with id {:?}", component_id))
-    }
-
     fn show_info_on(
         &mut self,
         node_id: NodeId,

--- a/src/lsp/process.rs
+++ b/src/lsp/process.rs
@@ -723,11 +723,10 @@ impl LspServerProcess {
             })
         });
         while let Ok(message) = receiver.recv() {
-            log::info!("receiver.recv = {:#?}", message);
             debounce.put(Event(message))
         }
 
-        log::info!("[LspServerProcess] Stopped listening for messages from LSP server");
+        log::info!("LspServerProcess::listen | Stopped listening for messages from LSP server");
         handle
     }
 


### PR DESCRIPTION
This is because the LSP request params (i.e. cursor position) are prepared before the cursor position is updated.

This is mitigated by pushing the params preparation to be as late as possible