### PR TITLE
feat(selection_mode/line): left = parent line

### DIFF
--- a/docs/docs/components/file-explorer.md
+++ b/docs/docs/components/file-explorer.md
@@ -41,15 +41,15 @@ Other keybindings can be found at [contextual keybindings](../normal-mode/space-
 
 Because the File Explorer is just a YAML file, the following actions are free[^1]:
 
-| Action                                                                        | How?                                         |
-| ----------------------------------------------------------------------------- | -------------------------------------------- |
-| Go to parent folder                                                           | Use [Parent Line][1]                         |
-| Go to first/last file in current folder                                       | Use [First/Last][2] with [Syntax Node][3]    |
+| Action                                                                       | How?                                         |
+| ---------------------------------------------------------------------------- | -------------------------------------------- |
+| Go to parent folder                                                          | Use [`e h`][1]                               |
+| Go to first/last file in current folder                                      | Use [First/Last][2] with [Syntax Node][3]    |
 | Go to next/previous file/folder at current level, skipping expanded children | Use [Previous/Next][4] with [Syntax Node][3] |
 
 [^1]: Free as in no extra implementations required
 
-[1]: ../normal-mode/core-movements.mdx#parent-line
-[2]: ../normal-mode/core-movements.mdx#firstlast
+[1]: ../normal-mode/selection-modes/regex-based.md#line
+[2]: ../normal-mode/core-movements.md#firstlast
 [3]: ../normal-mode/selection-modes/syntax-node-based.md#syntax-node
-[4]: ../normal-mode/core-movements.mdx#leftright
+[4]: ../normal-mode/core-movements.md#leftright

--- a/docs/docs/normal-mode/actions/index.md
+++ b/docs/docs/normal-mode/actions/index.md
@@ -141,7 +141,7 @@ Reason: The `esc enter` combo is sweet.
 
 Upon saving, formatting will be applied if possible.
 
-After formatting, the [Current](../core-movements.mdx#current) movement will be executed, to reduce disorientation caused by the misplaced selection due to content changes.
+After formatting, the [Current](../core-movements.md#current) movement will be executed, to reduce disorientation caused by the misplaced selection due to content changes.
 
 ## Undo/Redo
 

--- a/docs/docs/normal-mode/core-movements.md
+++ b/docs/docs/normal-mode/core-movements.md
@@ -9,13 +9,12 @@ import {TutorialFallback} from '@site/src/components/TutorialFallback';
 Core Movements is one of the main concepts in Ki, because it is standardized for
 every [selection modes](./selection-modes/index.md).
 
-There are 10 movements in total:
+There are 9 movements in total:
 
 1. [Left/Right](#leftright)
 1. [Up/Down](#updown)
 1. [First/Last](#firstlast)
 1. [Jump](#jump)
-1. [Parent Line](#parent-line)
 1. [To Index](#to-index)
 1. [Current](#current)
 
@@ -88,18 +87,6 @@ Recommended selection modes:
 This movement can also work with the Exchange mode to swap two syntax expressions that are far apart.
 
 [^1]: hop.nvim, leap.nvim, lightspeed.nvim etc.
-
-## Parent line
-
-Keybinding: `-`
-
-It moves the current selection to its nearest parent line.
-
-Parent lines are highlighted lines that represent the parent nodes of the current selection.
-
-This is useful for example when you are within the body of a function and you want to jump to the function name.
-
-This is also practical in the [File Explorer](../components/file-explorer.md) because the file explorer is rendered using YAML, so going to Parent Line means going to the parent folder!
 
 ## To Index
 

--- a/docs/docs/normal-mode/multi-cursor-mode.md
+++ b/docs/docs/normal-mode/multi-cursor-mode.md
@@ -5,7 +5,7 @@ import {TutorialFallback} from '@site/src/components/TutorialFallback';
 Keybinding: `q`  
 Reason: `q` is used to start recording a macro in Vim, but I realized 80% of the time what I need is multi-cursors, not a macro.
 
-Multi-cursor mode works through two main mechanisms: [Movement](./core-movements.mdx) and [Selection Mode](./selection-modes).
+Multi-cursor mode works through two main mechanisms: [Movement](./core-movements.md) and [Selection Mode](./selection-modes).
 
 Unlike other editors where there are specific keybindings for adding cursors in specific ways,
 Ki gives you the freedom to add cursors by either:
@@ -39,7 +39,7 @@ In the Multi-cursor mode, changing the selection mode means:
 
 <TutorialFallback filename="split-selections"/>
 
-[1]: ./core-movements.mdx#leftright
+[1]: ./core-movements.md#leftright
 
 ## 3. Filter selections
 

--- a/docs/docs/normal-mode/selection-modes/index.md
+++ b/docs/docs/normal-mode/selection-modes/index.md
@@ -4,12 +4,12 @@ sidebar_position: 1
 
 # Selection Modes
 
-Selection modes [^1] dictates how [core movements](../core-movements.mdx) works.
+Selection modes [^1] dictates how [core movements](../core-movements.md) works.
 
 There are roughly 3 categories of selection modes (not clear-cut):
 
 1. [Syntax tree-based](./syntax-node-based.md)
-2. [Regex-based](./regex-based.mdx)
+2. [Regex-based](./regex-based.md)
 3. [Local/Global](./local-global/index.md)
 
 [^1]: For Vim users, selection mode means text objects.

--- a/docs/docs/normal-mode/selection-modes/regex-based.md
+++ b/docs/docs/normal-mode/selection-modes/regex-based.md
@@ -10,11 +10,20 @@ import {TutorialFallback} from '@site/src/components/TutorialFallback';
 
 Keybinding: `e`
 
-In this selection mode `h`/`l` behaves exactly like `j`/`k`, and the selection
-is trimmed, which means that the leading and trailing spaces of each line are
-not selected.
+In this selection mode, the selection is trimmed, which means that the leading
+and trailing spaces of each line are not selected.
 
 This is usually used in conjunction with `i`/`a` to immediately enter insert mode at the first/last non-whitespace symbol of the current line.
+
+`h` moves the nearest parent line.
+
+Parent lines are highlighted lines that represent the parent nodes of the current selection.
+
+This is useful for example when you are within the body of a function and you want to jump to the function name.
+
+This is also practical in the [File Explorer](../../components/file-explorer.md) because the file explorer is rendered using YAML, so going to Parent Line means going to the parent folder!
+
+<TutorialFallback filename="line"/>
 
 ## Full Line
 
@@ -51,6 +60,6 @@ Keybindings:
 - `z`: Collapse selection (start)
 - `$`: Collapse selection (end)
 
-In this selection mode, the movements behave like the usual editor, where [Left/Right](./../core-movements.mdx#leftright) means left/right, and so on.
+In this selection mode, the movements behave like the usual editor, where [Left/Right](./../core-movements.md#leftright) means left/right, and so on.
 
-[First/Last](./../core-movements.mdx#firstlast) means the first/last column of the current line.
+[First/Last](./../core-movements.md#firstlast) means the first/last column of the current line.

--- a/docs/docs/normal-mode/selection-modes/syntax-node-based.md
+++ b/docs/docs/normal-mode/selection-modes/syntax-node-based.md
@@ -24,7 +24,7 @@ Keybinding: `s`
 
 | Movement                                            | Meaning                                                               |
 | --------------------------------------------------- | --------------------------------------------------------------------- |
-| [Next/Preivous](../core-movements.mdx#nextprevious) | Next/Previous **named** sibling node                                  |
+| [Next/Preivous](../core-movements.md#nextprevious) | Next/Previous **named** sibling node                                  |
 | Up                                                  | Parent node                                                           |
 | Down                                                | First **named** child                                                 |
 | Current                                             | Select the largest node                                               |
@@ -71,7 +71,7 @@ Reason: Coarse is more commonly used than Fine, thus Fine is assigned a harder-t
 
 | Movement                                            | Meaning                                          |
 | --------------------------------------------------- | ------------------------------------------------ |
-| [Next/Preivous](../core-movements.mdx#nextprevious) | Next/Previous sibling node                       |
+| [Next/Preivous](../core-movements.md#nextprevious) | Next/Previous sibling node                       |
 | Up                                                  | Parent node                                      |
 | Shrink                                              | First child                                      |
 | Current                                             | Smallest node that matches the current selection |

--- a/src/components/editor.rs
+++ b/src/components/editor.rs
@@ -486,7 +486,6 @@ pub(crate) enum Movement {
     /// 0-based
     Index(usize),
     Jump(CharIndexRange),
-    ToParentLine,
     Expand,
     DeleteBackward,
     DeleteForward,

--- a/src/components/editor_keymap_legend.rs
+++ b/src/components/editor_keymap_legend.rs
@@ -75,11 +75,6 @@ impl Editor {
                     }),
                 ),
                 Keymap::new(
-                    "-",
-                    "Parent Line".to_string(),
-                    Dispatch::ToEditor(MoveSelection(ToParentLine)),
-                ),
-                Keymap::new(
                     "0",
                     "To Index (1-based)".to_string(),
                     Dispatch::OpenMoveToIndexPrompt,

--- a/src/recipes.rs
+++ b/src/recipes.rs
@@ -11,6 +11,90 @@ pub(crate) fn recipe_groups() -> Vec<RecipeGroup> {
         showcase(),
         syntax_node(),
         RecipeGroup {
+            filename: "line",
+            recipes: [
+            Recipe {
+                description: "Select a line",
+                content: "
+To be, or not to be?
+That, is the question.
+"
+                .trim(),
+                file_extension: "md",
+                prepare_events: &[],
+                events: keys!("e"),
+                expectations: &[CurrentSelectedTexts(&["To be, or not to be?"])],
+                terminal_height: None,
+                similar_vim_combos: &["V"],
+                only: false,
+            },
+            Recipe {
+                description: "Go to first and last line",
+                content: "
+To be, or not to be, that is the question:
+Whether 'tis nobler in the mind to suffer
+The slings and arrows of outrageous fortune,
+Or to take arms against a sea of troubles
+And by opposing end them. To die—to sleep,
+"
+                .trim(),
+                file_extension: "md",
+                prepare_events: &[],
+                events: keys!("e . ,"),
+                expectations: &[CurrentSelectedTexts(&[
+                    "To be, or not to be, that is the question:",
+                ])],
+                terminal_height: None,
+                similar_vim_combos: &["g g", "G"],
+                only: false,
+            },
+            Recipe {
+                description: "Insert at the beginning of line",
+                content: "  hat is that?",
+                file_extension: "md",
+                prepare_events: &[],
+                events: keys!("e i W"),
+                expectations: &[CurrentComponentContent("  What is that?")],
+                terminal_height: None,
+                similar_vim_combos: &["I"],
+                only: false,
+            },
+            Recipe {
+                description: "Insert at the end of line",
+                content: "  What is that",
+                file_extension: "md",
+                prepare_events: &[],
+                events: keys!("e a ?"),
+                expectations: &[CurrentComponentContent("  What is that?")],
+                terminal_height: None,
+                similar_vim_combos: &["A"],
+                only: false,
+            },
+            Recipe {
+                description: "Go to parent line",
+                content: "
+- docs/:
+    - .gitignore
+    - book/:
+    - book.toml
+    - src/:
+        - SUMMARY.md
+        - components/:
+            - file-explorer.md
+            - index.md
+"
+                .trim(),
+                file_extension: "yaml",
+                prepare_events: keys!("/ i n d e x enter"),
+                events: keys!("e h h h"),
+                expectations: &[CurrentSelectedTexts(&["- docs/:"])],
+                terminal_height: Some(10),
+                similar_vim_combos: &[],
+                only: false,
+            }
+            ].to_vec(),
+        },
+        RecipeGroup {
             filename: "delete",
             recipes: [
                 Recipe {
@@ -47,6 +131,39 @@ Why?
                     prepare_events: &[],
                     events: keys!("t . D D"),
                     expectations: &[CurrentSelectedTexts(&["camelCase"])],
+                    terminal_height: None,
+                    similar_vim_combos: &[],
+                    only: false,
+                },
+                Recipe {
+                    description: "Delete forward: auto backward at the end",
+                    content: "foo bar spam".trim(),
+                    file_extension: "md",
+                    prepare_events: &[],
+                    events: keys!("t . d d"),
+                    expectations: &[CurrentSelectedTexts(&["foo"])],
+                    terminal_height: None,
+                    similar_vim_combos: &[],
+                    only: false,
+                },
+                Recipe {
+                    description: "Delete backward: auto backward at the beginning",
+                    content: "foo bar spam".trim(),
+                    file_extension: "md",
+                    prepare_events: &[],
+                    events: keys!("t D D"),
+                    expectations: &[CurrentSelectedTexts(&["spam"])],
+                    terminal_height: None,
+                    similar_vim_combos: &[],
+                    only: false,
+                },
+                Recipe {
+                    description: "Delete sibling nodes",
+                    content: "[{foo: bar}, spam, 1 + 1]".trim(),
+                    file_extension: "js",
+                    prepare_events: keys!("w l"),
+                    events: keys!("s d d"),
+                    expectations: &[CurrentSelectedTexts(&["1 + 1"]), CurrentComponentContent("[1 + 1]")],
                     terminal_height: None,
                     similar_vim_combos: &[],
                     only: false,
@@ -1319,21 +1436,6 @@ fn recipes() -> Vec<Recipe> {
             only: false,
         },
         Recipe {
-            description: "Select a line",
-            content: "
-To be, or not to be?
-That, is the question.
-"
-            .trim(),
-            file_extension: "md",
-            prepare_events: &[],
-            events: keys!("e"),
-            expectations: &[CurrentSelectedTexts(&["To be, or not to be?"])],
-            terminal_height: None,
-            similar_vim_combos: &["V"],
-            only: false,
-        },
-        Recipe {
             description: "Duplicate current line",
             content: "
 To be, or not to be?
@@ -1350,26 +1452,6 @@ That, is the question.",
             )],
             terminal_height: None,
             similar_vim_combos: &["y y p"],
-            only: false,
-        },
-        Recipe {
-            description: "Go to first and last line",
-            content: "
-To be, or not to be, that is the question:
-Whether 'tis nobler in the mind to suffer
-The slings and arrows of outrageous fortune,
-Or to take arms against a sea of troubles
-And by opposing end them. To die—to sleep,
-"
-            .trim(),
-            file_extension: "md",
-            prepare_events: &[],
-            events: keys!("e . ,"),
-            expectations: &[CurrentSelectedTexts(&[
-                "To be, or not to be, that is the question:",
-            ])],
-            terminal_height: None,
-            similar_vim_combos: &["g g", "G"],
             only: false,
         },
         Recipe {
@@ -1394,28 +1476,6 @@ And by opposing end them. To die—to sleep,",
             ])],
             terminal_height: None,
             similar_vim_combos: &["g g V G"],
-            only: false,
-        },
-        Recipe {
-            description: "Insert at the beginning of line",
-            content: "  hat is that?",
-            file_extension: "md",
-            prepare_events: &[],
-            events: keys!("e i W"),
-            expectations: &[CurrentComponentContent("  What is that?")],
-            terminal_height: None,
-            similar_vim_combos: &["I"],
-            only: false,
-        },
-        Recipe {
-            description: "Insert at the end of line",
-            content: "  What is that",
-            file_extension: "md",
-            prepare_events: &[],
-            events: keys!("e a ?"),
-            expectations: &[CurrentComponentContent("  What is that?")],
-            terminal_height: None,
-            similar_vim_combos: &["A"],
             only: false,
         },
         Recipe {

--- a/src/selection_mode/line_trimmed.rs
+++ b/src/selection_mode/line_trimmed.rs
@@ -1,4 +1,6 @@
-use super::SelectionMode;
+use crate::components::editor::IfCurrentNotFound;
+
+use super::{SelectionMode, SelectionModeParams};
 
 pub(crate) struct LineTrimmed;
 
@@ -37,6 +39,39 @@ impl SelectionMode for LineTrimmed {
                 }),
         ))
     }
+
+    fn left(
+        &self,
+        params: super::SelectionModeParams,
+    ) -> anyhow::Result<Option<crate::selection::Selection>> {
+        let SelectionModeParams {
+            buffer,
+            current_selection,
+            cursor_direction,
+        } = params;
+        let current_line = buffer.char_to_line(current_selection.extended_range().start)?;
+        Ok(buffer
+            .get_parent_lines(current_line)?
+            .into_iter()
+            .filter(|line| line.line < current_line)
+            .next_back()
+            .map(|line| {
+                let byte_range = buffer.line_to_byte_range(line.line)?;
+                let start = trim_leading_spaces(byte_range.range.start, &line.content);
+                let char_index_range =
+                    buffer.byte_range_to_char_index_range(&(start..start + 1))?;
+                self.current(
+                    SelectionModeParams {
+                        buffer,
+                        cursor_direction,
+                        current_selection: &current_selection.clone().set_range(char_index_range),
+                    },
+                    IfCurrentNotFound::LookForward,
+                )
+            })
+            .transpose()?
+            .flatten())
+    }
 }
 
 pub(crate) fn trim_leading_spaces(byte_start: usize, line: &str) -> usize {
@@ -54,7 +89,7 @@ pub(crate) fn trim_leading_spaces(byte_start: usize, line: &str) -> usize {
 
 #[cfg(test)]
 mod test_line {
-    use crate::{buffer::Buffer, selection::Selection};
+    use crate::{buffer::Buffer, components::editor::Direction, selection::Selection};
 
     use super::*;
 
@@ -82,5 +117,42 @@ mod test_line {
     fn single_line_without_trailing_newline_character() {
         let buffer = Buffer::new(None, "a");
         LineTrimmed.assert_all_selections(&buffer, Selection::default(), &[(0..1, "a")]);
+    }
+
+    #[test]
+    fn to_parent_line() {
+        let buffer = Buffer::new(
+            Some(tree_sitter_rust::language()),
+            "
+fn f() {
+    fn g() {
+        let a = 1;
+        let b = 2;
+        let c = 3;
+        let d = 4;
+    }
+
+}"
+            .trim(),
+        );
+
+        let test = |selected_line: usize, expected: &str| {
+            let start = buffer.line_to_char(selected_line).unwrap();
+            let result = LineTrimmed
+                .left(SelectionModeParams {
+                    buffer: &buffer,
+                    current_selection: &Selection::new((start..start + 1).into()),
+                    cursor_direction: &Direction::default(),
+                })
+                .unwrap()
+                .unwrap();
+
+            let actual = buffer.slice(&result.extended_range()).unwrap();
+            assert_eq!(actual, expected);
+        };
+
+        test(4, "fn g() {");
+
+        test(1, "fn f() {");
     }
 }


### PR DESCRIPTION
This also entails no more generic Parent Line movements. This is because movements are supposed to be generic in meaning and then be specialized in different selection modes, not the other way around.