### PR TITLE
feat(lsp): support DocumentSymbol and children

### DIFF
--- a/shared/src/languages.rs
+++ b/shared/src/languages.rs
@@ -7,8 +7,14 @@ pub const LANGUAGES: &[&Language] = &[
     &common_lisp(),
     &css(),
     &csv(),
+    &diff(),
     &dockerfile(),
     &elixir(),
+    &gitattributes(),
+    &gitcommit(),
+    &gitconfig(),
+    &gitignore(),
+    &gitrebase(),
     &gleam(),
     &graphql(),
     &hare(),
@@ -130,6 +136,19 @@ const fn csv() -> Language {
     }
 }
 
+const fn diff() -> Language {
+    Language {
+        extensions: &["diff"],
+        tree_sitter_grammar_config: Some(GrammarConfig {
+            id: "diff",
+            url: "https://github.com/the-mikedavis/tree-sitter-diff",
+            commit: "main",
+            subpath: None,
+        }),
+        ..Language::new()
+    }
+}
+
 const fn css() -> Language {
     Language {
         file_names: &[],
@@ -216,6 +235,71 @@ const fn graphql() -> Language {
         lsp_command: Some(LspCommand {
             command: Command("graphql-lsp", &["server", "-m", "stream"]),
             initialization_options: Some(r#"{ "graphql-config.load.legacy": true }"#),
+        }),
+        ..Language::new()
+    }
+}
+
+const fn gitattributes() -> Language {
+    Language {
+        file_names: &[".gitattributes"],
+        tree_sitter_grammar_config: Some(GrammarConfig {
+            id: "gitattributes",
+            url: "https://github.com/tree-sitter-grammars/tree-sitter-gitattributes",
+            commit: "master",
+            subpath: None,
+        }),
+        ..Language::new()
+    }
+}
+
+const fn gitcommit() -> Language {
+    Language {
+        file_names: &["COMMIT_EDITMSG"],
+        tree_sitter_grammar_config: Some(GrammarConfig {
+            id: "gitcommit",
+            url: "https://github.com/gbprod/tree-sitter-gitcommit",
+            commit: "main",
+            subpath: None,
+        }),
+        ..Language::new()
+    }
+}
+
+const fn gitconfig() -> Language {
+    Language {
+        file_names: &[".gitconfig"],
+        tree_sitter_grammar_config: Some(GrammarConfig {
+            id: "git_config",
+            url: "https://github.com/the-mikedavis/tree-sitter-git-config",
+            commit: "main",
+            subpath: None,
+        }),
+        ..Language::new()
+    }
+}
+
+const fn gitignore() -> Language {
+    Language {
+        file_names: &[".gitignore"],
+        tree_sitter_grammar_config: Some(GrammarConfig {
+            id: "gitignore",
+            url: "https://github.com/shunsambongi/tree-sitter-gitignore",
+            commit: "main",
+            subpath: None,
+        }),
+        ..Language::new()
+    }
+}
+
+const fn gitrebase() -> Language {
+    Language {
+        file_names: &["git-rebase-todo"],
+        tree_sitter_grammar_config: Some(GrammarConfig {
+            id: "git_rebase",
+            url: "https://github.com/the-mikedavis/tree-sitter-git-rebase",
+            commit: "main",
+            subpath: None,
         }),
         ..Language::new()
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -2527,18 +2527,17 @@ impl DispatchPrompt {
                 // so that we don't have to do this,
                 // i.e. we can just return the symbol directly,
                 // instead of having to find it again.
-                let dispatches: Dispatches = match symbols
+                if let Some(symbol) = symbols
                     .symbols
                     .iter()
                     .find(|symbol| text == symbol.display())
                 {
-                    Some(symbol) => {
-                        Dispatches::one(Dispatch::GotoLocation(symbol.location.to_owned()))
-                    }
-                    None => Dispatches::new(vec![]),
-                };
-
-                Ok(dispatches)
+                    Ok(Dispatches::new(vec![Dispatch::GotoLocation(
+                        symbol.location.clone(),
+                    )]))
+                } else {
+                    Ok(Dispatches::new(vec![]))
+                }
             }
             DispatchPrompt::RunCommand => Ok(Dispatches::new(
                 [Dispatch::RunCommand(text.to_string())]

--- a/src/app.rs
+++ b/src/app.rs
@@ -1167,7 +1167,13 @@ impl<T: Frontend> App<T> {
     }
 
     fn go_to_location(&mut self, Location { path, range }: &Location) -> Result<(), anyhow::Error> {
-        let component = self.open_file(path, OpenFileOption::Focus)?;
+        let open_path = if *path == "/".try_into()? {
+            self.current_component().borrow().path().unwrap().clone()
+        } else {
+            path.clone()
+        };
+
+        let component = self.open_file(&open_path, OpenFileOption::Focus)?;
         let dispatches = component
             .borrow_mut()
             .editor_mut()

--- a/src/lsp/symbols.rs
+++ b/src/lsp/symbols.rs
@@ -36,7 +36,7 @@ impl TryFrom<lsp_types::SymbolInformation> for Symbol {
 
     fn try_from(value: lsp_types::SymbolInformation) -> Result<Self, Self::Error> {
         let name = value.name;
-        let location: Location = value.location.try_into()?;
+        let location = Location::try_from(value.location)?;
         Ok(Self {
             name,
             kind: value.kind,

--- a/src/lsp/symbols.rs
+++ b/src/lsp/symbols.rs
@@ -19,13 +19,10 @@ fn collect_document_symbols(
 ) -> Result<(), anyhow::Error> {
     symbols.push(document_symbol.clone().try_into()?);
 
-    match document_symbol.clone().children {
-        Some(children) => {
-            for child in children {
-                collect_document_symbols(&child, symbols)?;
-            }
+    if let Some(children) = document_symbol.clone().children {
+        for child in children {
+            collect_document_symbols(&child, symbols)?;
         }
-        None => (),
     };
 
     Ok(())
@@ -73,8 +70,8 @@ impl TryFrom<lsp_types::DocumentSymbol> for Symbol {
 
     fn try_from(value: lsp_types::DocumentSymbol) -> Result<Self, Self::Error> {
         let name = value.name;
-        let start_position = value.range.start.try_into()?;
-        let end_position = value.range.end.try_into()?;
+        let start_position = value.range.start.into();
+        let end_position = value.range.end.into();
         Ok(Self {
             name,
             kind: value.kind,

--- a/src/lsp/symbols.rs
+++ b/src/lsp/symbols.rs
@@ -28,8 +28,15 @@ impl Symbols {
             .iter()
             .flatten()
             .flat_map(|child| {
-                Self::collect_document_symbols(child, Some(document_symbol.name.clone()), path)
-                    .unwrap_or_default()
+                let parent_name = format!(
+                    "{}{}",
+                    parent_name
+                        .as_ref()
+                        .map(|name| format!("{name} ▶ ",))
+                        .unwrap_or_default(),
+                    document_symbol.name.clone()
+                );
+                Self::collect_document_symbols(child, Some(parent_name), path).unwrap_or_default()
             })
             .chain(std::iter::once(root_symbol))
             .collect();

--- a/src/lsp/symbols.rs
+++ b/src/lsp/symbols.rs
@@ -56,7 +56,7 @@ impl Symbols {
 impl Symbol {
     fn try_from_symbol_information(value: lsp_types::SymbolInformation) -> anyhow::Result<Self> {
         let name = value.name;
-        let location = Location::try_from(value.location)?;
+        let location = value.location.try_into()?;
         Ok(Self {
             name,
             kind: value.kind,

--- a/src/lsp/symbols.rs
+++ b/src/lsp/symbols.rs
@@ -49,14 +49,6 @@ impl TryFrom<DocumentSymbolResponse> for Symbols {
             }
         }
 
-        symbols.sort_by(|a, b| {
-            a.file_path
-                .cmp(&b.file_path)
-                .then_with(|| a.range.start.cmp(&b.range.start))
-        });
-
-        log::info!("symbols: {:#?}", symbols);
-
         Ok(Self { symbols })
     }
 }

--- a/src/lsp/symbols.rs
+++ b/src/lsp/symbols.rs
@@ -15,24 +15,17 @@ impl TryFrom<DocumentSymbolResponse> for Symbols {
     type Error = anyhow::Error;
 
     fn try_from(value: DocumentSymbolResponse) -> Result<Self, Self::Error> {
-        match value {
-            DocumentSymbolResponse::Flat(symbols) => {
-                let symbols = symbols
-                    .into_iter()
-                    .map(|symbol| symbol.try_into())
-                    .collect::<Result<Vec<_>, _>>()?;
-
-                Ok(Self { symbols })
-            }
-            DocumentSymbolResponse::Nested(symbols) => {
-                let symbols = symbols
-                    .into_iter()
-                    .map(|symbol| symbol.try_into())
-                    .collect::<Result<Vec<_>, _>>()?;
-
-                Ok(Self { symbols })
-            }
-        }
+        let symbols = match value {
+            DocumentSymbolResponse::Flat(flat_symbols) => flat_symbols
+                .into_iter()
+                .map(|symbol| symbol.try_into())
+                .collect::<Result<Vec<_>, _>>()?,
+            DocumentSymbolResponse::Nested(nested_symbols) => nested_symbols
+                .into_iter()
+                .map(|symbol| symbol.try_into())
+                .collect::<Result<Vec<_>, _>>()?,
+        };
+        Ok(Self { symbols })
     }
 }
 

--- a/src/lsp/symbols.rs
+++ b/src/lsp/symbols.rs
@@ -104,15 +104,11 @@ impl Symbol {
 
 impl From<Symbol> for DropdownItem {
     fn from(symbol: Symbol) -> Self {
+        let dispatches = Dispatches::one(Dispatch::GotoLocation(symbol.location.to_owned()));
         DropdownItem::new(symbol.display())
             .set_group(Some(
-                symbol
-                    .container_name
-                    .clone()
-                    .unwrap_or("[TOP LEVEL]".to_string()),
+                symbol.container_name.unwrap_or("[TOP LEVEL]".to_string()),
             ))
-            .set_dispatches(Dispatches::one(Dispatch::GotoLocation(
-                symbol.location.to_owned(),
-            )))
+            .set_dispatches(dispatches)
     }
 }

--- a/src/lsp/symbols.rs
+++ b/src/lsp/symbols.rs
@@ -21,10 +21,16 @@ impl TryFrom<DocumentSymbolResponse> for Symbols {
                     .into_iter()
                     .map(|symbol| symbol.try_into())
                     .collect::<Result<Vec<_>, _>>()?;
+
                 Ok(Self { symbols })
             }
-            DocumentSymbolResponse::Nested(_nested) => {
-                todo!()
+            DocumentSymbolResponse::Nested(symbols) => {
+                let symbols = symbols
+                    .into_iter()
+                    .map(|symbol| symbol.try_into())
+                    .collect::<Result<Vec<_>, _>>()?;
+
+                Ok(Self { symbols })
             }
         }
     }
@@ -41,6 +47,26 @@ impl TryFrom<lsp_types::SymbolInformation> for Symbol {
             kind: value.kind,
             location,
             container_name: value.container_name,
+        })
+    }
+}
+
+impl TryFrom<lsp_types::DocumentSymbol> for Symbol {
+    type Error = anyhow::Error;
+
+    fn try_from(value: lsp_types::DocumentSymbol) -> Result<Self, Self::Error> {
+        let name = value.name;
+        let start_position = value.range.start.try_into()?;
+        let end_position = value.range.end.try_into()?;
+        let location = Location {
+            path: "/".try_into()?,
+            range: start_position..end_position,
+        };
+        Ok(Self {
+            name,
+            kind: value.kind,
+            location,
+            container_name: None,
         })
     }
 }


### PR DESCRIPTION
Solves #473.

* Add support for parsing `Nested` in addition to `Flat` responses from LSP servers for `Document Symbol`.
* `DocumentSymbol` does not have file path information, therefore:
  * Introduce new `go_to_current_component_range` function
  * Introduce new `GoToCurrentComponentRange` `Dispatch` type. This type only has a range and will use the current component.

