### PR TITLE
feat(editor): dirty detection for saving

### DIFF
--- a/docs/docs/normal-mode/space-menu.md
+++ b/docs/docs/normal-mode/space-menu.md
@@ -3,6 +3,7 @@
 The space menu is a handy shortcut for (not restricted to):
 
 - Contextual actions
+- File and quit actions
 - Searching files/symbols
 - Multi-cursor management
 - Opening other components
@@ -12,6 +13,15 @@ The space menu can be brought up by pressing `space`.
 ## Contextual actions
 
 Contextual actions are actions that are only applicable within a specific context.
+
+## File and quit actions
+
+| Keybinding | Action                                           |
+| ---------- | ------------------------------------------------ |
+| `space`    | Write current file, even if no changes were made |
+| `w`        | Write all files                                  |
+| `q`        | Write all files and quit                         |
+| `Q`        | Quit _without_ writing files                     |
 
 ### LSP Actions (only applicable in the main editor):
 

--- a/docs/docs/normal-mode/space-menu.md
+++ b/docs/docs/normal-mode/space-menu.md
@@ -21,7 +21,7 @@ Contextual actions are actions that are only applicable within a specific contex
 | `space`    | Write current file, even if no changes were made |
 | `w`        | Write all files                                  |
 | `q`        | Write all files and quit                         |
-| `Q`        | Quit _without_ writing files                     |
+| `Q`        | Quit _without_ writing unsaved files             |
 
 ### LSP Actions (only applicable in the main editor):
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -748,7 +748,6 @@ impl Buffer {
     }
 
     /// Has the buffer changed since its last save?
-    #[cfg(test)]
     pub(crate) fn dirty(&self) -> bool {
         self.dirty
     }

--- a/src/components/editor.rs
+++ b/src/components/editor.rs
@@ -498,7 +498,7 @@ pub(crate) enum Movement {
 
 impl Editor {
     /// Returns if the editor is currently dirty or not.
-    #[test]
+    #[cfg(test)]
     pub(crate) fn dirty(&self) -> bool {
         self.dirty
     }

--- a/src/components/editor.rs
+++ b/src/components/editor.rs
@@ -87,7 +87,8 @@ impl Component for Editor {
                     .display_relative_to(current_working_directory)
                     .unwrap_or_else(|_| path.display_absolute());
                 let icon = path.icon();
-                Some(format!(" {} {}", icon, string))
+                let dirty = if self.buffer().dirty() { " [*]" } else { "" };
+                Some(format!(" {} {}{}", icon, string, dirty))
             })
             .unwrap_or_else(|| "[No title]".to_string())
     }

