### PR TITLE
feat(lsp): symbol ranking

### DIFF
--- a/src/lsp/symbols.rs
+++ b/src/lsp/symbols.rs
@@ -124,6 +124,10 @@ impl From<Symbol> for DropdownItem {
             .set_group(Some(
                 symbol.container_name.unwrap_or("[TOP LEVEL]".to_string()),
             ))
+            .set_rank(Some(Box::new([
+                symbol.location.range.start.line,
+                symbol.location.range.start.column,
+            ])))
             .set_dispatches(dispatches)
     }
 }


### PR DESCRIPTION
This allows the symbols to order based on location in the source file not based on the string length, disregarding any positional meta data.