### PR TITLE
feat(multicursor): add cursor till first/last selection

### DIFF
--- a/docs/docs/normal-mode/actions/index.mdx
+++ b/docs/docs/normal-mode/actions/index.mdx
@@ -142,14 +142,3 @@ Notes:
 
 1. Undo/redo works for multi-cursors as well
 2. The current implementation is naive, it undoes/redoes character-by-character, instead of chunk-by-chunk, so it can be mildly frustrating
-
-## Filter matching selections
-
-Keybindings:
-
-- `K`: Keep matching selections
-- `alt+k`: Remove matching selections
-
-This is only used when there's more than 1 selection/cursor, and you want to remove some selections.
-
-<TutorialFallback filename="filter-matching-selections"/>

--- a/docs/docs/normal-mode/multi-cursor-mode.md
+++ b/docs/docs/normal-mode/multi-cursor-mode.md
@@ -5,32 +5,61 @@ import {TutorialFallback} from '@site/src/components/TutorialFallback';
 Keybinding: `q`  
 Reason: `q` is used to start recording a macro in Vim, but I realized 80% of the time what I need is multi-cursors, not a macro.
 
-### Movements
+Multi-cursor mode works through two main mechanisms: [Movement](./core-movements.mdx) and [Selection Mode](./selection-modes).
 
-In the Multi-cursor submode, every core movement means:
+Unlike other editors where there are specific keybindings for adding cursors in specific ways,
+Ki gives you the freedom to add cursors by either:
 
-> Add cursor with \<movement\>
+- Using Movement commands to place additional cursors
+- Changing the Selection Mode to split existing selections into multiple cursors
 
-Use the following text as an example:
+This flexibility allows you to:
 
-```txt
-hello ki, hello vim, hello helix
-```
+1. Add a cursor to the next word
+2. Add cursors until the last line
+3. Add a cursor to the previous diagnostic
+4. Add a cursor to an oddly specific place
+5. Add cursors to all lines within current selection(s)
 
-Suppose:
+These are just examples - the true power of multi-cursor mode comes from combining Movement and Selection Mode in creative ways. Unleash your imagination!
 