--- a/src/components/editor.rs
+++ b/src/components/editor.rs
@@ -498,6 +498,7 @@ pub(crate) enum Movement {
 
 impl Editor {
     /// Returns if the editor is currently dirty or not.
+    #[test]
     pub(crate) fn dirty(&self) -> bool {
         self.dirty
     }

--- a/src/components/editor.rs
+++ b/src/components/editor.rs
@@ -2163,26 +2163,19 @@ impl Editor {
     }
 
     fn do_save(&mut self, force: bool) -> anyhow::Result<Dispatches> {
-        let document_did_save_dispatch = if true {
-            let Some(path) = self
-                .buffer
-                .borrow_mut()
-                .save(self.selection_set.clone(), force)?
-            else {
-                return Ok(Default::default());
-            };
-
-            Some(Dispatch::DocumentDidSave { path })
-        } else {
-            None
+        let Some(path) = self
+            .buffer
+            .borrow_mut()
+            .save(self.selection_set.clone(), force)?
+        else {
+            return Ok(Default::default());
         };
 
         self.clamp()?;
         self.cursor_keep_primary_only();
         self.enter_normal_mode()?;
-
         Ok(Dispatches::one(Dispatch::RemainOnlyCurrentComponent)
-            .append_some(document_did_save_dispatch)
+            .append(Dispatch::DocumentDidSave { path })
             .chain(self.get_document_did_change_dispatch())
             .append(Dispatch::RemainOnlyCurrentComponent)
             .append_some(if self.selection_set.mode.is_contiguous() {

--- a/src/components/editor_keymap_legend.rs
+++ b/src/components/editor_keymap_legend.rs
@@ -936,6 +936,11 @@ impl Editor {
                     .chain(Some(KeymapLegendSection {
                         title: "File/Quitting".to_string(),
                         keymaps: Keymaps::new(&[
+                            Keymap::new(
+                                "enter",
+                                "Force Write".to_string(),
+                                Dispatch::ToEditor(DispatchEditor::ForceSave),
+                            ),
                             Keymap::new("w", "Write All".to_string(), Dispatch::SaveAll),
                             Keymap::new(
                                 "q",

--- a/src/components/test_editor.rs
+++ b/src/components/test_editor.rs
@@ -1182,7 +1182,7 @@ fn scroll_offset() -> anyhow::Result<()> {
                 height: 3,
             })),
             Editor(SetScrollOffset(2)),
-            Expect(EditorGrid("🦀  src/main.rs\n3│█amma\n4│lok")),
+            Expect(EditorGrid("🦀  src/main.rs [*]\n3│█amma\n4│lok")),
         ])
     })
 }
@@ -1250,7 +1250,7 @@ fn main() {
             // The "long" of "too long" is not shown, because it exceeded the view width
             Expect(EditorGrid(
                 "
-🦀  src/main.rs
+🦀  src/main.rs [*]
 1│fn main() {
 3│  █eta()
 4│}
@@ -1397,7 +1397,7 @@ fn main() {
             // because it is amongst the parent lines of the current selection
             Expect(EditorGrid(
                 "
-🦀  src/main.rs
+🦀  src/main.rs [*]
 2│fn main() {
 4│  let y = 2; //
 ↪│too long, wrapped
@@ -1449,7 +1449,7 @@ fn main() {
             Editor(SetScrollOffset(3)),
             Expect(EditorGrid(
                 "
-🦀  src/main.rs
+🦀  src/main.rs [*]
 2│fn main() {
 4│  let y = 2; //
 ↪│too long, wrapped
@@ -1683,7 +1683,7 @@ fn main() { // too long
             // The "long" of "too long" is not shown, because it exceeded the view width
             Expect(EditorGrid(
                 "
-🦀  src/main.rs
+🦀  src/main.rs [*]
 1│fn main() { // too
 3│  let █ar = baba;
 ↪│let wrapped = coco
@@ -1743,7 +1743,7 @@ fn main() { // too long
             Editor(MatchLiteral("let".to_string())),
             Expect(EditorGrid(
                 "
-🦀  src/main.rs
+🦀  src/main.rs [*]
 1│fn main() { // too
 ↪│ long
 2│  █et foo = 1;
@@ -1773,7 +1773,7 @@ fn empty_content_should_have_one_line() -> anyhow::Result<()> {
             })),
             Expect(EditorGrid(
                 "
-🦀  src/main.rs
+🦀  src/main.rs [*]
 1│█
 "
                 .trim(),
@@ -1886,7 +1886,7 @@ fn consider_unicode_width() -> anyhow::Result<()> {
             // Expect the cursor is on the letter 'a'
             // Expect an extra space is added between 'a' and the emoji
             // because, the unicode width of the emoji is 2
-            Expect(EditorGrid("🦀  src/main.rs\n1│👩  █bc\n\n\n\n\n\n\n")),
+            Expect(EditorGrid("🦀  src/main.rs [*]\n1│👩  █bc\n\n\n\n\n\n\n")),
         ])
     })
 }
@@ -1985,9 +1985,11 @@ fn modifying_editor_causes_dirty_state() -> anyhow::Result<()> {
         Box::new([
             App(OpenFile(s.main_rs())),
             Expect(Not(Box::new(EditorIsDirty()))),
+            Expect(CurrentComponentTitle(" 🦀 src/main.rs")),
             Editor(EnterInsertMode(Direction::Start)),
             App(HandleKeyEvents(keys!("a a esc").to_vec())),
             Expect(EditorIsDirty()),
+            Expect(CurrentComponentTitle(" 🦀 src/main.rs [*]")),
         ])
     })
 }
@@ -2001,8 +2003,10 @@ fn saving_editor_clears_dirty_state() -> anyhow::Result<()> {
             Editor(EnterInsertMode(Direction::Start)),
             App(HandleKeyEvents(keys!("a a esc").to_vec())),
             Expect(EditorIsDirty()),
+            Expect(CurrentComponentTitle(" 🦀 src/main.rs [*]")),
             Editor(Save),
             Expect(Not(Box::new(EditorIsDirty()))),
+            Expect(CurrentComponentTitle(" 🦀 src/main.rs")),
         ])
     })
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -64,11 +64,9 @@ pub(crate) struct Search {
 
 impl Default for Context {
     fn default() -> Self {
-        use crate::themes::vscode_light;
-
         Self {
             clipboard: Clipboard::new(),
-            theme: vscode_light(),
+            theme: Theme::default(),
             mode: None,
             #[cfg(test)]
             highlight_configs: crate::syntax_highlight::HighlightConfigs::new(),
@@ -87,7 +85,6 @@ impl Context {
     pub(crate) fn new(current_working_directory: CanonicalizedPath) -> Self {
         Self {
             current_working_directory,
-            theme: Theme::default(),
             ..Self::default()
         }
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -64,9 +64,11 @@ pub(crate) struct Search {
 
 impl Default for Context {
     fn default() -> Self {
+        use crate::themes::vscode_light;
+
         Self {
             clipboard: Clipboard::new(),
-            theme: Theme::default(),
+            theme: vscode_light(),
             mode: None,
             #[cfg(test)]
             highlight_configs: crate::syntax_highlight::HighlightConfigs::new(),
@@ -85,6 +87,7 @@ impl Context {
     pub(crate) fn new(current_working_directory: CanonicalizedPath) -> Self {
         Self {
             current_working_directory,
+            theme: Theme::default(),
             ..Self::default()
         }
     }

--- a/src/list/grep.rs
+++ b/src/list/grep.rs
@@ -44,7 +44,7 @@ pub(crate) fn replace(
             let mut buffer = Buffer::from_path(&path, local_search_config.require_tree_sitter())?;
             let (modified, _) = buffer.replace(local_search_config.clone(), Default::default())?;
             if modified {
-                buffer.save_without_formatting()?;
+                buffer.save_without_formatting(false)?;
                 sender
                     .send(path)
                     .map_err(|err| log::info!("Error = {:?}", err))

--- a/src/test_app.rs
+++ b/src/test_app.rs
@@ -971,7 +971,7 @@ fn first () {
             Editor(AlignViewTop),
             Expect(AppGrid(
                 "
- 🦀  src/main.rs
+ 🦀  src/main.rs [*]
 1│fn first () {
 5│  █ifth();
 6│}
@@ -983,7 +983,7 @@ fn first () {
             Editor(AlignViewBottom),
             Expect(AppGrid(
                 "
- 🦀  src/main.rs
+ 🦀  src/main.rs [*]
 1│fn first () {
 3│  third();
 4│  fourth(); // this line is long
@@ -1000,7 +1000,7 @@ fn first () {
             Editor(AlignViewBottom),
             Expect(AppGrid(
                 "
- 🦀  src/main.rs
+ 🦀  src/main.rs [*]
 1│fn first () {
 4│  fourth(); //
 ↪│this line is long

--- a/src/test_app.rs
+++ b/src/test_app.rs
@@ -80,6 +80,7 @@ pub(crate) enum ExpectKind {
     CurrentComponentContent(&'static str),
     EditorCursorPosition(Position),
     EditorGridCursorPosition(Position),
+    EditorIsDirty(),
     CurrentMode(Mode),
     FileContent(CanonicalizedPath, String),
     FileContentEqual(CanonicalizedPath, CanonicalizedPath),
@@ -187,6 +188,7 @@ impl ExpectKind {
                 let (result, context) = expect_kind.get_result(app)?;
                 (!result, format!("NOT ({context})"))
             }
+            EditorIsDirty() => contextualize(&component.borrow().editor().dirty(), &true),
             CurrentMode(mode) => contextualize(&component.borrow().editor().mode, mode),
             EditorCursorPosition(position) => contextualize(
                 &component.borrow().editor().get_cursor_position().unwrap(),

--- a/src/test_app.rs
+++ b/src/test_app.rs
@@ -188,7 +188,7 @@ impl ExpectKind {
                 let (result, context) = expect_kind.get_result(app)?;
                 (!result, format!("NOT ({context})"))
             }
-            EditorIsDirty() => contextualize(&component.borrow().editor().dirty(), &true),
+            EditorIsDirty() => contextualize(&component.borrow().editor().buffer().dirty(), &true),
             CurrentMode(mode) => contextualize(&component.borrow().editor().mode, mode),
             EditorCursorPosition(position) => contextualize(
                 &component.borrow().editor().get_cursor_position().unwrap(),


### PR DESCRIPTION
Currently when you press `enter` or exit the editor with `space q`, the file is saved always. This has a few undesired side effects:

1. If the file has LSP attached, it is notified the file has changed and work is done for no reason.
2. If the file has a formatter, it is called in an attempt to format the code. Again, work done for no reason.
3. If the file changes external to the editor, your external changes are blindly overwritten with the content in your buffer which you made no changes to.

If you have a long editing session, with many open files and a slow formatter, even quitting the editor can take a considerable time. If no changes are made, exiting is instant.

With this change, save is only attempted if the editor has been changed since it was read or last saved.