### PR TITLE
feat(explorer): add copy file to space menu for explorer

### DIFF
--- a/docs/docs/normal-mode/space-menu.md
+++ b/docs/docs/normal-mode/space-menu.md
@@ -26,6 +26,7 @@ Contextual actions are actions that are only applicable within a specific contex
 | Keybinding | Action                                                           |
 | ---------- | ---------------------------------------------------------------- |
 | `a`        | Add a new file/folder under the current path [^1]                |
+| `c`        | Copy current file to a new file                                  |
 | `d`        | Delete current file/folder                                       |
 | `m`        | Move (or rename) the current file/folder [^2]                    |
 | `r`        | Refresh the [file explorer](../components/file-explorer.md) [^3] |

--- a/docs/docs/normal-mode/space-menu.md
+++ b/docs/docs/normal-mode/space-menu.md
@@ -26,7 +26,7 @@ Contextual actions are actions that are only applicable within a specific contex
 | Keybinding | Action                                                           |
 | ---------- | ---------------------------------------------------------------- |
 | `a`        | Add a new file/folder under the current path [^1]                |
-| `c`        | Copy current file to a new file                                  |
+| `c`        | Copy current file to a new path                                  |
 | `d`        | Delete current file/folder                                       |
 | `m`        | Move (or rename) the current file/folder [^2]                    |
 | `r`        | Refresh the [file explorer](../components/file-explorer.md) [^3] |

--- a/src/app.rs
+++ b/src/app.rs
@@ -1380,6 +1380,7 @@ impl<T: Frontend> App<T> {
         self.layout.remove_suggestive_editor(&from);
         Ok(())
     }
+
     fn add_path_parent(&self, path: &Path) -> anyhow::Result<()> {
         if let Some(new_dir) = path.parent() {
             std::fs::create_dir_all(new_dir)?;
@@ -1399,8 +1400,12 @@ impl<T: Frontend> App<T> {
             std::fs::File::create(&path)?;
         }
         self.layout.refresh_file_explorer(&self.working_directory)?;
-        self.reveal_path_in_explorer(&path.try_into()?)?;
-
+        let path: CanonicalizedPath = path.try_into()?;
+        self.reveal_path_in_explorer(&path)?;
+        self.lsp_manager.send_message(
+            path.clone(),
+            FromEditor::WorkspaceDidCreateFiles { file_path: path },
+        )?;
         Ok(())
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1373,13 +1373,10 @@ impl<T: Frontend> App<T> {
         self.layout.refresh_file_explorer(&self.working_directory)?;
         let to = to.try_into()?;
         self.reveal_path_in_explorer(&to)?;
-        // self.lsp_manager.send_message(
-        // from.clone(),
-        // FromEditor::WorkspaceDidRenameFiles {
-        // old: from.clone(),
-        // new: to,
-        // },
-        // )?;
+        self.lsp_manager.send_message(
+            from.clone(),
+            FromEditor::WorkspaceDidCreateFiles { file_path: to },
+        )?;
         self.layout.remove_suggestive_editor(&from);
         Ok(())
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -869,7 +869,7 @@ impl<T: Frontend> App<T> {
     fn open_copy_file_prompt(&mut self, path: CanonicalizedPath) -> anyhow::Result<()> {
         self.open_prompt(
             PromptConfig {
-                title: "Copy path".to_string(),
+                title: "Copy current file to a new path".to_string(),
                 on_enter: DispatchPrompt::CopyFile { from: path.clone() },
                 items: Vec::new(),
                 enter_selects_first_matching_item: false,

--- a/src/components/file_explorer.rs
+++ b/src/components/file_explorer.rs
@@ -338,6 +338,11 @@ impl Component for FileExplorer {
                         Dispatch::OpenAddPathPrompt(node.path.clone()),
                     ),
                     Keymap::new(
+                        "c",
+                        "Copy file".to_string(),
+                        Dispatch::OpenCopyFilePrompt(node.path.clone()),
+                    ),
+                    Keymap::new(
                         "d",
                         "Delete path".to_string(),
                         Dispatch::OpenYesNoPrompt(YesNoPrompt {

--- a/src/components/prompt.rs
+++ b/src/components/prompt.rs
@@ -46,6 +46,7 @@ pub(crate) enum PromptHistoryKey {
     Rename,
     AddPath,
     MovePath,
+    CopyFile,
     Symbol,
     OpenFile,
     FilterGlob(GlobalSearchFilterGlob),


### PR DESCRIPTION
Copy a single file from one location to another location.

* Added to explorer space context menu
* Added documentation
* Added notification to the LSP server that a new file was created