### PR TITLE
perf(handle_key_event): compute node sexp lazily

### DIFF
--- a/src/components/editor.rs
+++ b/src/components/editor.rs
@@ -332,6 +332,7 @@ impl Component for Editor {
             }
             MoveToLastChar => return Ok(self.move_to_last_char()),
             PipeToShell { command } => return self.pipe_to_shell(command),
+            ShowCurrentTreeSitterNodeSexp => return self.show_current_tree_sitter_node_sexp(),
         }
         Ok(Default::default())
     }
@@ -2573,6 +2574,18 @@ impl Editor {
     fn pipe_to_shell(&mut self, command: String) -> Result<Dispatches, anyhow::Error> {
         self.transform_selection(Transformation::PipeToShell { command })
     }
+
+    fn show_current_tree_sitter_node_sexp(&self) -> Result<Dispatches, anyhow::Error> {
+        let buffer = self.buffer();
+        let node = buffer.get_current_node(self.selection_set.primary_selection(), false)?;
+        let info = node
+            .map(|node| node.to_sexp())
+            .unwrap_or("[No node found]".to_string());
+        Ok(Dispatches::one(Dispatch::ShowEditorInfo(Info::new(
+            "Tree-sitter node S-expression".to_string(),
+            info,
+        ))))
+    }
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug)]
@@ -2694,6 +2707,7 @@ pub(crate) enum DispatchEditor {
     PipeToShell {
         command: String,
     },
+    ShowCurrentTreeSitterNodeSexp,
 }
 
 #[derive(PartialEq, Eq, Debug, Clone)]

--- a/src/components/editor_keymap_legend.rs
+++ b/src/components/editor_keymap_legend.rs
@@ -22,7 +22,6 @@ use super::{
         Direction, DispatchEditor, Editor, HandleEventResult, IfCurrentNotFound, SurroundKind,
     },
     keymap_legend::{Keymap, KeymapLegendBody, KeymapLegendConfig, Keymaps},
-    suggestive_editor::Info,
 };
 
 use DispatchEditor::*;
@@ -766,38 +765,25 @@ impl Editor {
                     }))
                     .chain(Some(KeymapLegendSection {
                         title: "Misc".to_string(),
-                        keymaps: Keymaps::new(
-                            &Some(Keymap::new(
+                        keymaps: Keymaps::new(&[
+                            Keymap::new(
                                 "e",
                                 "Reveal current file in Explorer".to_string(),
                                 Dispatch::RevealInExplorer(self.path().unwrap_or_else(|| {
                                     context.current_working_directory().clone()
                                 })),
-                            ))
-                            .into_iter()
-                            .chain(Some(Keymap::new(
+                            ),
+                            Keymap::new(
                                 "z",
                                 "Undo Tree".to_string(),
                                 Dispatch::ToEditor(DispatchEditor::EnterUndoTreeMode),
-                            )))
-                            .chain(
-                                self.buffer()
-                                    .get_current_node(self.selection_set.primary_selection(), false)
-                                    .ok()
-                                    .flatten()
-                                    .map(|node| {
-                                        Keymap::new(
-                                            "x",
-                                            "Tree-sitter node S-expression".to_string(),
-                                            Dispatch::ShowEditorInfo(Info::new(
-                                                "Tree-sitter node S-expression".to_string(),
-                                                node.to_sexp(),
-                                            )),
-                                        )
-                                    }),
-                            )
-                            .collect_vec(),
-                        ),
+                            ),
+                            Keymap::new(
+                                "x",
+                                "Tree-sitter node S-expression".to_string(),
+                                Dispatch::ToEditor(DispatchEditor::ShowCurrentTreeSitterNodeSexp),
+                            ),
+                        ]),
                     }))
                     .collect(),
             },

--- a/src/components/test_editor.rs
+++ b/src/components/test_editor.rs
@@ -2516,3 +2516,24 @@ fn selection_set_history_updates_upon_edit() -> Result<(), anyhow::Error> {
         }
     })
 }
+
+#[test]
+fn show_current_tree_sitter_node_sexp() -> Result<(), anyhow::Error> {
+    execute_test(|s| {
+        {
+            Box::new([
+                App(OpenFile(s.main_rs())),
+                Editor(SetContent("fn main() {}".to_string())),
+                Editor(SetSelectionMode(
+                    IfCurrentNotFound::LookForward,
+                    SyntaxNodeCoarse,
+                )),
+                Editor(ShowCurrentTreeSitterNodeSexp),
+                App(OtherWindow),
+                Expect(CurrentComponentContent(
+                    "(function_item name: (identifier) parameters: (parameters) body: (block))",
+                )),
+            ])
+        }
+    })
+}


### PR DESCRIPTION
## Proof of improvement

### Old (`handle_key_event` ~ 10.24% of total time spent)
![old-flamegraph](https://github.com/user-attachments/assets/0777b8da-88cc-41eb-aa28-bc8a8327b70e)



### New (`handle_key_event` ~ 8.26% of total time spent)
![new-flamegraph](https://github.com/user-attachments/assets/75f80a4d-a9b3-4350-b764-fdc2d3aef0b5)
