### PR TITLE
perf(render_editor/get_grid): use binary search to filter syntax highlight spans

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -929,14 +929,17 @@ impl Buffer {
     pub(crate) fn line_range_to_byte_range(
         &self,
         visible_line_range: &Range<usize>,
-    ) -> Range<usize> {
-        self.line_to_byte_range(visible_line_range.start)
-            .map(|range| range.range().start)
-            .unwrap_or(0)
-            ..self
-                .line_to_byte_range(visible_line_range.end)
-                .map(|range| range.range().end)
-                .unwrap_or(0)
+    ) -> anyhow::Result<Range<usize>> {
+        let start = self
+            .line_to_byte_range(visible_line_range.start)?
+            .range()
+            .start;
+        let end = self
+            .line_to_byte_range(visible_line_range.end.saturating_sub(1))?
+            .range()
+            .end;
+        debug_assert!(start <= end);
+        Ok(start..end)
     }
 }
 

--- a/src/components/render_editor.rs
+++ b/src/components/render_editor.rs
@@ -38,13 +38,12 @@ impl Editor {
             self.get_parent_lines().unwrap_or_default();
         let top_offset = hidden_parent_lines.len() as u16;
         let scroll_offset = self.scroll_offset();
-        let visible_lines = &rope
+        let visible_lines = rope
             .lines()
             .enumerate()
             .skip(scroll_offset as usize)
             .take(height as usize)
-            .map(|(line_index, slice)| (line_index, slice.to_string()))
-            .collect_vec();
+            .map(|(line_index, slice)| (line_index, slice.to_string()));
 
         let visible_lines_grid: Grid = Grid::new(Dimension { height, width });
 
@@ -62,10 +61,9 @@ impl Editor {
             .map(|range| HighlightSpan {
                 set_symbol: None,
                 is_cursor: false,
-                ranges: HighlightSpanRange::ByteRange(range.range().clone()),
+                range: HighlightSpanRange::ByteRange(range.range().clone()),
                 source: Source::StyleKey(UiPossibleSelection),
-            })
-            .collect_vec();
+            });
 
         let bookmarks = buffer
             .bookmarks()
@@ -74,27 +72,23 @@ impl Editor {
                 set_symbol: None,
                 is_cursor: false,
                 source: Source::StyleKey(UiBookmark),
-                ranges: HighlightSpanRange::CharIndexRange(bookmark),
-            })
-            .collect_vec();
+                range: HighlightSpanRange::CharIndexRange(bookmark),
+            });
         let secondary_selections = &editor.selection_set.secondary_selections();
         let primary_selection = HighlightSpan {
             set_symbol: None,
             is_cursor: false,
-            ranges: HighlightSpanRange::CharIndexRange(selection.extended_range()),
+            range: HighlightSpanRange::CharIndexRange(selection.extended_range()),
             source: Source::StyleKey(UiPrimarySelection),
         };
 
-        let primary_selection_anchors = selection
-            .anchors()
-            .into_iter()
-            .map(|anchor| HighlightSpan {
+        let primary_selection_anchors =
+            selection.anchors().into_iter().map(|anchor| HighlightSpan {
                 set_symbol: None,
                 is_cursor: false,
-                ranges: HighlightSpanRange::CharIndexRange(anchor),
+                range: HighlightSpanRange::CharIndexRange(anchor),
                 source: Source::StyleKey(UiPrimarySelectionAnchors),
-            })
-            .collect_vec();
+            });
         let primary_selection_primary_cursor = buffer
             .char_to_position(selection.to_char_index(&editor.cursor_direction))
             .ok()
