### PR TITLE
feat(keymap): add previous/next buffer navigation

### DIFF
--- a/docs/docs/normal-mode/other-movements.md
+++ b/docs/docs/normal-mode/other-movements.md
@@ -60,3 +60,10 @@ Keybindings:
 
 - `{`: Go to previously opened file
 - `}`: Go to the next opened file
+
+## Go to the previous/next buffer
+
+Keybindings:
+
+- `-`: Go to previous buffer
+- `=`: Go to next buffer

--- a/src/components/editor_keymap_legend.rs
+++ b/src/components/editor_keymap_legend.rs
@@ -124,6 +124,16 @@ impl Editor {
                     Dispatch::GoToPreviousFile,
                 ),
                 Keymap::new("}", "Go to next file".to_string(), Dispatch::GoToNextFile),
+                Keymap::new(
+                    "-",
+                    "Go to previous buffer".to_string(),
+                    Dispatch::CycleBuffer(Direction::Start),
+                ),
+                Keymap::new(
+                    "=",
+                    "Go to next buffer".to_string(),
+                    Dispatch::CycleBuffer(Direction::End),
+                ),
             ]),
         }
     }


### PR DESCRIPTION
Will cycle through currently open file buffers. If you get to the end of the buffer list, it will start over at the beginning. Likewise, if you are at the start of the buffer list and go previous, it will cycle back to the last buffer.

When you close a buffer with `ctrl+c`, it will no longer be part of the buffer navigation.

Currently, this functionality is bound to `-` and `=`. Better keys may be `tab` and `shift+tab` but that has a conflict currently with Go back and Go forward.

This is different than previous/next opened files as that will cycle through files that you opened at some point in time. Closing a file does not remove it from the history stack.