### PR TITLE
fix(selection_mode/line): not selecting current line if cursor on last whitespace of current line

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2244,9 +2244,9 @@ dependencies = [
 
 [[package]]
 name = "ropey"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53ce7a2c43a32e50d666e33c5a80251b31147bb4b49024bcab11fb6f20c671ed"
+checksum = "93411e420bcd1a75ddd1dc3caf18c23155eda2c090631a85af21ba19e97093b5"
 dependencies = [
  "smallvec",
  "str_indices",

--- a/src/char_index_range.rs
+++ b/src/char_index_range.rs
@@ -74,10 +74,18 @@ impl CharIndexRange {
 
     pub(crate) fn trimmed(&self, buffer: &crate::buffer::Buffer) -> anyhow::Result<Self> {
         let text = buffer.slice(self)?.to_string();
-        let leading_whitespace_count = text.chars().take_while(|c| c.is_whitespace()).count();
-        let trailing_whitespace_count =
-            text.chars().rev().take_while(|c| c.is_whitespace()).count();
-        Ok((self.start + leading_whitespace_count..self.end - trailing_whitespace_count).into())
+
+        if text.chars().all(char::is_whitespace) {
+            Ok(*self)
+        } else {
+            let leading_whitespace_count = text.chars().take_while(|c| c.is_whitespace()).count();
+            let trailing_whitespace_count =
+                text.chars().rev().take_while(|c| c.is_whitespace()).count();
+            Ok(
+                (self.start + leading_whitespace_count..self.end - trailing_whitespace_count)
+                    .into(),
+            )
+        }
     }
 
     pub(crate) fn is_supserset_of(&self, other: &CharIndexRange) -> bool {

--- a/src/components/test_editor.rs
+++ b/src/components/test_editor.rs
@@ -2888,3 +2888,22 @@ foov foou bar
         ])
     })
 }
+
+#[test]
+fn select_current_line_when_cursor_is_at_last_space_of_current_line() -> anyhow::Result<()> {
+    execute_test(|s| {
+        Box::new([
+            App(OpenFile(s.main_rs())),
+            Editor(SetContent("abc \n yo".to_string())),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Column)),
+            Editor(MoveSelection(Last)),
+            Expect(CurrentSelectedTexts(&[" "])),
+            Editor(MoveSelection(Previous)),
+            Expect(CurrentSelectedTexts(&["c"])),
+            Editor(MoveSelection(Next)),
+            Expect(CurrentSelectedTexts(&[" "])),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Line)),
+            Expect(CurrentSelectedTexts(&["abc "])),
+        ])
+    })
+}

--- a/src/selection_mode/mod.rs
+++ b/src/selection_mode/mod.rs
@@ -791,7 +791,7 @@ mod test_selection_mode {
         test(
             Movement::Current(IfCurrentNotFound::LookForward),
             5..6,
-            3..5,
+            1..6,
         );
         test(
             Movement::Current(IfCurrentNotFound::LookForward),


### PR DESCRIPTION
This issue is caused by https://github.com/ki-editor/ki-editor/commit/ae1b19691f27de834ca526208eec43fa1d2ea654#diff-6ed05a70c735e96a3ca0ede9586069af860c4358f3fe59803b2e9a953fce9611R465