### PR TITLE
feat(cli): make edit the default command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2614,6 +2614,7 @@ name = "shared"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "etcetera",
  "fancy-regex",
  "grammar",
  "isahc",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,6 +6,9 @@ use shared::canonicalized_path::CanonicalizedPath;
 struct Cli {
     #[command(subcommand)]
     command: Option<CommandPlaceholder>,
+
+    #[command(flatten)]
+    edit: EditArgs,
 }
 
 #[derive(Subcommand)]
@@ -124,6 +127,6 @@ pub(crate) fn cli() -> anyhow::Result<()> {
                 ..Default::default()
             }),
         },
-        None => crate::run(Default::default()),
+        None => run_edit_command(cli.edit),
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,7 +6,6 @@ use shared::canonicalized_path::CanonicalizedPath;
 struct Cli {
     #[command(subcommand)]
     command: Option<CommandPlaceholder>,
-    edit: EditArgs,
 }
 
 #[derive(Subcommand)]
@@ -41,7 +40,7 @@ enum Commands {
     In(InArgs),
 }
 
-#[derive(Args, Default)]
+#[derive(Args, Default, Clone)]
 struct EditArgs {
     path: Option<String>,
 }
@@ -95,7 +94,7 @@ pub(crate) fn cli() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Some(CommandPlaceholder::Edit(_)) => run_edit_command(cli.edit),
+        Some(CommandPlaceholder::Edit(args)) => run_edit_command(args),
         Some(CommandPlaceholder::At { command }) => match command {
             Commands::Grammar { command } => {
                 match command {


### PR DESCRIPTION
See #484.

This PR hides the "edit" command and makes it default.

Examples are given at the root of the ki-language git repo.

* `ki` -- opens [ROOT] window as it always has
* `ki readme.md` -- opens `readme.md`
* `ki src` -- opens the File Explorer for the `src` directory
* `ki log` -- opens a new file named `log`
* `ki @ log` -- prints log path and exits
* `ki @ grammar` -- shows grammar help and exits
* `ki @ grammar build` -- builds grammar and exits

New help output from `ki --help`:

```
Usage: ki [PATH] [COMMAND]

Commands:
  @     Run commands
  help  Print this message or the help of the given subcommand(s)

Arguments:
  [PATH]

Options:
  -h, --help     Print help
  -V, --version  Print version
```

Output of `ki @ --help`

```
Run commands

Usage: ki @ <COMMAND>

Commands:
  grammar          Build and fetch tree-sitter grammar files
  highlight-query  Manage cached tree-sitter highlight files
  log              Prints the log file path
  in               Run Ki in the given path, treating the path as the working directory
  help             Print this message or the help of the given subcommand(s)

Options:
  -h, --help  Print help
```