### PR TITLE
feat(editor): yank ring

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   check:
     name: all-rust-check
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
 
     steps:
     - uses: actions/checkout@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1214,6 +1214,7 @@ dependencies = [
  "my_proc_macros",
  "name-variant",
  "nary_tree",
+ "nonempty",
  "nucleo-matcher",
  "once_cell",
  "portable-pty",
@@ -1503,6 +1504,12 @@ dependencies = [
  "memoffset 0.6.5",
  "pin-utils",
 ]
+
+[[package]]
+name = "nonempty"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "303e8749c804ccd6ca3b428de7fe0d86cb86bc7606bc15291f100fd487960bb8"
 
 [[package]]
 name = "nu-ansi-term"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ nary_tree = "0.4.3"
 name-variant = "0.1.0"
 strum = "0.26.2"
 strum_macros = "0.26.2"
+nonempty = "0.10.0"
 
 [dev-dependencies]
 serial_test = "2.0.0"

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -16,6 +16,7 @@
       - [LSP](./normal-mode/selection-modes/local-global/lsp-based.md)
       - [Misc](./normal-mode/selection-modes/local-global/misc.md)
   - [Actions](./normal-mode/actions/index.md)
+    - [Clipboard-related Actions](./normal-mode/actions/clipboard-related-actions.md)
   - [Movement-Actions](./normal-mode/movement-actions.md)
   - [Other Movements](./normal-mode/other-movements.md)
   - [Space Menu](./normal-mode/space-menu.md)

--- a/docs/src/normal-mode/actions/clipboard-related-actions.md
+++ b/docs/src/normal-mode/actions/clipboard-related-actions.md
@@ -19,6 +19,9 @@ When there are multiple cursors:
 - Copy joins every selection into a single string and then place it in the system clipboard
 - Paste uses the same string from the system clipboard for every cursor
 
+Note: when new content are copied to the system clipboard, it will also be
+copied to the editor clipboard.
+
 ## Copy
 
 Keybindings:

--- a/docs/src/normal-mode/actions/clipboard-related-actions.md
+++ b/docs/src/normal-mode/actions/clipboard-related-actions.md
@@ -1,0 +1,86 @@
+# Clipboard-related Actions
+
+The following actions are grouped separately on this page because they interact with the clipboard.
+
+There are two kinds of clipboards:
+
+1. The editor clipboard
+2. The system clipboard
+
+By default, the editor clipboard is used, to use the system clipboard, press
+`\` before pressing the keybindings of the following actions.
+
+The editor clipboard works for multiple cursors, the text of each cursor can be
+copied to and pasted from the editor clipboard respectively.
+
+The system clipboard however does not support multiple cursors.
+When there are multiple cursors:
+
+- Copy joins every selection into a single string and then place it in the system clipboard
+- Paste uses the same string from the system clipboard for every cursor
+
+## Copy
+
+Keybindings:
+
+- `y`: Copy to editor clipboard
+
+Memory aid: y stands for yank, yank to the clipboard.
+
+This action copies the current selected text.
+
+Copy behaves differently depending on the number of cursors.
+
+When there is more than one cursor, the selected texts of each cursor will be
+copied to the cursor-specific clipboard.
+
+## Paste
+
+Keybindings:
+
+- `p`: Paste after selection
+- `P`: Paste before selection
+
+This action pastes the content from the clipboard (either the system clipboard or
+cursor-specific clipboard) after/before the current selection.
+
+Notes:
+
+- It does not replace the current selection.
+- The pasted text will be selected.
+
+### Smart Paste
+
+Smart Paste will be executed when the selection mode is [contiguous](../selection-modes/index.md#contiguity).
+
+Smart Paste works by analyzing the gap between the current selection and the
+previous/next selection, then insert the gap before/after the pasted text.
+
+For example, consider the following Javascript code:
+
+```js
+hello(x, y);
+```
+
+Assuming the current selection mode is [Syntax Node (Coarse)](../selection-modes/syntax-node-based.md#syntax-node-coarse), and the current selection is `y`, and the
+copied text is `z`, performing a `p` results in the following:
+
+```js
+hello(x, y, z);
+```
+
+## Change Cut
+
+Keybindings: `C`
+
+This is similar to [Change](./index.md#change), but it copies the deleted text into the system clipboard.  
+Like `ctrl+x` in Windows and `cmd+x` in macOS.
+
+## Replace
+
+Keybindings:
+
+- `r`: Replace
+- `R`: Replace (Cut), copies the replaced content into the clipboard
+
+This replaces the current selected text with the copied text.

--- a/docs/src/normal-mode/actions/index.md
+++ b/docs/src/normal-mode/actions/index.md
@@ -68,7 +68,6 @@ hello(y);
 Keybindings:
 
 - `c`: Change
-- `C`: Change (Cut), copies the deleted content into the clipboard
 
 This deletes the current selected text, and enter [Insert mode
 ](../../modes.md#insert).

--- a/docs/src/normal-mode/actions/index.md
+++ b/docs/src/normal-mode/actions/index.md
@@ -3,7 +3,7 @@
 ## Notes for reading
 
 1. When "selection" is mentioned, you should read it as "selection(s)", because
-   these actions work with multi-cursors.
+   these actions work with multiple cursors.
 
 ## Enter [insert mode](../../insert-mode/index.md)
 
@@ -11,55 +11,6 @@ Keybindings:
 
 - `i`: Enter insert mode before selection
 - `a`: Enter insert mode after selection
-
-## Copy
-
-Keybinding: `y`  
-Memory aid: y stands for yank, yank to the clipboard.
-
-This action copies the current selected text.
-
-Copy behaves differently depending on the number of cursors.
-
-When there is only one cursor, the content is copied to the system clipboard.
-
-When there is more than one cursor, the selected texts of each cursor will be
-copied to a cursor-specific clipboard instead.
-
-## Paste
-
-Keybindings:
-
-- `p`: Paste after selection
-- `P`: Paste before selection
-
-This action pastes the content from the clipboard (either the system clipboard or
-cursor-specific clipboard) after/before the current selection.
-
-Notes:
-
-- It does not replace the current selection.
-- The pasted text will be selected.
-
-### Smart Paste
-
-When the selection mode is [contiguous](../selection-modes/index.md#contiguity), Smart Paste will be executed.
-
-Smart Paste works by analyzing the gap between the current selection and the
-previous/next selection, then insert the gap before/after the pasted text.
-
-For example, consider the following Javascript code:
-
-```js
-hello(x, y);
-```
-
-Assuming the current selection mode is [Syntax Node (Coarse)](../selection-modes/syntax-node-based.md#syntax-node-coarse), and the current selection is `y`, and the
-copied text is `z`, performing a `p` results in the following:
-
-```js
-hello(x, y, z);
-```
 
 ## Open
 
@@ -122,14 +73,16 @@ Keybindings:
 This deletes the current selected text, and enter [Insert mode
 ](../../modes.md#insert).
 
-## Replace
+## Replace with previous/next copied text
 
 Keybindings:
 
-- `r`: Replace
-- `R`: Replace (Cut), copies the replaced content into the clipboard
+- `ctrl+n`: Replace current selection with next copied text in the clipboard history
+- `ctrl+p`: Replace current selection with previous copied text in the clipboard history
 
-This replaces the current selected text with the copied text.
+This is similar to [Yanking Earlier Kills](https://www.gnu.org/software/emacs/manual/html_node/emacs/Earlier-Kills.html) in Emacs.
+
+This is useful when you want to retrieve earlier copies.
 
 ## Replace with pattern
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -595,7 +595,12 @@ impl<T: Frontend> App<T> {
             Dispatch::RefreshFileExplorer => {
                 self.layout.refresh_file_explorer(&self.working_directory)?
             }
-            Dispatch::SetClipboardContent(content) => self.context.set_clipboard_content(content),
+            Dispatch::SetClipboardContent {
+                contents,
+                to_system_clipboard,
+            } => self
+                .context
+                .set_clipboard_content(contents, to_system_clipboard)?,
             Dispatch::SetGlobalMode(mode) => self.set_global_mode(mode),
 
             #[cfg(test)]
@@ -2109,7 +2114,10 @@ pub(crate) enum Dispatch {
     },
     AddPath(String),
     RefreshFileExplorer,
-    SetClipboardContent(String),
+    SetClipboardContent {
+        contents: Vec<String>,
+        to_system_clipboard: bool,
+    },
     SetGlobalMode(Option<GlobalMode>),
     #[cfg(test)]
     HandleKeyEvent(event::KeyEvent),

--- a/src/app.rs
+++ b/src/app.rs
@@ -597,10 +597,10 @@ impl<T: Frontend> App<T> {
             }
             Dispatch::SetClipboardContent {
                 contents,
-                to_system_clipboard,
+                use_system_clipboard,
             } => self
                 .context
-                .set_clipboard_content(contents, to_system_clipboard)?,
+                .set_clipboard_content(contents, use_system_clipboard)?,
             Dispatch::SetGlobalMode(mode) => self.set_global_mode(mode),
 
             #[cfg(test)]
@@ -2116,7 +2116,7 @@ pub(crate) enum Dispatch {
     RefreshFileExplorer,
     SetClipboardContent {
         contents: Vec<String>,
-        to_system_clipboard: bool,
+        use_system_clipboard: bool,
     },
     SetGlobalMode(Option<GlobalMode>),
     #[cfg(test)]

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,6 @@
 use crate::{
     buffer::Buffer,
+    clipboard::CopiedTexts,
     components::{
         component::{Component, ComponentId, GetGridResult},
         dropdown::{DropdownItem, DropdownRender},
@@ -596,7 +597,7 @@ impl<T: Frontend> App<T> {
                 self.layout.refresh_file_explorer(&self.working_directory)?
             }
             Dispatch::SetClipboardContent {
-                contents,
+                copied_texts: contents,
                 use_system_clipboard,
             } => self
                 .context
@@ -2115,7 +2116,7 @@ pub(crate) enum Dispatch {
     AddPath(String),
     RefreshFileExplorer,
     SetClipboardContent {
-        contents: Vec<String>,
+        copied_texts: CopiedTexts,
         use_system_clipboard: bool,
     },
     SetGlobalMode(Option<GlobalMode>),

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -1,26 +1,92 @@
 #[derive(Clone)]
 pub(crate) struct Clipboard {
-    history: Vec<String>,
+    history: RingHistory<Vec<String>>,
 }
 
 impl Clipboard {
     pub(crate) fn new() -> Clipboard {
-        Clipboard { history: vec![] }
-    }
-
-    /// Get from OS clipboard when available
-    pub(crate) fn get_content(&self) -> Option<String> {
-        arboard::Clipboard::new()
-            .and_then(|mut clipboard| clipboard.get_text())
-            .ok()
-            .or_else(|| self.history.last().cloned())
-    }
-
-    /// Set OS clipboard when available
-    pub(crate) fn set_content(&mut self, content: String) {
-        if let Ok(mut clipboard) = arboard::Clipboard::new() {
-            clipboard.set_text(content.clone()).ok();
+        Clipboard {
+            history: Default::default(),
         }
-        self.history.push(content);
+    }
+
+    pub(crate) fn get(&self, history_offset: isize) -> Option<Vec<String>> {
+        self.history.get(history_offset)
+    }
+
+    pub(crate) fn get_from_system_clipboard(&self) -> anyhow::Result<String> {
+        Ok(arboard::Clipboard::new()?.get_text()?)
+    }
+
+    pub(crate) fn set(
+        &mut self,
+        content: Vec<String>,
+        to_system_clipboard: bool,
+    ) -> anyhow::Result<()> {
+        self.history.add(content.clone());
+        if to_system_clipboard {
+            arboard::Clipboard::new()?.set_text(content.join("\n"))?
+        }
+        Ok(())
+    }
+}
+
+#[derive(PartialEq, Clone, Debug, Eq, Hash, Default)]
+pub(crate) struct RingHistory<T: Clone> {
+    items: Vec<T>,
+}
+impl<T: Clone> RingHistory<T> {
+    /// 0 means latest.  
+    /// -1 means previous.  
+    /// +1 means next.  
+    pub(crate) fn get(&self, history_offset: isize) -> Option<T> {
+        let len = self.items.len();
+        if len == 0 {
+            return None;
+        }
+        if history_offset.is_positive() {
+            self.items
+                .iter()
+                .cycle()
+                .skip(len - 1)
+                .nth(history_offset.unsigned_abs().rem_euclid(len))
+                .cloned()
+        } else {
+            self.items
+                .iter()
+                .rev()
+                .nth(history_offset.unsigned_abs().rem_euclid(len))
+                .cloned()
+        }
+    }
+
+    pub(crate) fn add(&mut self, item: T) {
+        self.items.push(item)
+    }
+}
+
+#[cfg(test)]
+mod test_ring_history {
+    use super::*;
+    #[test]
+    fn test_get() {
+        let mut history = RingHistory::default();
+        assert_eq!(history.get(0), None);
+        history.add("a".to_string());
+        history.add("b".to_string());
+        history.add("c".to_string());
+
+        let expected = [
+            (-3, "c"),
+            (-2, "a"),
+            (-1, "b"),
+            (0, "c"),
+            (1, "a"),
+            (2, "b"),
+            (3, "c"),
+        ];
+        for (offset, expected) in expected {
+            assert_eq!(history.get(offset), Some(expected.to_string()))
+        }
     }
 }

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -21,10 +21,10 @@ impl Clipboard {
     pub(crate) fn set(
         &mut self,
         content: Vec<String>,
-        to_system_clipboard: bool,
+        use_system_clipboard: bool,
     ) -> anyhow::Result<()> {
         self.history.add(content.clone());
-        if to_system_clipboard {
+        if use_system_clipboard {
             arboard::Clipboard::new()?.set_text(content.join("\n"))?
         }
         Ok(())

--- a/src/components/editor_keymap_legend.rs
+++ b/src/components/editor_keymap_legend.rs
@@ -258,6 +258,16 @@ impl Editor {
                     Dispatch::ToEditor(ReplaceWithPattern),
                 ),
                 Keymap::new(
+                    "ctrl+p",
+                    "Replace (with previous copied text)".to_string(),
+                    Dispatch::ToEditor(ReplaceWithPreviousCopiedText),
+                ),
+                Keymap::new(
+                    "ctrl+n",
+                    "Replace (with next copied text)".to_string(),
+                    Dispatch::ToEditor(ReplaceWithNextCopiedText),
+                ),
+                Keymap::new(
                     "v",
                     "Toggle Visual Mode".to_string(),
                     Dispatch::ToEditor(ToggleVisualMode),
@@ -673,6 +683,21 @@ impl Editor {
                                 "o",
                                 "Keep only primary cursor".to_string(),
                                 Dispatch::ToEditor(DispatchEditor::CursorKeepPrimaryOnly),
+                            ),
+                        ]),
+                    }))
+                    .chain(Some(KeymapLegendSection {
+                        title: "Clipboard".to_string(),
+                        keymaps: Keymaps::new(&[
+                            Keymap::new(
+                                "y",
+                                "Copy to system clipboard".to_string(),
+                                Dispatch::ToEditor(DispatchEditor::CopyToSystemClipboard),
+                            ),
+                            Keymap::new(
+                                "p",
+                                "Paste from system clipboard".to_string(),
+                                Dispatch::ToEditor(DispatchEditor::PasteFromSystemClipboard),
                             ),
                         ]),
                     }))

--- a/src/components/editor_keymap_legend.rs
+++ b/src/components/editor_keymap_legend.rs
@@ -192,16 +192,7 @@ impl Editor {
                     "Insert (after selection)".to_string(),
                     Dispatch::ToEditor(EnterInsertMode(Direction::End)),
                 ),
-                Keymap::new(
-                    "c",
-                    "Change".to_string(),
-                    Dispatch::ToEditor(Change { cut: false }),
-                ),
-                Keymap::new(
-                    "C",
-                    "Change Cut".to_string(),
-                    Dispatch::ToEditor(Change { cut: true }),
-                ),
+                Keymap::new("c", "Change".to_string(), Dispatch::ToEditor(Change)),
                 Keymap::new(
                     "d",
                     "Delete (until next selection)".to_string(),
@@ -233,26 +224,6 @@ impl Editor {
                     Dispatch::ToEditor(Open(Direction::Start)),
                 ),
                 Keymap::new(
-                    "p",
-                    "Paste (after selection)".to_string(),
-                    Dispatch::ToEditor(Paste(Direction::End)),
-                ),
-                Keymap::new(
-                    "P",
-                    "Paste (before selection)".to_string(),
-                    Dispatch::ToEditor(Paste(Direction::Start)),
-                ),
-                Keymap::new(
-                    "r",
-                    "Replace".to_string(),
-                    Dispatch::ToEditor(ReplaceWithCopiedText),
-                ),
-                Keymap::new(
-                    "R",
-                    "Replace Cut".to_string(),
-                    Dispatch::ToEditor(ReplaceCut),
-                ),
-                Keymap::new(
                     "ctrl+r",
                     "Replace with pattern".to_string(),
                     Dispatch::ToEditor(ReplaceWithPattern),
@@ -272,12 +243,65 @@ impl Editor {
                     "Toggle Visual Mode".to_string(),
                     Dispatch::ToEditor(ToggleVisualMode),
                 ),
-                Keymap::new("y", "Yank (Copy)".to_string(), Dispatch::ToEditor(Copy)),
                 Keymap::new("enter", "Save".to_string(), Dispatch::ToEditor(Save)),
                 Keymap::new(
                     "!",
                     "Transform".to_string(),
                     Dispatch::ShowKeymapLegend(self.transform_keymap_legend_config()),
+                ),
+            ]),
+        }
+    }
+
+    fn keymap_clipboard_related_actions(&self, use_system_clipboard: bool) -> KeymapLegendSection {
+        KeymapLegendSection {
+            title: "Clipboard-related actions".to_string(),
+            keymaps: Keymaps::new(&[
+                Keymap::new(
+                    "C",
+                    "Change Cut".to_string(),
+                    Dispatch::ToEditor(ChangeCut {
+                        use_system_clipboard,
+                    }),
+                ),
+                Keymap::new(
+                    "p",
+                    "Paste (after selection)".to_string(),
+                    Dispatch::ToEditor(Paste {
+                        direction: Direction::End,
+                        use_system_clipboard,
+                    }),
+                ),
+                Keymap::new(
+                    "P",
+                    "Paste (before selection)".to_string(),
+                    Dispatch::ToEditor(Paste {
+                        direction: Direction::Start,
+                        use_system_clipboard,
+                    }),
+                ),
+                Keymap::new(
+                    "r",
+                    "Replace".to_string(),
+                    Dispatch::ToEditor(ReplaceWithCopiedText {
+                        use_system_clipboard,
+                        cut: false,
+                    }),
+                ),
+                Keymap::new(
+                    "R",
+                    "Replace Cut".to_string(),
+                    Dispatch::ToEditor(ReplaceWithCopiedText {
+                        use_system_clipboard,
+                        cut: true,
+                    }),
+                ),
+                Keymap::new(
+                    "y",
+                    "Yank (Copy)".to_string(),
+                    Dispatch::ToEditor(Copy {
+                        use_system_clipboard,
+                    }),
                 ),
             ]),
         }
@@ -301,7 +325,10 @@ impl Editor {
                 Keymap::new(
                     "ctrl+v",
                     "Paste".to_string(),
-                    Dispatch::ToEditor(Paste(Direction::End)),
+                    Dispatch::ToEditor(Paste {
+                        direction: Direction::End,
+                        use_system_clipboard: false,
+                    }),
                 ),
                 Keymap::new("ctrl+y", "Redo".to_string(), Dispatch::ToEditor(Redo)),
                 Keymap::new("ctrl+z", "Undo".to_string(), Dispatch::ToEditor(Undo)),
@@ -451,6 +478,16 @@ impl Editor {
                     Dispatch::ShowKeymapLegend(self.space_keymap_legend_config(context)),
                 ),
                 Keymap::new(
+                    "\\",
+                    "Clipboard-related actions (use system clipboard)".to_string(),
+                    Dispatch::ShowKeymapLegend(KeymapLegendConfig {
+                        title: "Clipboard-related actions (use system clipboard)".to_string(),
+                        body: KeymapLegendBody::SingleSection {
+                            keymaps: self.keymap_clipboard_related_actions(true).keymaps,
+                        },
+                    }),
+                ),
+                Keymap::new(
                     "'",
                     "Find literal".to_string(),
                     Dispatch::ShowKeymapLegend(self.show_literal_keymap_legend_config()),
@@ -533,6 +570,7 @@ impl Editor {
                     self.keymap_other_movements(),
                     self.keymap_selection_modes(context),
                     self.keymap_actions(),
+                    self.keymap_clipboard_related_actions(false),
                     self.keymap_others(context),
                     self.keymap_universal(),
                 ]
@@ -683,21 +721,6 @@ impl Editor {
                                 "o",
                                 "Keep only primary cursor".to_string(),
                                 Dispatch::ToEditor(DispatchEditor::CursorKeepPrimaryOnly),
-                            ),
-                        ]),
-                    }))
-                    .chain(Some(KeymapLegendSection {
-                        title: "Clipboard".to_string(),
-                        keymaps: Keymaps::new(&[
-                            Keymap::new(
-                                "y",
-                                "Copy to system clipboard".to_string(),
-                                Dispatch::ToEditor(DispatchEditor::CopyToSystemClipboard),
-                            ),
-                            Keymap::new(
-                                "p",
-                                "Paste from system clipboard".to_string(),
-                                Dispatch::ToEditor(DispatchEditor::PasteFromSystemClipboard),
                             ),
                         ]),
                     }))

--- a/src/components/test_editor.rs
+++ b/src/components/test_editor.rs
@@ -1,6 +1,7 @@
 use crate::app::LocalSearchConfigUpdate;
 use crate::app::Scope;
 use crate::char_index_range::CharIndexRange;
+use crate::clipboard::CopiedTexts;
 use crate::components::editor::DispatchEditor::*;
 use crate::components::editor::Movement::*;
 
@@ -745,7 +746,7 @@ fn paste_in_insert_mode_1() -> anyhow::Result<()> {
             App(OpenFile(s.main_rs())),
             Editor(SetContent("foo bar spam".to_string())),
             App(SetClipboardContent {
-                contents: ["haha".to_string()].to_vec(),
+                copied_texts: CopiedTexts::one("haha".to_string()),
                 use_system_clipboard: false,
             }),
             Editor(MatchLiteral("bar".to_string())),
@@ -791,7 +792,7 @@ fn paste_after() -> anyhow::Result<()> {
             App(OpenFile(s.main_rs())),
             Editor(SetContent("foo bar spam".to_string())),
             App(SetClipboardContent {
-                contents: ["haha".to_string()].to_vec(),
+                copied_texts: CopiedTexts::one("haha".to_string()),
                 use_system_clipboard: false,
             }),
             Editor(MatchLiteral("bar".to_string())),
@@ -814,7 +815,7 @@ fn smart_paste() -> anyhow::Result<()> {
                 Editor(SetContent("fn main(a:A, b:B) {}".to_string())),
                 Editor(MatchLiteral("a:A".to_string())),
                 App(SetClipboardContent {
-                    contents: ["c:C".to_string()].to_vec(),
+                    copied_texts: CopiedTexts::one("c:C".to_string()),
                     use_system_clipboard: false,
                 }),
                 Editor(SetSelectionMode(SyntaxNodeCoarse)),
@@ -838,7 +839,7 @@ fn paste_before() -> anyhow::Result<()> {
             App(OpenFile(s.main_rs())),
             Editor(SetContent("foo bar spam".to_string())),
             App(SetClipboardContent {
-                contents: ["haha".to_string()].to_vec(),
+                copied_texts: CopiedTexts::one("haha".to_string()),
                 use_system_clipboard: false,
             }),
             Editor(MatchLiteral("bar".to_string())),
@@ -861,12 +862,12 @@ fn replace_from_clipboard() -> anyhow::Result<()> {
                 "fn f(){ let x = S(a); let y = S(b); }".to_string(),
             )),
             App(SetClipboardContent {
-                contents: ["let z = S(c);".to_string()].to_vec(),
+                copied_texts: CopiedTexts::one("let z = S(c);".to_string()),
                 use_system_clipboard: false,
             }),
             Editor(ReplaceWithCopiedText {
                 cut: false,
-                use_system_clipboard: true,
+                use_system_clipboard: false,
             }),
             Expect(CurrentComponentContent(
                 "let z = S(c);fn f(){ let x = S(a); let y = S(b); }",
@@ -1913,7 +1914,7 @@ fn undo_till_empty_should_not_crash_in_insert_mode() -> anyhow::Result<()> {
             App(OpenFile(s.main_rs())),
             Editor(SetContent("".to_string())),
             App(SetClipboardContent {
-                contents: ["foo".to_string()].to_vec(),
+                copied_texts: CopiedTexts::one("foo".to_string()),
                 use_system_clipboard: false,
             }),
             Editor(EnterInsertMode(Direction::Start)),

--- a/src/context.rs
+++ b/src/context.rs
@@ -96,9 +96,9 @@ impl Context {
     pub(crate) fn set_clipboard_content(
         &mut self,
         contents: Vec<String>,
-        to_system_clipboard: bool,
+        use_system_clipboard: bool,
     ) -> anyhow::Result<()> {
-        self.clipboard.set(contents.clone(), to_system_clipboard)
+        self.clipboard.set(contents.clone(), use_system_clipboard)
     }
     pub(crate) fn mode(&self) -> Option<GlobalMode> {
         self.mode.clone()

--- a/src/context.rs
+++ b/src/context.rs
@@ -85,12 +85,20 @@ impl Context {
         }
     }
 
-    pub(crate) fn get_clipboard_content(&self) -> Option<String> {
-        self.clipboard.get_content()
+    pub(crate) fn get_clipboard_content(&self, history_offset: isize) -> Option<Vec<String>> {
+        self.clipboard.get(history_offset)
     }
 
-    pub(crate) fn set_clipboard_content(&mut self, content: String) {
-        self.clipboard.set_content(content.clone());
+    pub(crate) fn get_from_system_clipboard(&self) -> anyhow::Result<String> {
+        self.clipboard.get_from_system_clipboard()
+    }
+
+    pub(crate) fn set_clipboard_content(
+        &mut self,
+        contents: Vec<String>,
+        to_system_clipboard: bool,
+    ) -> anyhow::Result<()> {
+        self.clipboard.set(contents.clone(), to_system_clipboard)
     }
     pub(crate) fn mode(&self) -> Option<GlobalMode> {
         self.mode.clone()

--- a/src/context.rs
+++ b/src/context.rs
@@ -8,7 +8,7 @@ use shared::canonicalized_path::CanonicalizedPath;
 
 use crate::{
     app::{GlobalSearchConfigUpdate, GlobalSearchFilterGlob, LocalSearchConfigUpdate, Scope},
-    clipboard::Clipboard,
+    clipboard::{Clipboard, CopiedTexts},
     components::{keymap_legend::KeymapLegendSection, prompt::PromptHistoryKey},
     list::grep::RegexConfig,
     quickfix_list::DiagnosticSeverityRange,
@@ -85,17 +85,24 @@ impl Context {
         }
     }
 
-    pub(crate) fn get_clipboard_content(&self, history_offset: isize) -> Option<Vec<String>> {
-        self.clipboard.get(history_offset)
-    }
-
-    pub(crate) fn get_from_system_clipboard(&self) -> anyhow::Result<String> {
-        self.clipboard.get_from_system_clipboard()
+    /// Note: `history_offset` is ignored when `use_system_clipboard` is true.
+    pub(crate) fn get_clipboard_content(
+        &self,
+        use_system_clipboard: bool,
+        history_offset: isize,
+    ) -> anyhow::Result<Option<CopiedTexts>> {
+        Ok(if use_system_clipboard {
+            Some(CopiedTexts::new(nonempty::NonEmpty::singleton(
+                self.clipboard.get_from_system_clipboard()?,
+            )))
+        } else {
+            self.clipboard.get(history_offset)
+        })
     }
 
     pub(crate) fn set_clipboard_content(
         &mut self,
-        contents: Vec<String>,
+        contents: CopiedTexts,
         use_system_clipboard: bool,
     ) -> anyhow::Result<()> {
         self.clipboard.set(contents.clone(), use_system_clipboard)

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,6 @@ mod position;
 
 mod app;
 pub(crate) mod history;
-
 mod quickfix_list;
 mod rectangle;
 mod screen;

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ mod position;
 
 mod app;
 pub(crate) mod history;
+
 mod quickfix_list;
 mod rectangle;
 mod screen;

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -1,4 +1,5 @@
 use itertools::Itertools;
+use nonempty::NonEmpty;
 use std::ops::{Add, Sub};
 
 use crate::{
@@ -161,14 +162,15 @@ impl Default for SelectionSet {
 }
 
 impl SelectionSet {
-    pub(crate) fn map<F, A>(&self, f: F) -> Vec<A>
+    pub(crate) fn map<F, A>(&self, f: F) -> NonEmpty<A>
     where
         F: Fn(&Selection) -> A,
     {
-        vec![f(&self.primary)]
-            .into_iter()
-            .chain(self.secondary.iter().map(f))
-            .collect()
+        NonEmpty {
+            head: &self.primary,
+            tail: self.secondary.iter().collect(),
+        }
+        .map(f)
     }
 
     pub(crate) fn only(&mut self) {


### PR DESCRIPTION
To implement this feature, the mechanism that automatically decides to use either the system clipboard or the editor clipboard is removed, as it introduces complexities that obstruct extensibility.

Actions that use the clipboard are now parameterized with `use_system_clipboard`, which now means there are two versions of these actions, one that uses the editor clipboard and one that uses the system clipboard.

