### PR TITLE
feat(languages/gleam): added (definition, tree-sitter, lsp and formatter)

### DIFF
--- a/shared/src/languages.rs
+++ b/shared/src/languages.rs
@@ -7,6 +7,7 @@ pub const LANGUAGES: &[&Language] = &[
     &css(),
     &csv(),
     &dockerfile(),
+    &gleam(),
     &graphql(),
     &hare(),
     &html(),
@@ -136,6 +137,25 @@ const fn dockerfile() -> Language {
             commit: "main",
             subpath: None,
         }),
+    }
+}
+
+const fn gleam() -> Language {
+    Language {
+        lsp_language_id: Some(LanguageId::new("gleam")),
+        extensions: &["gleam"],
+        tree_sitter_grammar_config: Some(GrammarConfig {
+            id: "gleam",
+            url: "https://github.com/gleam-lang/tree-sitter-gleam",
+            commit: "main",
+            subpath: None,
+        }),
+        formatter_command: Some(Command("gleam", &["format", "--stdin"])),
+        lsp_command: Some(LspCommand {
+            command: Command("gleam", &["lsp"]),
+            initialization_options: None,
+        }),
+        ..Language::new()
     }
 }
 

--- a/shared/src/languages.rs
+++ b/shared/src/languages.rs
@@ -153,7 +153,7 @@ const fn gleam() -> Language {
         formatter_command: Some(Command("gleam", &["format", "--stdin"])),
         lsp_command: Some(LspCommand {
             command: Command("gleam", &["lsp"]),
-            initialization_options: None,
+            ..LspCommand::default()
         }),
         ..Language::new()
     }


### PR DESCRIPTION
"Gleam is a friendly language for building type-safe systems that scale!". It is growing in popularity, often times being compared to Rust. It compiles to the Beam VM (Erlang and Elixir) as well as directly to JavaScript.

https://gleam.run