### PR TITLE
feat: differentiate between user and system buffers

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -985,9 +985,14 @@ impl<T: Frontend> App<T> {
             return Ok(matching_editor);
         }
 
-        let buffer = Buffer::from_path(path, true)?;
+        let mut buffer = Buffer::from_path(path, true)?;
         let language = buffer.language();
         let content = buffer.content();
+
+        if option == OpenFileOption::Background {
+            buffer.set_user(false);
+        }
+
         let buffer = Rc::new(RefCell::new(buffer));
         let editor = SuggestiveEditor::from_buffer(buffer, SuggestiveEditorFilter::CurrentWord);
         let component_id = editor.id();

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -40,6 +40,7 @@ pub(crate) struct Buffer {
     decorations: Vec<Decoration>,
     selection_set_history: History<SelectionSet>,
     dirty: bool,
+    user: bool,
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
@@ -74,7 +75,20 @@ impl Buffer {
             quickfix_list_items: Vec::new(),
             selection_set_history: History::new(),
             dirty: false,
+            user: true,
         }
+    }
+
+    pub(crate) fn set_user(&mut self, user: bool) {
+        self.user = user;
+    }
+
+    /// Was this buffer requested directly by the user for editing?
+    ///
+    /// Scenarios where it was not, but opened anyway include Global Search, LSP
+    /// diagnostic tracking.
+    pub(crate) fn user(&self) -> bool {
+        self.user
     }
 
     pub(crate) fn clear_quickfix_list_items(&mut self) {
@@ -660,6 +674,7 @@ impl Buffer {
         if let Some(path) = &self.path {
             path.write(&self.content())?;
             self.dirty = false;
+            self.user = true;
             Ok(Some(path.clone()))
         } else {
             log::info!("Buffer has no path");

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -219,6 +219,7 @@ impl Layout {
     pub(crate) fn get_opened_files(&self) -> Vec<CanonicalizedPath> {
         self.background_suggestive_editors
             .iter()
+            .filter(|(_, editor)| editor.borrow().editor().buffer().user())
             .map(|(path, _)| path.clone())
             .collect()
     }


### PR DESCRIPTION
# The Problem

Currently a user can open a file and it appears in the buffer list as well as cycling through opened buffers. The system, however, can also open files that the user did not request. For example, the LSP server sends notifications can causes files to be opened and tracked for diagnostic reasons.

This causes confusion and makes it more difficult for a user to switch between files in the editor. When they open file A and file B; then try to cycle through buffers or switch buffers using `space b` and the system shows file A, file C, file D, file X, file Y, and file B. Not at all what they were expecting.

Further, when searching, you may enter a search term and it find results in 20 files. Immediately, those files are opened and added to the buffer list. So, a user may be working on file A, search for some reference material and then go back to editing file A. Later they open file B. Now, when going back to file A, those 20 files that were previously found via search (and maybe never even visited) are in the buffer list and cycle buffer.

# The Solution

This PR adds a `user` boolean value to the buffer. If the user opened the file, its `user` flag is set to `true`. If the system opens it, for searching, LSP diagnostics or something else, the `user` flag is set to `false`.

The Buffer Picker and Cycle Buffer only presents user opened files.

A system opened file can be converted into a user file if the user makes a change to a file and saves it. For example, via search `file_b.txt` is shown and the user edits that file and saves. `file_b.txt` now becomes a user file and is presented in the Buffer Picker and Cycle Buffer action.