### PR TITLE
feat(editor): use last non-contiguous selection mode

### DIFF
--- a/docs/src/normal-mode/other-movements.md
+++ b/docs/src/normal-mode/other-movements.md
@@ -37,8 +37,8 @@ Usefulness of `%`:
 
 Keybindings:
 
-- `[`: Go back
-- `]`: Go forward
+- `ctrl+o`: Go back
+- `ctrl+i`/`tab`: Go forward
 
 `[` is useful when you messed up the current selection, especially when you are
 using [Syntax Node](./selection-modes/syntax-node-based.md#syntax-node), and

--- a/docs/src/normal-mode/selection-modes/local-global/index.md
+++ b/docs/src/normal-mode/selection-modes/local-global/index.md
@@ -8,7 +8,19 @@ There are 3 categories of Local/Global selection modes:
 1. [LSP-based](./lsp-based.md)
 1. [Misc](./misc.md)
 
-These selection modes are nested under `n` (Find (Local)) or `g` (Find (Global)).
+> These selection modes are nested under `[`/`]` (Find (Local)) or `g` (Find (Global)).
 
-When using Find (Local) mode, `n` searches forward and `N` searchs backward if
+When using Find (Local) mode, `[` searches backward and `]` searchs forward if
 no matching selection is found under cursor.
+
+## Shortcut (`n`/`N`)
+
+All selection modes under this Local/Global category are non-contiguous,
+and since they require at least two keypresses, Ki provides a shortcut:
+
+> To set the current selection mode back to the last non-contiguous selection modes,
+> press `n` (search forward) or `N` (search backward).
+
+For example, after you searched for a term (either locally or globally),
+and you've changed to another contiguous selection mode (such as Word),
+pressing `n`/`N` will set the selection mode back to the term search.

--- a/docs/src/universal-keybindings.md
+++ b/docs/src/universal-keybindings.md
@@ -30,8 +30,8 @@ Examples of such windows are:
 
 ## Close current window
 
-Keybinding: `ctrl+q`  
-Memory aid: q stands for quit
+Keybinding: `ctrl+c`  
+Memory aid: c stands for close
 
 Note: when the current window is closed, all of its children will be unmounted (removed) from the screen as well.
 

--- a/src/components/editor.rs
+++ b/src/components/editor.rs
@@ -1255,14 +1255,18 @@ impl Editor {
     ) -> anyhow::Result<Dispatches> {
         self.move_selection_with_selection_mode_without_global_mode(
             Movement::Current(if_current_not_found),
-            selection_mode,
+            selection_mode.clone(),
         )
         .map(|dispatches| {
-            Some(Dispatch::SetGlobalMode(None))
-                .into_iter()
-                .chain(dispatches.into_vec())
-                .collect::<Vec<_>>()
-                .into()
+            Dispatches::one(Dispatch::SetGlobalMode(None))
+                .chain(dispatches)
+                .append_some(if selection_mode.is_contiguous() {
+                    None
+                } else {
+                    Some(Dispatch::SetLastNonContiguousSelectionMode(Either::Left(
+                        selection_mode,
+                    )))
+                })
         })
     }
 

--- a/src/components/editor_keymap_legend.rs
+++ b/src/components/editor_keymap_legend.rs
@@ -97,8 +97,12 @@ impl Editor {
                     "Scroll page up".to_string(),
                     Dispatch::ToEditor(ScrollPageUp),
                 ),
-                Keymap::new("[", "Go back".to_string(), Dispatch::ToEditor(GoBack)),
-                Keymap::new("]", "Go forward".to_string(), Dispatch::ToEditor(GoForward)),
+                Keymap::new("ctrl+o", "Go back".to_string(), Dispatch::ToEditor(GoBack)),
+                Keymap::new(
+                    "tab",
+                    "Go forward".to_string(),
+                    Dispatch::ToEditor(GoForward),
+                ),
                 Keymap::new(
                     "{",
                     "Go to previous file".to_string(),
@@ -136,24 +140,6 @@ impl Editor {
                     Dispatch::ToEditor(SetSelectionMode(IfCurrentNotFound::LookForward, LineFull)),
                 ),
                 Keymap::new(
-                    "n",
-                    "Find (Local) - Forward".to_string(),
-                    Dispatch::ShowKeymapLegend(self.find_keymap_legend_config(
-                        context,
-                        Scope::Local,
-                        IfCurrentNotFound::LookForward,
-                    )),
-                ),
-                Keymap::new(
-                    "N",
-                    "Find (Local) - Backward".to_string(),
-                    Dispatch::ShowKeymapLegend(self.find_keymap_legend_config(
-                        context,
-                        Scope::Local,
-                        IfCurrentNotFound::LookBackward,
-                    )),
-                ),
-                Keymap::new(
                     "g",
                     "Find (Global)".to_string(),
                     Dispatch::ShowKeymapLegend(self.find_keymap_legend_config(
@@ -161,6 +147,16 @@ impl Editor {
                         Scope::Global,
                         IfCurrentNotFound::LookForward,
                     )),
+                ),
+                Keymap::new(
+                    "n",
+                    "Last non-contiguous selection mode - Forward".to_string(),
+                    Dispatch::UseLastNonContiguousSelectionMode(IfCurrentNotFound::LookForward),
+                ),
+                Keymap::new(
+                    "N",
+                    "Last non-contiguous selection mode - Backward".to_string(),
+                    Dispatch::UseLastNonContiguousSelectionMode(IfCurrentNotFound::LookBackward),
                 ),
                 Keymap::new(
                     "s",
@@ -199,6 +195,24 @@ impl Editor {
                     "z",
                     "Column".to_string(),
                     Dispatch::ToEditor(SetSelectionMode(IfCurrentNotFound::LookForward, Column)),
+                ),
+                Keymap::new(
+                    "[",
+                    "Find (Local) - Backward".to_string(),
+                    Dispatch::ShowKeymapLegend(self.find_keymap_legend_config(
+                        context,
+                        Scope::Local,
+                        IfCurrentNotFound::LookBackward,
+                    )),
+                ),
+                Keymap::new(
+                    "]",
+                    "Find (Local) - Forward".to_string(),
+                    Dispatch::ShowKeymapLegend(self.find_keymap_legend_config(
+                        context,
+                        Scope::Local,
+                        IfCurrentNotFound::LookForward,
+                    )),
                 ),
             ]),
         }
@@ -359,16 +373,16 @@ impl Editor {
             title: "Universal keymaps (works in every mode)".to_string(),
             keymaps: Keymaps::new(&[
                 Keymap::new(
+                    "ctrl+c",
+                    "Close current window".to_string(),
+                    Dispatch::CloseCurrentWindow,
+                ),
+                Keymap::new(
                     "ctrl+l",
                     "Switch view alignment".to_string(),
                     Dispatch::ToEditor(SwitchViewAlignment),
                 ),
-                Keymap::new("ctrl+o", "Other window".to_string(), Dispatch::OtherWindow),
-                Keymap::new(
-                    "ctrl+q",
-                    "Close current window".to_string(),
-                    Dispatch::CloseCurrentWindow,
-                ),
+                Keymap::new("ctrl+s", "Switch window".to_string(), Dispatch::OtherWindow),
                 Keymap::new(
                     "ctrl+v",
                     "Paste".to_string(),

--- a/src/components/test_editor.rs
+++ b/src/components/test_editor.rs
@@ -2561,7 +2561,7 @@ Editor(MatchLiteral(amos.foo())),
                     IfCurrentNotFound::LookForward,
                     LineTrimmed,
                 )),
-                App(HandleKeyEvents(keys!("N s ( enter").to_vec())),
+                App(HandleKeyEvents(keys!("? ( enter").to_vec())),
                 Editor(SetSelectionMode(IfCurrentNotFound::LookForward, WordLong)),
                 Editor(MoveSelection(Previous)),
                 Expect(CurrentSelectedTexts(&["to_string"])),
@@ -2636,6 +2636,30 @@ fn yank_paste_extended_selection() -> Result<(), anyhow::Error> {
                 Editor(Insert("foo".to_string())),
                 Editor(EnterInsertMode(Direction::End)),
                 Expect(CurrentComponentContent("who lives who livesfoo in a")),
+            ])
+        }
+    })
+}
+
+#[test]
+fn last_contiguous_selection_mode() -> Result<(), anyhow::Error> {
+    execute_test(|s| {
+        {
+            Box::new([
+                App(OpenFile(s.main_rs())),
+                Editor(SetContent("who lives in a".to_string())),
+                Editor(SetSelectionMode(IfCurrentNotFound::LookForward, WordShort)),
+                Editor(ToggleBookmark),
+                Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Bookmark)),
+                Editor(SetSelectionMode(IfCurrentNotFound::LookForward, WordShort)),
+                Expect(CurrentSelectedTexts(&["who"])),
+                Editor(MoveSelection(Last)),
+                Expect(CurrentSelectedTexts(&["a"])),
+                App(UseLastNonContiguousSelectionMode(
+                    IfCurrentNotFound::LookForward,
+                )),
+                Expect(CurrentSelectedTexts(&["who"])),
+                Expect(CurrentSelectionMode(Bookmark)),
             ])
         }
     })

--- a/src/test_app.rs
+++ b/src/test_app.rs
@@ -1298,6 +1298,12 @@ fn main() {
             )),
             App(SetGlobalMode(Some(GlobalMode::QuickfixListItem))),
             Expect(ExpectKind::QuickfixListInfo("This is fine")),
+            App(OpenFile(s.foo_rs())),
+            Expect(CurrentComponentPath(Some(s.foo_rs()))),
+            App(UseLastNonContiguousSelectionMode(
+                IfCurrentNotFound::LookForward,
+            )),
+            Expect(CurrentComponentPath(Some(s.main_rs()))),
         ])
     })
 }


### PR DESCRIPTION
Main change:
- Add `n`/`N` as "use last non-contiguous mode"

Other changes:
- Change `n`/`N` to `[`/`]`
- Change `[`/`]` to `ctrl+o`/`ctrl+i`
- Change `ctrl+o` to `ctrl+s` (might be temporary)
- Change `ctrl+q` to `ctrl+c`