-- The current selection mode is [Find Literal "hello"](./selection-modes/local-global/text-search.md#1-literal)
-- The current selection is the first `hello`
-- The current submode is Multi-cursor
+## 1. Movements
 
-... then executing [Next][1] adds a new cursor to the second `hello`.
+In the Multi-cursor mode, every core movement means:
 
-### Selection Mode Changes
+> Add a cursor with \<movement\>
 
-In the Multi-cursor submode, changing the selection mode means:
+<TutorialFallback filename="add-cursor-with-movement"/>
 
-> Split each selections by the new selection mode
+## 2. Selection Mode Changes
+
+In the Multi-cursor mode, changing the selection mode means:
+
+> Split each selection by the new selection mode
 
 <TutorialFallback filename="split-selections"/>
 
 [1]: ./core-movements.mdx#leftright
+
+## 3. Filter selections
+
+Keybindings:
+
+- `m`: Maintain matching selections
+- `r`: Remove matching selections
+
+This is only used when there's more than 1 selection/cursor, and you want to remove some selections.
+
+<TutorialFallback filename="filter-matching-selections"/>
+
+## 4. Add to all matching selections
+
+Keybinding: `q`
+
+<TutorialFallback filename="add-cursor-to-all-matching-selections"/>
+
+## 5. Keep primary cursor only
+
+Keybinding: `o`
+
+<TutorialFallback filename="keep-primary-cursor-only"/>

--- a/docs/docs/normal-mode/space-menu.md
+++ b/docs/docs/normal-mode/space-menu.md
@@ -62,17 +62,6 @@ For example, the search query `stb 'wild` matches `wild-serbian-bear-tiger` and 
 
 Because [every component is a buffer/editor](../core-concepts.md#2-every-component-is-a-buffereditor), fuzzy search logic is also used for filtering LSP completions.
 
-## Multi-cursor
-
-| Keybinding | Action                                                               |
-| ---------- | -------------------------------------------------------------------- |
-| `a`        | Add cursor to all selections in the current [selection mode][1] [^1] |
-| `o`        | Keeps **o**nly the primary selections                                |
-
-[1]: ./selection-modes/index.md
-
-[^1]: Especially useful when used with [Text Search](./selection-modes/local-global/text-search.md) or [Syntax Node](./selection-modes/syntax-node-based.md).
-
 ## Opening other components
 
 | Keybinding | Action                                   |

--- a/docs/docs/pitch.md
+++ b/docs/docs/pitch.md
@@ -66,7 +66,7 @@ Delete unused imports:
 - `l` (add a cursor to the next selection)
 - `s` (set selection mode to Syntax Node)
 - `d` (delete)
-- `space o` (keep only the primary selection)
+- `q o` (keep only the primary selection)
 
 Again, notice how the commas are removed automatically.
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -735,8 +735,8 @@ impl<T: Frontend> App<T> {
             Dispatch::SetLastActionDescription(description) => {
                 self.last_action_description = Some(description)
             }
-            Dispatch::OpenFilterSelectionsPrompt { keep } => {
-                self.open_filter_selections_prompt(keep)?
+            Dispatch::OpenFilterSelectionsPrompt { maintain } => {
+                self.open_filter_selections_prompt(maintain)?
             }
         }
         Ok(())
@@ -2108,23 +2108,23 @@ impl<T: Frontend> App<T> {
         Ok(())
     }
 
-    fn open_filter_selections_prompt(&mut self, keep: bool) -> anyhow::Result<()> {
+    fn open_filter_selections_prompt(&mut self, maintain: bool) -> anyhow::Result<()> {
         let config = self.context.get_local_search_config(Scope::Local);
         let mode = config.mode;
         self.open_prompt(
             PromptConfig {
                 title: format!(
                     "{} selections matching search ({})",
-                    if keep { "Keep" } else { "Remove" },
+                    if maintain { "Maintain" } else { "Remove" },
                     mode.display()
                 ),
-                on_enter: DispatchPrompt::FilterSelectionMatchingSearch { keep },
+                on_enter: DispatchPrompt::FilterSelectionMatchingSearch { maintain },
                 items: Vec::new(),
                 enter_selects_first_matching_item: false,
                 leaves_current_line_empty: true,
                 fire_dispatches_on_change: None,
             },
-            PromptHistoryKey::FilterSelectionsMatchingSearch { keep },
+            PromptHistoryKey::FilterSelectionsMatchingSearch { maintain },
             None,
         )
     }
@@ -2346,7 +2346,7 @@ pub(crate) enum Dispatch {
     UseLastNonContiguousSelectionMode(IfCurrentNotFound),
     SetLastActionDescription(String),
     OpenFilterSelectionsPrompt {
-        keep: bool,
+        maintain: bool,
     },
 }
 
@@ -2470,7 +2470,7 @@ pub(crate) enum DispatchPrompt {
     SetContent,
     PipeToShell,
     FilterSelectionMatchingSearch {
-        keep: bool,
+        maintain: bool,
     },
 }
 impl DispatchPrompt {
@@ -2566,9 +2566,9 @@ impl DispatchPrompt {
                     command: text.to_string(),
                 },
             ))),
-            DispatchPrompt::FilterSelectionMatchingSearch { keep } => Ok(Dispatches::one(
+            DispatchPrompt::FilterSelectionMatchingSearch { maintain } => Ok(Dispatches::one(
                 Dispatch::ToEditor(DispatchEditor::FilterSelectionMatchingSearch {
-                    keep,
+                    maintain,
                     search: text.to_string(),
                 }),
             )),

--- a/src/components/prompt.rs
+++ b/src/components/prompt.rs
@@ -57,7 +57,7 @@ pub(crate) enum PromptHistoryKey {
     Theme,
     PipeToShell,
     FilterSelectionsMatchingSearch {
-        keep: bool,
+        maintain: bool,
     },
 }
 

--- a/src/components/test_editor.rs
+++ b/src/components/test_editor.rs
@@ -2945,3 +2945,43 @@ fn exchange_till_first() -> anyhow::Result<()> {
         ])
     })
 }