@@ -106,41 +100,38 @@ impl Editor {
             Some(HighlightSpan {
                 set_symbol: None,
                 is_cursor: false,
-                ranges: HighlightSpanRange::CharIndex(
+                range: HighlightSpanRange::CharIndex(
                     selection.to_char_index(&editor.cursor_direction.reverse()),
                 ),
                 source: Source::Style(theme.ui.primary_selection_secondary_cursor),
             })
         };
 
-        let secondary_selection = secondary_selections
-            .iter()
-            .map(|secondary_selection| HighlightSpan {
-                set_symbol: None,
-                is_cursor: false,
-                ranges: HighlightSpanRange::CharIndexRange(secondary_selection.extended_range()),
-                source: Source::StyleKey(UiSecondarySelection),
-            })
-            .collect_vec();
-
-        let seconday_selection_anchors = secondary_selections
-            .iter()
-            .flat_map(|selection| {
-                selection.anchors().into_iter().map(|anchor| HighlightSpan {
+        let secondary_selection =
+            secondary_selections
+                .iter()
+                .map(|secondary_selection| HighlightSpan {
                     set_symbol: None,
                     is_cursor: false,
-                    ranges: HighlightSpanRange::CharIndexRange(anchor),
-                    source: Source::StyleKey(UiSecondarySelectionAnchors),
-                })
+                    range: HighlightSpanRange::CharIndexRange(secondary_selection.extended_range()),
+                    source: Source::StyleKey(UiSecondarySelection),
+                });
+
+        let seconday_selection_anchors = secondary_selections.iter().flat_map(|selection| {
+            selection.anchors().into_iter().map(|anchor| HighlightSpan {
+                set_symbol: None,
+                is_cursor: false,
+                range: HighlightSpanRange::CharIndexRange(anchor),
+                source: Source::StyleKey(UiSecondarySelectionAnchors),
             })
-            .collect_vec();
+        });
         let secondary_selection_cursors =
             secondary_selections.iter().flat_map(|secondary_selection| {
                 [
                     HighlightSpan {
                         set_symbol: None,
                         is_cursor: false,
-                        ranges: HighlightSpanRange::CharIndex(
+                        range: HighlightSpanRange::CharIndex(
                             secondary_selection.to_char_index(&editor.cursor_direction.reverse()),
                         ),
                         source: Source::Style(theme.ui.secondary_selection_secondary_cursor),
@@ -148,7 +139,7 @@ impl Editor {
                     HighlightSpan {
                         set_symbol: None,
                         is_cursor: false,
-                        ranges: HighlightSpanRange::CharIndex(
+                        range: HighlightSpanRange::CharIndex(
                             secondary_selection.to_char_index(&editor.cursor_direction),
                         ),
                         source: Source::Style(theme.ui.secondary_selection_primary_cursor),
@@ -164,7 +155,7 @@ impl Editor {
             .map(|diagnostic| HighlightSpan {
                 set_symbol: None,
                 is_cursor: false,
-                ranges: HighlightSpanRange::CharIndexRange(diagnostic.range),
+                range: HighlightSpanRange::CharIndexRange(diagnostic.range),
                 source: Source::StyleKey(match diagnostic.severity {
                     Some(DiagnosticSeverity::ERROR) => DiagnosticsError,
                     Some(DiagnosticSeverity::WARNING) => DiagnosticsWarning,
@@ -184,55 +175,88 @@ impl Editor {
                 set_symbol: Some(jump.character.to_string()),
                 is_cursor: false,
                 source: Source::Style(style),
-                ranges: HighlightSpanRange::CharIndex(
+                range: HighlightSpanRange::CharIndex(
                     jump.selection.to_char_index(&self.cursor_direction),
                 ),
             }
         });
-        let extra_decorations = buffer
-            .decorations()
-            .iter()
-            .flat_map(|decoration| {
-                Some(HighlightSpan {
-                    set_symbol: None,
-                    is_cursor: false,
-                    ranges: HighlightSpanRange::CharIndexRange(
-                        decoration
-                            .selection_range()
-                            .to_char_index_range(&buffer)
-                            .ok()?,
-                    ),
-                    source: Source::StyleKey(decoration.style_key().clone()),
-                })
-            })
-            .collect_vec();
-        let highlighted_spans = buffer
-            .highlighted_spans()
-            .into_iter()
-            .map(|highlighted_span| HighlightSpan {
+        let extra_decorations = buffer.decorations().iter().flat_map(|decoration| {
+            Some(HighlightSpan {
                 set_symbol: None,
                 is_cursor: false,
-                ranges: HighlightSpanRange::ByteRange(highlighted_span.byte_range),
-                source: Source::StyleKey(highlighted_span.style_key),
+                range: HighlightSpanRange::CharIndexRange(
+                    decoration
+                        .selection_range()
+                        .to_char_index_range(&buffer)
+                        .ok()?,
+                ),
+                source: Source::StyleKey(decoration.style_key().clone()),
             })
-            .collect_vec();
+        });
+
+        let line_indices = hidden_parent_lines.iter().map(|line| line.line);
+        let hidden_parent_line_range = line_indices.clone().min().unwrap_or_default()
+            ..line_indices.max().unwrap_or_default() + 1;
+        let visible_line_range = self.visible_line_range();
+        let visible_line_byte_range = buffer.line_range_to_byte_range(&visible_line_range);
+        let hidden_parent_line_byte_range =
+            buffer.line_range_to_byte_range(&hidden_parent_line_range);
+        let spans = buffer.highlighted_spans();
+        let highlighted_spans = {
+            fn range_search<T, F>(items: &[T], start: usize, end: usize, get_range: F) -> &[T]
+            where
+                F: Fn(&T) -> Range<usize>,
+            {
+                // Find the start index
+                // We consider an item to be "greater" than start if its range's end is greater than start
+                let start_idx = items.partition_point(|item| get_range(item).end <= start);
+
+                // Find the end index
+                // We consider an item to be "less than or equal" to end if its range's start is less than or equal to end
+                let end_idx = items.partition_point(|item| get_range(item).start <= end);
+                debug_assert!(end_idx < items.len());
+                debug_assert!(start_idx <= end_idx);
+
+                // Return the slice containing items that potentially overlap with [start, end]
+                &items[start_idx..end_idx]
+            }
+
+            range_search(
+                &spans,
+                visible_line_byte_range.start,
+                visible_line_byte_range.end,
+                |span| span.byte_range.clone(),
+            )
+            .into_iter()
+            .chain(range_search(
+                &spans,
+                hidden_parent_line_byte_range.start,
+                hidden_parent_line_byte_range.end,
+                |span| span.byte_range.clone(),
+            ))
+            .map(|span| HighlightSpan {
+                range: HighlightSpanRange::ByteRange(span.byte_range.clone()),
+                source: Source::StyleKey(span.style_key.clone()),
+                set_symbol: None,
+                is_cursor: false,
+            })
+        };
         let custom_regex_highlights = lazy_regex::regex!("(?i)#[0-9a-f]{6}")
-            .find_iter(&rope.to_string())
+            .find_iter(&content)
             .map(|m| (m.as_str().to_string(), m.range()))
             .filter_map(|(hex, range)| {
                 let color = crate::themes::Color::from_hex(&hex).ok()?;
                 Some(HighlightSpan {
                     set_symbol: None,
                     is_cursor: false,
-                    ranges: HighlightSpanRange::ByteRange(range),
+                    range: HighlightSpanRange::ByteRange(range),
                     source: Source::Style(
                         Style::new()
                             .background_color(color)
                             .foreground_color(color.get_contrasting_color()),
                     ),
                 })
-            })
-            .collect_vec();
+            });
 
         let regex_highlight_rules = self
             .regex_highlight_rules
@@ -243,7 +267,7 @@ impl Editor {
                     let match_ = captures.name(name)?;
                     Some(HighlightSpan {
                         source,
-                        ranges: HighlightSpanRange::ByteRange(match_.range()),
+                        range: HighlightSpanRange::ByteRange(match_.range()),
                         set_symbol: None,
                         is_cursor: false,
                     })
@@ -260,12 +284,11 @@ impl Editor {
                         .collect_vec(),
                 )
             })
-            .flatten()
-            .collect_vec();
+            .flatten();
 
         let visible_parent_lines = visible_parent_lines.into_iter().map(|line| HighlightSpan {
             source: Source::StyleKey(StyleKey::ParentLine),
-            ranges: HighlightSpanRange::Line(line.line),
+            range: HighlightSpanRange::Line(line.line),
             set_symbol: None,
             is_cursor: false,
         });
@@ -288,16 +311,16 @@ impl Editor {
             .chain(regex_highlight_rules)
             .collect_vec();
         let visible_lines_updates = {
-            let boundaries = [Boundary::new(&buffer, self.visible_line_range())];
+            let boundaries = [Boundary::new(&buffer, visible_line_range)];
             updates
                 .iter()
-                .flat_map(|span| span.to_cell_update(&buffer, theme, &boundaries))
+                .flat_map(|span| span.to_cell_updates(&buffer, theme, &boundaries))
                 .chain(primary_selection_primary_cursor)
                 .collect_vec()
         };
 
         let visible_lines_grid = visible_lines_grid.render_content(
-            &visible_lines.iter().map(|(_, line)| line).join(""),
+            &visible_lines.map(|(_, line)| line).join(""),
             RenderContentLineNumber::LineNumber {
                 start_line_index: scroll_offset as usize,
                 max_line_number: len_lines as usize,
@@ -323,12 +346,12 @@ impl Editor {
                 .iter()
                 .map(|line| HighlightSpan {
                     source: Source::StyleKey(StyleKey::ParentLine),
-                    ranges: HighlightSpanRange::Line(line.line),
+                    range: HighlightSpanRange::Line(line.line),
                     set_symbol: None,
                     is_cursor: false,
                 })
                 .chain(updates)
-                .flat_map(|span| span.to_cell_update(&buffer, theme, &boundaries))
+                .flat_map(|span| span.to_cell_updates(&buffer, theme, &boundaries))
                 .collect_vec();
             hidden_parent_lines.into_iter().fold(
                 Grid::new(Dimension { height: 0, width }),
@@ -438,9 +461,10 @@ impl Editor {
     }
 }
 
+#[derive(Clone)]
 pub(crate) struct HighlightSpan {
     pub(crate) source: Source,
-    pub(crate) ranges: HighlightSpanRange,
+    pub(crate) range: HighlightSpanRange,
     pub(crate) set_symbol: Option<String>,
     pub(crate) is_cursor: bool,
 }
@@ -449,7 +473,7 @@ impl HighlightSpan {
     /// Convert this `HighlightSpans` into `Vec<CellUpdate>`,
     /// only perform conversions for positions that falls within the given `boundaries`,
     /// so that we can minimize the call to the expensive `buffer.xxx_to_position` methods
-    fn to_cell_update(
+    fn to_cell_updates(
         &self,
         buffer: &Buffer,
         theme: &Theme,
@@ -458,27 +482,26 @@ impl HighlightSpan {
         boundaries
             .iter()
             .filter_map(|boundary| {
-                let char_index_range: CharIndexRange = match &self.ranges {
-                    HighlightSpanRange::CharIndexRange(range) => range_intersection(
-                        range.start..range.end,
-                        boundary.char_index_range.clone(),
-                    )?
-                    .into(),
+                let char_index_range: CharIndexRange = match &self.range {
+                    HighlightSpanRange::CharIndexRange(range) => {
+                        range_intersection(&(range.start..range.end), &boundary.char_index_range)?
+                            .into()
+                    }
                     HighlightSpanRange::ByteRange(range) => buffer
                         .byte_range_to_char_index_range(&range_intersection(
-                            range.clone(),
-                            boundary.byte_range.clone(),
+                            &range,
+                            &boundary.byte_range,
                         )?)
                         .ok()?,
                     HighlightSpanRange::CharIndex(char_index) => range_intersection(
-                        *char_index..(*char_index + 1),
-                        boundary.char_index_range.clone(),
+                        &(*char_index..(*char_index + 1)),
+                        &boundary.char_index_range,
                     )?
                     .into(),
                     HighlightSpanRange::Line(line) => buffer
                         .line_range_to_char_index_range(range_intersection(
-                            *line..line + 1,
-                            boundary.line_range.clone(),
+                            &(*line..line + 1),
+                            &boundary.line_range,
                         )?)
                         .ok()?,
                 };
@@ -509,7 +532,7 @@ impl HighlightSpan {
     }
 }
 
-fn range_intersection<T: Ord>(a: Range<T>, b: Range<T>) -> Option<Range<T>> {
+fn range_intersection<T: Ord + Copy>(a: &Range<T>, b: &Range<T>) -> Option<Range<T>> {
     let start = std::cmp::max(a.start, b.start);
     let end = std::cmp::min(a.end, b.end);
     if start < end {
@@ -525,6 +548,7 @@ pub(crate) enum Source {
     Style(Style),
 }
 
+#[derive(Clone, PartialEq)]
 pub(crate) enum HighlightSpanRange {
     CharIndexRange(CharIndexRange),
     ByteRange(Range<usize>),

--- a/src/components/test_editor.rs
+++ b/src/components/test_editor.rs
@@ -1686,6 +1686,13 @@ fn main() { // too long
                 })
                 .collect(),
             ),
+            Expect(
+                // Expect the left parenthesis of the outbound parent line "fn main() { // too long" is highlighted properly
+                ExpectKind::GridCellStyleKey(
+                    Position::new(1, 9),
+                    Some(StyleKey::Syntax("punctuation.bracket".to_string())),
+                ),
+            ),
             ExpectMulti(
                 [
                     // Expect the `let` keyword of line 3 (which is inbound and not wrapped) is highlighted properly

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -33,13 +33,13 @@ pub(crate) struct Cell {
     pub(crate) is_bold: bool,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Hash, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Copy, PartialOrd, Ord)]
 pub(crate) struct CellLine {
     pub(crate) color: Color,
     pub(crate) style: CellLineStyle,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Hash, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Copy, PartialOrd, Ord)]
 pub(crate) enum CellLineStyle {
     Undercurl,
     Underline,

--- a/src/style.rs
+++ b/src/style.rs
@@ -3,7 +3,7 @@ use crate::{
     themes::Color,
 };
 
-#[derive(Debug, Default, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, Default, PartialEq, Eq, Clone, Copy, Hash, PartialOrd, Ord)]
 pub(crate) struct Style {
     pub(crate) foreground_color: Option<Color>,
     pub(crate) background_color: Option<Color>,

--- a/src/themes/mod.rs
+++ b/src/themes/mod.rs
@@ -449,7 +449,7 @@ pub fn highlight_names() -> &'static Vec<&'static str> {
 }
 
 /// This should be constructed using the `hex!` macro.
-#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Deserialize)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Deserialize, PartialOrd, Ord)]
 pub(crate) struct Color {
     r: u8,
     g: u8,


### PR DESCRIPTION
## Preface
Rendering is one of the bottlenecks of Ki's performance, after analysis, syntax highlighting spans are found to be the root cause, due to its large amount (around 50k spans for a 2.7k lines Rust file).

## Solution
Use binary search to quickly obtain all the syntax highlighting spans in view instead of iterating the whole list.

## Proof of fix
The following flamegraphs are generated by opening `editor.rs` of this repository, and continuously scrolling down (by holding `ctrl+d`) until it reaches like 1873.

### Old (`get_grid` ≅ 42% of total time spent)
![old-flamegraph](https://github.com/user-attachments/assets/195de04e-d476-4a7f-9742-afc1e03fc150)


### New  (`get_grid` ≅ 32% of total time spent)
![new-flamegraph](https://github.com/user-attachments/assets/37cd42a4-d1e5-4eda-8513-5866625ad657)

