### PR TITLE
"ki edit ." now opens file explorer instead of crashing.

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2,16 +2,11 @@ use crate::{
     buffer::Buffer,
     clipboard::CopiedTexts,
     components::{
-        component::{Component, ComponentId, GetGridResult},
-        dropdown::{DropdownItem, DropdownRender},
-        editor::{DispatchEditor, Editor, IfCurrentNotFound, Movement},
-        keymap_legend::{
+        component::{Component, ComponentId, GetGridResult}, dropdown::{DropdownItem, DropdownRender}, editor::{DispatchEditor, Editor, IfCurrentNotFound, Movement}, file_explorer::FileExplorer, keymap_legend::{
             Keymap, KeymapLegendBody, KeymapLegendConfig, KeymapLegendSection, Keymaps,
-        },
-        prompt::{Prompt, PromptConfig, PromptHistoryKey},
-        suggestive_editor::{
+        }, prompt::{Prompt, PromptConfig, PromptHistoryKey}, suggestive_editor::{
             DispatchSuggestiveEditor, Info, SuggestiveEditor, SuggestiveEditorFilter,
-        },
+        }
     },
     context::{Context, GlobalMode, LocalSearchConfigMode, QuickfixListSource, Search},
     frontend::Frontend,
@@ -163,7 +158,11 @@ impl<T: Frontend> App<T> {
         }
 
         if let Some(entry_path) = entry_path {
-            self.open_file(&entry_path, OpenFileOption::Focus)?;
+            if entry_path.as_ref().is_dir() {
+                self.layout.open_file_explorer();
+            } else {
+                self.open_file(&entry_path, OpenFileOption::Focus)?;
+            }
         }
 
         self.render()?;

--- a/src/app.rs
+++ b/src/app.rs
@@ -2,11 +2,16 @@ use crate::{
     buffer::Buffer,
     clipboard::CopiedTexts,
     components::{
-        component::{Component, ComponentId, GetGridResult}, dropdown::{DropdownItem, DropdownRender}, editor::{DispatchEditor, Editor, IfCurrentNotFound, Movement}, file_explorer::FileExplorer, keymap_legend::{
+        component::{Component, ComponentId, GetGridResult},
+        dropdown::{DropdownItem, DropdownRender},
+        editor::{DispatchEditor, Editor, IfCurrentNotFound, Movement},
+        keymap_legend::{
             Keymap, KeymapLegendBody, KeymapLegendConfig, KeymapLegendSection, Keymaps,
-        }, prompt::{Prompt, PromptConfig, PromptHistoryKey}, suggestive_editor::{
+        },
+        prompt::{Prompt, PromptConfig, PromptHistoryKey},
+        suggestive_editor::{
             DispatchSuggestiveEditor, Info, SuggestiveEditor, SuggestiveEditorFilter,
-        }
+        },
     },
     context::{Context, GlobalMode, LocalSearchConfigMode, QuickfixListSource, Search},
     frontend::Frontend,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -74,6 +74,7 @@ pub(crate) fn cli() -> anyhow::Result<()> {
                 if !path.exists() {
                     std::fs::write(path, "")?;
                 }
+
                 crate::run(crate::RunConfig {
                     entry_path: Some(args.path.try_into()?),
                     ..Default::default()

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -75,9 +75,11 @@ pub(crate) fn cli() -> anyhow::Result<()> {
                     std::fs::write(path, "")?;
                 }
 
+                let path = Some(args.path.try_into()?);
+
                 crate::run(crate::RunConfig {
-                    entry_path: Some(args.path.try_into()?),
-                    ..Default::default()
+                    entry_path: path.clone(),
+                    working_directory: path,
                 })
             }
             Commands::Log => {


### PR DESCRIPTION
It used to crash at `main.rs` where `cli::cli.unwrap()` was called because you'd just get an `Err` as the `edit` match arm wasn't able to handle a directory instead of a file. The file explorer does open but it is slow. I'm wondering if it's an issue of how I opened the file explorer or if it's an issue of the file explorer.

There is a bug where `ki edit ..` opens the current directory instead of the parent directory (will work on it) but I thought to just open the PR so it is kept track of it.