### PR TITLE
feat(editor): delete extended selection

### DIFF
--- a/src/components/editor.rs
+++ b/src/components/editor.rs
@@ -768,28 +768,34 @@ impl Editor {
                         // If the selection mode is contiguous,
                         // perform a "kill next/previous" instead
                         else {
-                            let other_selection = get_selection(&direction)
+                            if let Some(other_selection) = get_selection(&direction)
                                 .or_else(|| get_selection(&direction.reverse()))
-                                .unwrap_or(selection.clone().into())
-                                .selection;
-
-                            let other_range = other_selection.range();
-                            if other_range == current_range {
-                                default
-                            } else if other_range.start >= current_range.end {
-                                let delete_range: CharIndexRange =
-                                    (current_range.start..other_range.start).into();
-                                let select_range = {
-                                    other_selection
-                                        .extended_range()
-                                        .shift_left(delete_range.len())
-                                };
-                                (delete_range, select_range)
-                            } else {
-                                let delete_range: CharIndexRange =
-                                    (other_range.end..current_range.end).into();
-                                let select_range = other_selection.range();
-                                (delete_range, select_range)
+                            {
+                                let other_range = other_selection.selection.range();
+                                if other_range == current_range {
+                                    default
+                                } else if other_range.start >= current_range.end {
+                                    let delete_range: CharIndexRange =
+                                        (current_range.start..other_range.start).into();
+                                    let select_range = {
+                                        other_selection
+                                            .selection
+                                            .extended_range()
+                                            .shift_left(delete_range.len())
+                                    };
+                                    (delete_range, select_range)
+                                } else {
+                                    let delete_range: CharIndexRange =
+                                        (other_range.end..current_range.end).into();
+                                    let select_range = other_selection.selection.range();
+                                    (delete_range, select_range)
+                                }
+                            }
+                            // If other selection not found, then only deletes the selection
+                            // without moving forward or backward
+                            else {
+                                let range = selection.extended_range();
+                                (range, (range.start..range.start).into())
                             }
                         }
                     };

--- a/src/components/editor_keymap_legend.rs
+++ b/src/components/editor_keymap_legend.rs
@@ -221,12 +221,12 @@ impl Editor {
                 Keymap::new(
                     "d",
                     "Delete (until next selection)".to_string(),
-                    Dispatch::ToEditor(Delete { backward: false }),
+                    Dispatch::ToEditor(Delete(Direction::End)),
                 ),
                 Keymap::new(
                     "D",
                     "Delete (until previous selection)".to_string(),
-                    Dispatch::ToEditor(Delete { backward: true }),
+                    Dispatch::ToEditor(Delete(Direction::Start)),
                 ),
                 Keymap::new(
                     "^",

--- a/src/components/test_editor.rs
+++ b/src/components/test_editor.rs
@@ -187,7 +187,7 @@ fn delete_should_not_kill_if_not_possible_2() -> anyhow::Result<()> {
             )),
             Editor(Delete(Direction::End)),
             Expect(CurrentComponentContent("fn main() {}")),
-            Expect(CurrentSelectedTexts(&[")"])),
+            Expect(CurrentSelectedTexts(&[""])),
         ])
     })
 }
@@ -320,6 +320,21 @@ fn test_delete_extended_selection_is_first_selection() -> anyhow::Result<()> {
             Editor(Delete(Direction::Start)),
             Expect(CurrentComponentContent("in")),
             Expect(CurrentSelectedTexts(&["in"])),
+        ])
+    })
+}
+
+#[test]
+fn test_delete_extended_selection_whole_file() -> anyhow::Result<()> {
+    execute_test(move |s| {
+        Box::new([
+            App(OpenFile(s.main_rs())),
+            Editor(SetContent("who lives in a pineapple".to_string())),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, WordShort)),
+            Editor(SelectAll),
+            Editor(Delete(Direction::End)),
+            Expect(CurrentComponentContent("")),
+            Expect(CurrentSelectedTexts(&[""])),
         ])
     })
 }

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -743,10 +743,6 @@ impl Selection {
         }
     }
 
-    pub(crate) fn is_extended(&self) -> bool {
-        self.initial_range.is_some()
-    }
-
     fn enable_extension(&mut self) {
         self.initial_range = Some(self.range);
     }
@@ -763,6 +759,23 @@ impl Selection {
             initial_range: initial_range.and_then(|range| range.apply_edit(edit)),
             info,
         })
+    }
+
+    pub(crate) fn collapsed_to_anchor_range(self, direction: &Direction) -> Self {
+        let range = if let Some(initial_range) = self.initial_range {
+            let (start, end) = if initial_range.start < self.range.start {
+                (initial_range, self.range)
+            } else {
+                (self.range, initial_range)
+            };
+            match direction {
+                Direction::Start => start,
+                Direction::End => end,
+            }
+        } else {
+            self.range
+        };
+        self.set_range(range).set_initial_range(None)
     }
 }
 

--- a/src/test_app.rs
+++ b/src/test_app.rs
@@ -790,7 +790,7 @@ pub(crate) fn repo_git_hunks() -> Result<(), anyhow::Error> {
                 IfCurrentNotFound::LookForward,
                 LineTrimmed,
             )),
-            Editor(Delete { backward: false }),
+            Editor(Delete(Direction::End)),
             // Insert a comment at the first line of foo.rs
             App(OpenFile(s.foo_rs().clone())),
             Editor(Insert("// Hello".to_string())),
@@ -901,7 +901,7 @@ fn align_view_bottom_with_outbound_parent_lines() -> anyhow::Result<()> {
                 LineTrimmed,
             )),
             Editor(SelectAll),
-            Editor(Delete { backward: false }),
+            Editor(Delete(Direction::End)),
             Editor(Insert(
                 "
 fn first () {


### PR DESCRIPTION
Previously, deleting an extended selection only removed the highlighted content, contrary to the expected behavior of also deleting forward or backward based on the current selection mode. 

This PR fixes this issue, implementing the expected deletion behavior.