### PR TITLE
feat(keymap/space): add commands to space menu

### DIFF
--- a/src/components/editor_keymap_legend.rs
+++ b/src/components/editor_keymap_legend.rs
@@ -931,21 +931,13 @@ impl Editor {
                     .chain(Some(KeymapLegendSection {
                         title: "File/Quitting".to_string(),
                         keymaps: Keymaps::new(&[
-                            Keymap::new(
-                                "w",
-                                "Write All".to_string(),
-                                Dispatch::RunCommand("write-all".to_string()),
-                            ),
+                            Keymap::new("w", "Write All".to_string(), Dispatch::SaveAll),
                             Keymap::new(
                                 "q",
                                 "Write All and Quit".to_string(),
-                                Dispatch::RunCommand("write-quit-all".to_string()),
+                                Dispatch::SaveQuitAll,
                             ),
-                            Keymap::new(
-                                "Q",
-                                "Quit WITHOUT saving".to_string(),
-                                Dispatch::RunCommand("quit-all".to_string()),
-                            ),
+                            Keymap::new("Q", "Quit WITHOUT saving".to_string(), Dispatch::QuitAll),
                         ]),
                     }))
                     .chain(Some(KeymapLegendSection {

--- a/src/components/editor_keymap_legend.rs
+++ b/src/components/editor_keymap_legend.rs
@@ -926,12 +926,35 @@ impl Editor {
                                 "Tree-sitter node S-expr".to_string(),
                                 Dispatch::ToEditor(DispatchEditor::ShowCurrentTreeSitterNodeSexp),
                             ),
+                        ]),
+                    }))
+                    .chain(Some(KeymapLegendSection {
+                        title: "File/Quitting".to_string(),
+                        keymaps: Keymaps::new(&[
                             Keymap::new(
-                                "?",
-                                "Help".to_string(),
-                                Dispatch::ToEditor(DispatchEditor::ShowKeymapLegendHelp),
+                                "w",
+                                "Write All".to_string(),
+                                Dispatch::RunCommand("write-all".to_string()),
+                            ),
+                            Keymap::new(
+                                "q",
+                                "Write All and Quit".to_string(),
+                                Dispatch::RunCommand("write-quit-all".to_string()),
+                            ),
+                            Keymap::new(
+                                "Q",
+                                "Quit WITHOUT saving".to_string(),
+                                Dispatch::RunCommand("quit-all".to_string()),
                             ),
                         ]),
+                    }))
+                    .chain(Some(KeymapLegendSection {
+                        title: "Help".to_string(),
+                        keymaps: Keymaps::new(&[Keymap::new(
+                            "?",
+                            "Help".to_string(),
+                            Dispatch::ToEditor(DispatchEditor::ShowKeymapLegendHelp),
+                        )]),
                     }))
                     .collect(),
             },


### PR DESCRIPTION
Add Write All, Write Quit All and Quit All commands to the space menu.

Command mode was not touched, it still remains unchanged. This could be the first step in getting away from it. Next step could be to simply unbind the ":" key and third step removing the code, if desired.

resolves #477

