### PR TITLE
keymap: change `[`/`]` to `N`/`n` & `n` to `;`

### DIFF
--- a/docs/docs/normal-mode/selection-modes/local-global/index.md
+++ b/docs/docs/normal-mode/selection-modes/local-global/index.md
@@ -8,19 +8,19 @@ There are 3 categories of Local/Global selection modes:
 1. [LSP-based](./lsp-based.md)
 1. [Misc](./misc.md)
 
-> These selection modes are nested under `[`/`]` (Find (Local)) or `g` (Find (Global)).
+> These selection modes are nested under `n`/`N` (Find (Local)) or `g` (Find (Global)).
 
-When using Find (Local) mode, `[` searches backward and `]` searchs forward if
+When using Find (Local) mode, `N` searches backward and `n` searchs forward if
 no matching selection is found under cursor.
 
-## Shortcut (`n`/`N`)
+## Shortcut (`;`)
 
 All selection modes under this Local/Global category are non-contiguous,
 and since they require at least two keypresses, Ki provides a shortcut:
 
 > To set the current selection mode back to the last non-contiguous selection modes,
-> press `n` (search forward) or `N` (search backward).
+> press `;`.
 
 For example, after you searched for a term (either locally or globally),
 and you've changed to another contiguous selection mode (such as Word),
-pressing `n`/`N` will set the selection mode back to the term search.
+pressing `;` will set the selection mode back to the term search.

--- a/src/components/editor_keymap_legend.rs
+++ b/src/components/editor_keymap_legend.rs
@@ -161,14 +161,9 @@ impl Editor {
                     )),
                 ),
                 Keymap::new(
-                    "n",
-                    "Last non-contiguous selection mode - Forward".to_string(),
+                    ";",
+                    "Last non-contiguous selection mode".to_string(),
                     Dispatch::UseLastNonContiguousSelectionMode(IfCurrentNotFound::LookForward),
-                ),
-                Keymap::new(
-                    "N",
-                    "Last non-contiguous selection mode - Backward".to_string(),
-                    Dispatch::UseLastNonContiguousSelectionMode(IfCurrentNotFound::LookBackward),
                 ),
                 Keymap::new(
                     "s",
@@ -204,21 +199,21 @@ impl Editor {
                     Dispatch::ToEditor(SetSelectionMode(IfCurrentNotFound::LookForward, Column)),
                 ),
                 Keymap::new(
-                    "[",
-                    "Find (Local) - Backward".to_string(),
-                    Dispatch::ShowKeymapLegend(self.find_keymap_legend_config(
-                        context,
-                        Scope::Local,
-                        IfCurrentNotFound::LookBackward,
-                    )),
-                ),
-                Keymap::new(
-                    "]",
+                    "n",
                     "Find (Local) - Forward".to_string(),
                     Dispatch::ShowKeymapLegend(self.find_keymap_legend_config(
                         context,
                         Scope::Local,
                         IfCurrentNotFound::LookForward,
+                    )),
+                ),
+                Keymap::new(
+                    "N",
+                    "Find (Local) - Backward".to_string(),
+                    Dispatch::ShowKeymapLegend(self.find_keymap_legend_config(
+                        context,
+                        Scope::Local,
+                        IfCurrentNotFound::LookBackward,
                     )),
                 ),
             ]),
@@ -590,7 +585,7 @@ impl Editor {
         KeymapLegendSection {
             keymaps: Keymaps::new(&[
                 Keymap::new(
-                    ";",
+                    "~",
                     "Replace".to_string(),
                     Dispatch::ToEditor(EnterReplaceMode),
                 ),

--- a/src/recipes.rs
+++ b/src/recipes.rs
@@ -280,7 +280,7 @@ hello_world
             content: "fo ba fo ba".trim(),
             file_extension: "md",
             prepare_events: &[],
-            events: keys!("w ] c l"),
+            events: keys!("w n c l"),
             expectations: &[CurrentSelectedTexts(&["fo"])],
             terminal_height: Some(7),
         },
@@ -298,7 +298,7 @@ foo
             .trim(),
             file_extension: "js",
             prepare_events: &[],
-            events: keys!("s ] c l"),
+            events: keys!("s n c l"),
             expectations: &[CurrentSelectedTexts(&["foo\n  .bar()"])],
             terminal_height: Some(14),
         },
@@ -366,6 +366,15 @@ foo
             terminal_height: Some(7),
         },
         Recipe {
+            description: "Repeat last non-contigous selection mode",
+            content: "fo world fo where".trim(),
+            file_extension: "md",
+            prepare_events: &[],
+            events: keys!("/ f o enter z d ;"),
+            expectations: &[CurrentSelectedTexts(&["fo"])],
+            terminal_height: None,
+        },
+        Recipe {
             description: "Multi-cursor: add using movement",
             content: "
 foo bar spam
@@ -376,7 +385,7 @@ foo bar spam
             .trim(),
             file_extension: "md",
             prepare_events: &[],
-            events: keys!("w ] c q l l esc a x"),
+            events: keys!("w n c q l l esc a x"),
             expectations: &[CurrentComponentContent(
                 "foox bar spam
 spam foox bar
@@ -396,7 +405,7 @@ foo bar spam
             .trim(),
             file_extension: "md",
             prepare_events: &[],
-            events: keys!("w ] c space a a x"),
+            events: keys!("w n c space a a x"),
             expectations: &[CurrentComponentContent(
                 "foox bar spam
 spam foox bar


### PR DESCRIPTION
Because `[`/`]` is so commonly used, they deserve more accessible keybindings.