+
+#[test]
+fn add_cursor_till_first() -> anyhow::Result<()> {
+    execute_test(|s| {
+        Box::new([
+            App(OpenFile(s.main_rs())),
+            Editor(SetContent(
+                "fn main(foo: T, apple: T, banana: T, coffee: T) {}".to_string(),
+            )),
+            Editor(MatchLiteral("banana: T".to_string())),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, SyntaxNode)),
+            Expect(CurrentSelectedTexts(&["banana: T"])),
+            Editor(EnterMultiCursorMode),
+            Editor(MoveSelection(First)),
+            Expect(CurrentSelectedTexts(&["foo: T", "apple: T", "banana: T"])),
+        ])
+    })
+}
+
+#[test]
+fn add_cursor_till_last() -> anyhow::Result<()> {
+    execute_test(|s| {
+        Box::new([
+            App(OpenFile(s.main_rs())),
+            Editor(SetContent(
+                "fn main(foo: T, apple: T, banana: T, coffee: T) {}".to_string(),
+            )),
+            Editor(MatchLiteral("apple: T".to_string())),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, SyntaxNode)),
+            Expect(CurrentSelectedTexts(&["apple: T"])),
+            Editor(EnterMultiCursorMode),
+            Editor(MoveSelection(Last)),
+            Expect(CurrentSelectedTexts(&[
+                "apple: T",
+                "banana: T",
+                "coffee: T",
+            ])),
+        ])
+    })
+}

--- a/src/recipes.rs
+++ b/src/recipes.rs
@@ -1,6 +1,7 @@
 use my_proc_macros::keys;
 
 use crate::{
+    components::editor::Mode,
     generate_recipes::{Recipe, RecipeGroup},
     test_app::*,
 };
@@ -415,11 +416,87 @@ foo ha"
                         .trim(),
                     file_extension: "rs",
                     prepare_events: &[],
-                    events: keys!("e v j q / f o o enter w q W alt+k - enter"),
+                    events: keys!("e v j q / f o o enter w q W q r - enter"),
                     expectations: &[CurrentSelectedTexts(&[
                         "foo", "da", "foo", "baz", "foo", "yo",
                     ])],
                     terminal_height: Some(7),
