### PR TITLE
fix(global replace): panics if working directory contains very large text file

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -861,7 +861,12 @@ impl Buffer {
             }
             LocalSearchConfigMode::Regex(regex_config) => {
                 let regex = regex_config.to_regex(&config.search())?;
-                let replaced = regex.replace_all(&before, config.replacement()).to_string();
+                let replaced = regex
+                    // We use `try_replacen` instead of `replace_all`
+                    // because the latter panics on very large file,
+                    // subsequently crashing Ki.
+                    .try_replacen(&before, 0, config.replacement())?
+                    .to_string();
                 self.get_edit_transaction(&replaced)?
             }
             LocalSearchConfigMode::AstGrep => {


### PR DESCRIPTION
## Changes
Use `try_replace` instead of `replace_all` which calls `replacen` which panics on huge files. 

## Reference
- https://docs.rs/fancy-regex/latest/fancy_regex/struct.Regex.html#method.replacen
- https://docs.rs/fancy-regex/latest/fancy_regex/struct.Regex.html#method.replace_all
- https://docs.rs/fancy-regex/latest/fancy_regex/struct.Regex.html#method.try_replacen