### PR TITLE
feat(theme): configurable via KI_EDITOR_THEME environment variable

### DIFF
--- a/docs/docs/configurations.md
+++ b/docs/docs/configurations.md
@@ -14,10 +14,15 @@ However, I'm open to suggestions, I might even create a new language for that.
 
 ## Files for configurations
 
-| Type      | Path                                 |
-| --------- | ------------------------------------ |
-| Languages | `shared/src/languages.rs`            |
-| Theme     | (Not yet as there is only one theme) |
+| Type      | Path                      |
+| --------- | ------------------------- |
+| Languages | `shared/src/languages.rs` |
+
+## Environment variables for configurations
+
+Until a method of basic configuration is decided upon, the theme for Ki can be configured via the environment variable
+`KI_EDITOR_THEME`. The theme defaults to "VS Code (Light)". You can find a list of known themes by launching `ki` and
+using the Pick Theme option, `SPACE t`.
 
 [^1]: For example, see [dwm](https://wiki.archlinux.org/title/dwm#Configuration) and [Xmonad](https://xmonad.org/TUTORIAL.html)
 [^2]: Neovim usually let's you glide through until it commits kamikaze

--- a/src/themes/mod.rs
+++ b/src/themes/mod.rs
@@ -93,13 +93,14 @@ impl Theme {
 
 impl Default for Theme {
     fn default() -> Self {
-        let theme_name =
-            std::env::var("KI_EDITOR_THEME").unwrap_or_else(|_| "VS Code (Light)".to_string());
+        let desired_theme_name = std::env::var("KI_EDITOR_THEME")
+            .unwrap_or_else(|_| "VS Code (Light)".to_string())
+            .to_lowercase();
         let mut available_themes = themes().unwrap();
         available_themes.sort_by(|a, b| a.name.cmp(&b.name));
         available_themes
             .iter()
-            .find(|theme| theme.name == theme_name)
+            .find(|theme| theme.name.to_lowercase() == desired_theme_name)
             .unwrap_or_else(|| {
                 let theme_names: Vec<String> = available_themes
                     .iter()
@@ -112,7 +113,7 @@ impl Default for Theme {
 
 Available themes are:
 {}",
-                    theme_name, themes_list
+                    desired_theme_name, themes_list
                 );
             })
             .clone()

--- a/src/themes/mod.rs
+++ b/src/themes/mod.rs
@@ -93,7 +93,29 @@ impl Theme {
 
 impl Default for Theme {
     fn default() -> Self {
-        vscode_light().clone()
+        let theme_name =
+            std::env::var("KI_EDITOR_THEME").unwrap_or_else(|_| "VS Code (Light)".to_string());
+        let mut available_themes = themes().unwrap();
+        available_themes.sort_by(|a, b| a.name.cmp(&b.name));
+        available_themes
+            .iter()
+            .find(|theme| theme.name == theme_name)
+            .unwrap_or_else(|| {
+                let theme_names: Vec<String> = available_themes
+                    .iter()
+                    .map(|theme| format!("  * {}", theme.name))
+                    .collect();
+                let themes_list = theme_names.join("\n");
+                panic!(
+                    "
+{} theme was not found. Please update your KI_EDITOR_THEME environment variable.
+
+Available themes are:
+{}",
+                    theme_name, themes_list
+                );
+            })
+            .clone()
     }
 }
 


### PR DESCRIPTION
This is a temporary measure until configuration is brought to Ki.

Ki will default to "VS Code (Light)". If KI_EDITOR_THEME is set, it will be used to find the correct theme. If it is set to an unknown theme, an error will appear along with a list of known themes.