+                    similar_vim_combos: &[],
+                    only: false,
+                },
+            ]
+            .to_vec(),
+        },
+        RecipeGroup {
+            filename: "add-cursor-with-movement",
+            recipes: [
+                Recipe {
+                    description: "Add cursor to the next selections",
+                    content: "foo bar spam baz"
+                    .trim(),
+                    file_extension: "md",
+                    prepare_events: &[],
+                    events: keys!("w q l l"),
+                    expectations: &[
+                        CurrentSelectedTexts(&["foo", "bar", "spam"]),
+                    ],
+                    terminal_height: None,
+                    similar_vim_combos: &[],
+                    only: false,
+                },
+                Recipe {
+                    description: "Add cursor to the previous selections",
+                    content: "foo bar spam baz"
+                    .trim(),
+                    file_extension: "md",
+                    prepare_events: &[],
+                    events: keys!("w . q h h"),
+                    expectations: &[
+                        CurrentSelectedTexts(&["bar", "spam", "baz"]),
+                    ],
+                    terminal_height: None,
+                    similar_vim_combos: &[],
+                    only: false,
+                },
+                Recipe {
+                    description: "Add cursor to any places (with Jump)",
+                    content: "alpha beta gamma omega"
+                    .trim(),
+                    file_extension: "md",
+                    prepare_events: &[],
+                    events: keys!("w q f g"),
+                    expectations: &[
+                        CurrentSelectedTexts(&["alpha", "gamma"]),
+                    ],
+                    terminal_height: None,
+                    similar_vim_combos: &[],
+                    only: false,
+                },
+                Recipe {
+                    description: "Add cursor till the last selection",
+                    content: "alpha beta gamma omega zeta"
+                    .trim(),
+                    file_extension: "md",
+                    prepare_events: &[],
+                    events: keys!("w l q ."),
+                    expectations: &[
+                        CurrentSelectedTexts(&["beta", "gamma", "omega", "zeta"]),
+                    ],
+                    terminal_height: None,
+                    similar_vim_combos: &[],
+                    only: false,
+                },
+                Recipe {
+                    description: "Add cursor till the first selection",
+                    content: "alpha beta gamma omega zeta"
+                    .trim(),
+                    file_extension: "md",
+                    prepare_events: keys!("/ z enter"),
+                    events: keys!("w h q ,"),
+                    expectations: &[
+                        CurrentSelectedTexts(&["alpha","beta", "gamma", "omega"]),
+                    ],
+                    terminal_height: None,
                     similar_vim_combos: &[],
                     only: false,
                 },
@@ -596,7 +673,7 @@ pub(crate) fn get_selection_mode_trait_object(
 "#,
                     file_extension: "rs",
                     prepare_events: &[],
-                    events: keys!("' n / s e l e c t i o n space m o d e enter ' r f o o space b a r enter ctrl+c space a ctrl+r space o"),
+                    events: keys!("' n / s e l e c t i o n space m o d e enter ' r f o o space b a r enter ctrl+c q q ctrl+r q o"),
                     expectations: &[],
                     terminal_height: None,
                     similar_vim_combos: &[],
@@ -659,7 +736,7 @@ pub(crate) fn get_selection_mode_trait_object(
             filename: "filter-matching-selections",
             recipes: [
             Recipe {
-                description: "Keep matching selections",
+                description: "Maintain matching selections",
                 content: "
     enum Foo {
        Bar(baz),
@@ -672,11 +749,14 @@ pub(crate) fn get_selection_mode_trait_object(
                 .trim(),
                 file_extension: "rs",
                 prepare_events: keys!("/ b enter"),
-                events: keys!("s space a K / / enter"),
-                expectations: &[CurrentSelectedTexts(&[
-                    "/// Spam is good\n",
-                    "/// Fifa means filifala\n",
-                ])],
+                events: keys!("s q q q m / / enter"),
+                expectations: &[
+                    CurrentSelectedTexts(&[
+                        "/// Spam is good\n",
+                        "/// Fifa means filifala\n",
+                    ]),
+                    CurrentMode(Mode::Normal)
+                ],
                 terminal_height: None,
                 similar_vim_combos: &[],
                 only: false,
@@ -695,7 +775,7 @@ pub(crate) fn get_selection_mode_trait_object(
                     .trim(),
                     file_extension: "rs",
                     prepare_events: keys!("/ b enter"),
-                    events: keys!("s space a alt+k / / enter"),
+                    events: keys!("s q q q r / / enter"),
                     expectations: &[CurrentSelectedTexts(&[
                         "Bar(baz)",
                         "Spam { what: String }",
@@ -704,7 +784,54 @@ pub(crate) fn get_selection_mode_trait_object(
                     terminal_height: None,
                     similar_vim_combos: &[],
                     only: false,
-                }].to_vec(),
+            }].to_vec(),
+        },
+        RecipeGroup {
+            filename: "add-cursor-to-all-matching-selections",
+            recipes: [
+            Recipe {
+            description: "Example",
+            content: "
+foo bar spam
+spam foo bar
+bar spam foo
+foo bar spam
+"
+            .trim(),
+            file_extension: "md",
+            prepare_events: &[],
+            events: keys!("w * q q a x"),
+            expectations: &[CurrentComponentContent(
+                "foox bar spam
+spam foox bar
+bar spam foox
+foox bar spam",
+            )],
+            terminal_height: None,
+            similar_vim_combos: &[],
+            only: false,
+        }].to_vec(),
+        },
+        RecipeGroup {
+            filename: "keep-primary-cursor-only",
+            recipes: [
+            Recipe {
+            description: "Example",
+            content: "
+foo bar spam
+spam foo bar
+bar spam foo
+foo bar spam
+"
+            .trim(),
+            file_extension: "md",
+            prepare_events: &[],
+            events: keys!("w * q q q o"),
+            expectations: &[CurrentSelectedTexts(&["foo"])],
+            terminal_height: None,
+            similar_vim_combos: &[],
+            only: false,
+        }].to_vec(),
         },
         RecipeGroup {
             filename: "recipes",
@@ -764,7 +891,7 @@ pub(crate) fn run(path: Option<CanonicalizedPath>) -> anyhow::Result<()> {
                     .trim(),
                     file_extension: "rs",
                     prepare_events: &[],
-                    events: keys!("/ p r i n t enter space a s d"),
+                    events: keys!("/ p r i n t enter q q s d"),
                     expectations: &[],
                     terminal_height: None,
                     similar_vim_combos: &[],
@@ -797,7 +924,7 @@ pub(crate) fn run(path: Option<CanonicalizedPath>) -> anyhow::Result<()> {
                     file_extension: "md",
                     prepare_events: &[],
                     events: keys!(
-                        "' x / ^ - space backslash [ space backslash ] enter space a s y d e . p a backspace"
+                        "' x / ^ - space backslash [ space backslash ] enter q q s y d e . p a backspace"
                     ),
                     expectations: &[],
                     terminal_height: None,
@@ -833,7 +960,7 @@ pub(crate) fn from_text(language: Option<tree_sitter::Language>, text: &str) -> 
                     file_extension: "rs",
                     prepare_events: &[],
                     events: keys!(
-                        "/ y x enter s space a b n v s ( i S o m e esc s b n n T space o"
+                        "/ y x enter s q q b n v s ( i S o m e esc s b n n T q o"
                     ),
                     expectations: &[],
                     terminal_height: None,
@@ -1226,28 +1353,6 @@ foo bar spam
 spam foox bar
 bar spam foox
 foo bar spam",
-            )],
-            terminal_height: None,
-            similar_vim_combos: &[],
-            only: false,
-        },
-        Recipe {
-            description: "Multi-cursor: Select all matches",
-            content: "
-foo bar spam
-spam foo bar
-bar spam foo
-foo bar spam
-"
-            .trim(),
-            file_extension: "md",
-            prepare_events: &[],
-            events: keys!("w * space a a x"),
-            expectations: &[CurrentComponentContent(
-                "foox bar spam
-spam foox bar
-bar spam foox
-foox bar spam",
             )],
             terminal_height: None,
             similar_vim_combos: &[],

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -124,12 +124,14 @@ impl SelectionSet {
         }))
     }
 
+    /// Returns `false` if no new selection is added
     pub(crate) fn add_selection(
         &mut self,
         buffer: &Buffer,
         direction: &Movement,
         cursor_direction: &Direction,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<bool> {
+        let initial_selections_length = self.selections.len();
         let last_selection = &self
             .selections
             .get(self.cursor_index)
@@ -166,7 +168,7 @@ impl SelectionSet {
             }
         }
 
-        Ok(())
+        Ok(self.selections.len() > initial_selections_length)
     }
 
     pub(crate) fn all_selections(


### PR DESCRIPTION
Also consistentize multicursor keybindings:

| Action | Old | New |
|--|--|--|
|Add cursor to all matching selections|`space a`|`q q`|
|Keep primary cursor only|`space o`|`q o`|
|Remove matching selections | `alt+k` | `q r` |
|Maintain matching selections | `K` | `q m`|