### PR TITLE
fix(editor): DisableMouseCapture on quit

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -181,6 +181,7 @@ impl<T: Frontend> App<T> {
         let mut frontend = self.frontend.lock().unwrap();
         frontend.leave_alternate_screen()?;
         frontend.disable_raw_mode()?;
+        frontend.disable_mouse_capture()?;
         // self.lsp_manager.shutdown();
 
         std::process::exit(0);

--- a/src/frontend/crossterm.rs
+++ b/src/frontend/crossterm.rs
@@ -25,7 +25,7 @@ impl Default for Crossterm {
 
 use crossterm::{
     cursor::{Hide, MoveTo, SetCursorStyle, Show},
-    event::{DisableBracketedPaste, EnableBracketedPaste, EnableMouseCapture},
+    event::{DisableBracketedPaste, EnableBracketedPaste, EnableMouseCapture, DisableMouseCapture},
     execute, queue,
     style::{
         Attribute, Color, Print, SetAttribute, SetBackgroundColor, SetForegroundColor,
@@ -48,6 +48,11 @@ impl Frontend for Crossterm {
 
     fn enable_mouse_capture(&mut self) -> anyhow::Result<()> {
         self.stdout.execute(EnableMouseCapture)?;
+        Ok(())
+    }
+
+    fn disable_mouse_capture(&mut self) -> anyhow::Result<()> {
+        self.stdout.execute(DisableMouseCapture)?;
         Ok(())
     }
 

--- a/src/frontend/mock.rs
+++ b/src/frontend/mock.rs
@@ -26,6 +26,10 @@ impl super::Frontend for MockFrontend {
         Ok(())
     }
 
+    fn disable_mouse_capture(&mut self) -> anyhow::Result<()> {
+        Ok(())
+    }
+
     fn leave_alternate_screen(&mut self) -> anyhow::Result<()> {
         Ok(())
     }

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -8,6 +8,7 @@ pub trait Frontend {
     fn get_terminal_dimension(&self) -> anyhow::Result<Dimension>;
     fn enter_alternate_screen(&mut self) -> anyhow::Result<()>;
     fn enable_mouse_capture(&mut self) -> anyhow::Result<()>;
+    fn disable_mouse_capture(&mut self) -> anyhow::Result<()>;
     fn leave_alternate_screen(&mut self) -> anyhow::Result<()>;
     fn enable_raw_mode(&mut self) -> anyhow::Result<()>;
     fn disable_raw_mode(&mut self) -> anyhow::Result<()>;


### PR DESCRIPTION
Mouse capture with crossterm is enabled but never disabled on quit. On Mac this causes mouse events to be input to terminal until terminal is reset. 