### PR TITLE
feat(languages/git): git commit, config, ignore and attributes

### DIFF
--- a/shared/src/languages.rs
+++ b/shared/src/languages.rs
@@ -6,11 +6,13 @@ pub const LANGUAGES: &[&Language] = &[
     &common_lisp(),
     &css(),
     &csv(),
+    &diff(),
     &dockerfile(),
     &gitattributes(),
     &gitcommit(),
     &gitconfig(),
     &gitignore(),
+    &gitrebase(),
     &graphql(),
     &hare(),
     &html(),
@@ -109,6 +111,18 @@ const fn csv() -> Language {
     }
 }
 
+const fn diff() -> Language {
+    Language {
+        extensions: &["diff"],
+        tree_sitter_grammar_config: Some(GrammarConfig {
+            id: "diff",
+            url: "https://github.com/the-mikedavis/tree-sitter-diff",
+            commit: "main",
+            subpath: None,
+        }),
+        ..Language::new()
+    }
+}
 const fn css() -> Language {
     Language {
         file_names: &[],
@@ -206,6 +220,19 @@ const fn gitignore() -> Language {
         tree_sitter_grammar_config: Some(GrammarConfig {
             id: "gitignore",
             url: "https://github.com/shunsambongi/tree-sitter-gitignore",
+            commit: "main",
+            subpath: None,
+        }),
+        ..Language::new()
+    }
+}
+
+const fn gitrebase() -> Language {
+    Language {
+        file_names: &["git-rebase-todo"],
+        tree_sitter_grammar_config: Some(GrammarConfig {
+            id: "git_rebase",
+            url: "https://github.com/the-mikedavis/tree-sitter-git-rebase",
             commit: "main",
             subpath: None,
         }),

--- a/shared/src/languages.rs
+++ b/shared/src/languages.rs
@@ -188,6 +188,7 @@ const fn gitattributes() -> Language {
         ..Language::new()
     }
 }
+
 const fn gitcommit() -> Language {
     Language {
         file_names: &["COMMIT_EDITMSG"],

--- a/shared/src/languages.rs
+++ b/shared/src/languages.rs
@@ -7,6 +7,10 @@ pub const LANGUAGES: &[&Language] = &[
     &css(),
     &csv(),
     &dockerfile(),
+    &gitattributes(),
+    &gitcommit(),
+    &gitconfig(),
+    &gitignore(),
     &graphql(),
     &hare(),
     &html(),
@@ -153,6 +157,57 @@ const fn graphql() -> Language {
         lsp_command: Some(LspCommand {
             command: Command("graphql-lsp", &["server", "-m", "stream"]),
             initialization_options: Some(r#"{ "graphql-config.load.legacy": true }"#),
+        }),
+        ..Language::new()
+    }
+}
+
+const fn gitattributes() -> Language {
+    Language {
+        file_names: &[".gitattributes"],
+        tree_sitter_grammar_config: Some(GrammarConfig {
+            id: "gitattributes",
+            url: "https://github.com/tree-sitter-grammars/tree-sitter-gitattributes",
+            commit: "master",
+            subpath: None,
+        }),
+        ..Language::new()
+    }
+}
+const fn gitcommit() -> Language {
+    Language {
+        file_names: &["COMMIT_EDITMSG"],
+        tree_sitter_grammar_config: Some(GrammarConfig {
+            id: "gitcommit",
+            url: "https://github.com/gbprod/tree-sitter-gitcommit",
+            commit: "main",
+            subpath: None,
+        }),
+        ..Language::new()
+    }
+}
+
+const fn gitconfig() -> Language {
+    Language {
+        file_names: &[".gitconfig"],
+        tree_sitter_grammar_config: Some(GrammarConfig {
+            id: "git_config",
+            url: "https://github.com/the-mikedavis/tree-sitter-git-config",
+            commit: "main",
+            subpath: None,
+        }),
+        ..Language::new()
+    }
+}
+
+const fn gitignore() -> Language {
+    Language {
+        file_names: &[".gitignore"],
+        tree_sitter_grammar_config: Some(GrammarConfig {
+            id: "gitignore",
+            url: "https://github.com/shunsambongi/tree-sitter-gitignore",
+            commit: "main",
+            subpath: None,
         }),
         ..Language::new()
     }

--- a/src/components/editor_keymap_config.rs
+++ b/src/components/editor_keymap_config.rs
@@ -1,1 +1,0 @@
-editor_keymap_alt.rs


### PR DESCRIPTION
This enables syntax highlighting when using ki as your git commit editor.

It also enables syntax highlighting for .gitignore, .gitattributes and .gitconfig files.