### PR TITLE
fix(render): multi-width unicode character not showing most of the time

### DIFF
--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -16,6 +16,7 @@ use ::crossterm::{
         SetUnderlineColor,
     },
 };
+use itertools::Itertools;
 
 pub(crate) trait Frontend {
     fn get_terminal_dimension(&self) -> anyhow::Result<Dimension>;
@@ -45,6 +46,17 @@ pub(crate) trait Frontend {
 
             diff
         };
+
+        debug_assert_eq!(
+            cells,
+            cells
+                .clone()
+                .into_iter()
+                .sorted_by_key(|cell| (cell.position.line, -(cell.position.column as isize)))
+                .collect_vec(),
+            "Cells should be sorted in reverse order by column to ensure proper rendering of
+ multi-width characters in terminal displays"
+        );
         for cell in cells {
             queue!(
                 self.writer(),

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -182,24 +182,25 @@ mod test_screen {
             Default::default(),
         );
         let actual = new.diff(&mut old);
-        let expected = vec![
-            PositionedCell {
-                position: Position { line: 0, column: 0 },
-                cell: Cell::from_char('b'),
-            },
+        let expected = [
             PositionedCell {
                 position: Position { line: 0, column: 1 },
                 cell: Cell::from_char('c'),
             },
             PositionedCell {
-                position: Position { line: 1, column: 0 },
-                cell: Cell::from_char(' '),
+                position: Position { line: 0, column: 0 },
+                cell: Cell::from_char('b'),
             },
             PositionedCell {
                 position: Position { line: 1, column: 1 },
                 cell: Cell::from_char(' '),
             },
-        ];
+            PositionedCell {
+                position: Position { line: 1, column: 0 },
+                cell: Cell::from_char(' '),
+            },
+        ]
+        .to_vec();
         assert_eq!(actual, expected);
     }
 }

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -47,6 +47,9 @@ impl Screen {
                             .iter()
                             .flat_map(|border| border.to_positioned_cells(self.border_style)),
                     )
+                    // Cells should be sorted reversed by column, so that multi-width character
+                    // will not be overridden by blank character in terminal rendering
+                    .sorted_by_key(|cell| (cell.position.line, -(cell.position.column as isize)))
                     .collect(),
             );
             self.get_positioned_cells()


### PR DESCRIPTION
This is fixed by reversing the column-wise cell printing order, which was initially left-to-right.