### PR TITLE
fix(cli): ki edit now works on files as well as . and .. (#463)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -75,11 +75,16 @@ pub(crate) fn cli() -> anyhow::Result<()> {
                     std::fs::write(path, "")?;
                 }
 
-                let path = Some(args.path.try_into()?);
+                let path: Option<CanonicalizedPath> = Some(args.path.try_into()?);
+                let working_directory = match path.clone() {
+                    Some(value) if value.is_dir() => Some(value),
+                    Some(value) => value.parent()?,
+                    _ => Default::default()
+                 };
 
                 crate::run(crate::RunConfig {
-                    entry_path: path.clone(),
-                    working_directory: path,
+                    entry_path: path,
+                    working_directory
                 })
             }
             Commands::Log => {


### PR DESCRIPTION
In the call to `RunConfig`, `working_directory` must be a directory. The bug was that it was a file.

With this patch, if the path supplied on the CLI is a file, `working_directory` will become the parent of whatever was specified on the command line. If it is not a file, it is taken as is. If not specified, it becomes `Default::default()`.