### PR TITLE
feat: quick editor jumping

### DIFF
--- a/docs/docs/normal-mode/other-movements.md
+++ b/docs/docs/normal-mode/other-movements.md
@@ -67,3 +67,34 @@ Keybindings:
 
 - `-`: Go to previous buffer
 - `=`: Go to next buffer
+
+## Quick Editor Jumping
+
+You can "tag" editors with the numbers 1 through 5 for quick access during your
+editing session. This feature allows you to efficiently manage and switch
+between your primary files and other ancillary files. Here's how it works:
+
+### Number Key Actions
+
+#### Tagging an Editor
+
+If no editors are currently tagged with the number you press, the current editor will be tagged with that number.
+
+#### Clearing a Tag
+
+If the current editor is already tagged with the number you press, the tag will be cleared from that editor.
+
+#### Jumping to a Tagged Editor
+
+If there is an editor tagged with the number you press, the editor will switch to that tagged editor immediately.
+
+### Workflow Overview
+
+This workflow is designed to streamline your editing process by allowing quick
+access to your primary files. During an editing session, you often work on
+primary files while occasionally referring to other less important files. Using
+the number keys, you can quickly jump back to your main files, enhancing your
+productivity and focus.
+
+By utilizing this tagging system, you can efficiently navigate your editing
+environment and maintain your workflow's momentum.

--- a/src/app.rs
+++ b/src/app.rs
@@ -1880,23 +1880,23 @@ impl<T: Frontend> App<T> {
     }
 
     fn handle_jump_editor(&mut self, tag: char) -> anyhow::Result<()> {
-        let editor_with_tag = self.layout.find_editor_tagged(tag);
+        let tag_to_set = if let Some(editor_with_tag) = self.layout.find_editor_tagged(tag) {
+            let current_path = self.current_component().borrow().path();
+            if Some(editor_with_tag.clone()) == current_path {
+                None
+            } else {
+                self.open_file(&editor_with_tag, OpenFileOption::Focus)?;
 
-        // 1. If this editor has this tag, clear it.
-        if editor_with_tag == self.current_component().borrow().path() {
-            self.layout.clear_editors_tagged(tag);
-        }
-        // 2. If any editor has this tag, jump to it.
-        else if let Some(path) = editor_with_tag {
-            self.open_file(&path, OpenFileOption::Focus)?;
-        }
-        // 3. Assign this tag to this editor.
-        else {
-            self.current_component()
-                .borrow_mut()
-                .editor_mut()
-                .set_tag(Some(tag));
-        }
+                return Ok(());
+            }
+        } else {
+            Some(tag)
+        };
+
+        self.current_component()
+            .borrow_mut()
+            .editor_mut()
+            .set_tag(tag_to_set);
 
         Ok(())
     }

--- a/src/components/editor.rs
+++ b/src/components/editor.rs
@@ -394,7 +394,6 @@ pub(crate) struct Editor {
     id: ComponentId,
     pub(crate) current_view_alignment: Option<ViewAlignment>,
     copied_text_history_offset: Counter,
-    /// Human assigned tag for quick editor jumping
     tag: Option<char>,
 }
 
@@ -1446,11 +1445,6 @@ impl Editor {
     pub(crate) fn set_tag(&mut self, tag: Option<char>) {
         self.tag = tag;
         self.mode = Mode::Normal;
-    }
-
-    /// Clear any tag assigned to this editor.
-    pub(crate) fn clear_tag(&mut self) {
-        self.tag = None
     }
 
     pub(crate) fn path(&self) -> Option<CanonicalizedPath> {

--- a/src/components/editor.rs
+++ b/src/components/editor.rs
@@ -217,7 +217,6 @@ impl Component for Editor {
             #[cfg(test)]
             MatchLiteral(literal) => return self.match_literal(&literal),
             ToggleMark => self.toggle_marks(),
-            SetTag(tag) => self.set_tag(tag),
             EnterNormalMode => self.enter_normal_mode()?,
             CursorAddToAllSelections => self.add_cursor_to_all_selections()?,
             CursorKeepPrimaryOnly => self.cursor_keep_primary_only(),
@@ -3308,7 +3307,6 @@ pub(crate) enum DispatchEditor {
     },
     Open(Direction),
     ToggleMark,
-    SetTag(Option<char>),
     EnterNormalMode,
     EnterExchangeMode,
     EnterReplaceMode,

--- a/src/components/editor.rs
+++ b/src/components/editor.rs
@@ -89,7 +89,7 @@ impl Component for Editor {
                 let icon = path.icon();
                 let dirty = if self.buffer().dirty() { " [*]" } else { "" };
                 let tag = if let Some(tag) = self.tag {
-                    format!(" <{}>", tag)
+                    format!(" #{}", tag)
                 } else {
                     "".to_string()
                 };
@@ -1444,7 +1444,7 @@ impl Editor {
     }
 
     /// Assign a tag to this editor.
-    fn set_tag(&mut self, tag: Option<char>) {
+    pub(crate) fn set_tag(&mut self, tag: Option<char>) {
         self.tag = tag;
         self.mode = Mode::Normal;
     }

--- a/src/components/editor.rs
+++ b/src/components/editor.rs
@@ -88,11 +88,10 @@ impl Component for Editor {
                     .unwrap_or_else(|_| path.display_absolute());
                 let icon = path.icon();
                 let dirty = if self.buffer().dirty() { " [*]" } else { "" };
-                let tag = if let Some(tag) = self.tag {
-                    format!(" #{}", tag)
-                } else {
-                    "".to_string()
-                };
+                let tag = self
+                    .tag
+                    .map_or_else(String::new, |tag| format!(" #{}", tag));
+
                 Some(format!(" {} {}{}{}", icon, string, tag, dirty))
             })
             .unwrap_or_else(|| "[No title]".to_string())

--- a/src/components/editor.rs
+++ b/src/components/editor.rs
@@ -1436,12 +1436,10 @@ impl Editor {
         self.buffer_mut().save_marks(selections.into())
     }
 
-    /// Retrieve the tag assigned, if any, to this editor.
     pub(crate) fn tag(&self) -> Option<char> {
         self.tag
     }
 
-    /// Assign a tag to this editor.
     pub(crate) fn set_tag(&mut self, tag: Option<char>) {
         self.tag = tag;
         self.mode = Mode::Normal;

--- a/src/components/editor_keymap_legend.rs
+++ b/src/components/editor_keymap_legend.rs
@@ -134,6 +134,31 @@ impl Editor {
                     "Go to next buffer".to_string(),
                     Dispatch::CycleBuffer(Direction::End),
                 ),
+                Keymap::new(
+                    "1",
+                    "Quick Jump - #1".to_string(),
+                    Dispatch::JumpEditor('1'),
+                ),
+                Keymap::new(
+                    "2",
+                    "Quick Jump - #2".to_string(),
+                    Dispatch::JumpEditor('2'),
+                ),
+                Keymap::new(
+                    "3",
+                    "Quick Jump - #3".to_string(),
+                    Dispatch::JumpEditor('3'),
+                ),
+                Keymap::new(
+                    "4",
+                    "Quick Jump - #4".to_string(),
+                    Dispatch::JumpEditor('4'),
+                ),
+                Keymap::new(
+                    "5",
+                    "Quick Jump - #5".to_string(),
+                    Dispatch::JumpEditor('5'),
+                ),
             ]),
         }
     }

--- a/src/components/test_editor.rs
+++ b/src/components/test_editor.rs
@@ -3249,3 +3249,35 @@ fn visual_select_anchor_change_selection_mode() -> anyhow::Result<()> {
         ])
     })
 }
+
+#[test]
+fn toggle_editor_tag() -> anyhow::Result<()> {
+    execute_test(|s| {
+        Box::new([
+            App(OpenFile(s.main_rs())),
+            Expect(CurrentComponentTitle(" 🦀 src/main.rs")),
+            App(HandleKeyEvent(key!("1"))),
+            Expect(CurrentComponentTitle(" 🦀 src/main.rs #1")),
+            App(HandleKeyEvent(key!("1"))),
+            Expect(CurrentComponentTitle(" 🦀 src/main.rs")),
+        ])
+    })
+}
+
+#[test]
+fn jump_editor_tag() -> anyhow::Result<()> {
+    execute_test(|s| {
+        Box::new([
+            App(OpenFile(s.main_rs())),
+            App(HandleKeyEvent(key!("1"))),
+            Expect(CurrentComponentTitle(" 🦀 src/main.rs #1")),
+            App(OpenFile(s.foo_rs())),
+            App(HandleKeyEvent(key!("2"))),
+            Expect(CurrentComponentTitle(" 🦀 src/foo.rs #2")),
+            App(HandleKeyEvent(key!("1"))),
+            Expect(CurrentComponentTitle(" 🦀 src/main.rs #1")),
+            App(HandleKeyEvent(key!("2"))),
+            Expect(CurrentComponentTitle(" 🦀 src/foo.rs #2")),
+        ])
+    })
+}

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -310,19 +310,6 @@ impl Layout {
         Ok(())
     }
 
-    pub(crate) fn clear_editors_tagged(&mut self, tag_char: char) {
-        self.background_suggestive_editors
-            .iter()
-            .for_each(|(_, editor)| {
-                let mut borrowed = editor.borrow_mut();
-                let editor = borrowed.editor_mut();
-
-                if editor.tag() == Some(tag_char) {
-                    editor.clear_tag();
-                }
-            })
-    }
-
     pub(crate) fn find_editor_tagged(&self, tag_char: char) -> Option<CanonicalizedPath> {
         self.background_suggestive_editors
             .iter()

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -310,6 +310,34 @@ impl Layout {
         Ok(())
     }
 
+    pub(crate) fn clear_editors_tagged(&mut self, tag_char: char) {
+        self.background_suggestive_editors
+            .iter()
+            .for_each(|(_, editor)| {
+                let mut borrowed = editor.borrow_mut();
+                let editor = borrowed.editor_mut();
+
+                if editor.tag() == Some(tag_char) {
+                    editor.clear_tag();
+                }
+            })
+    }
+
+    pub(crate) fn find_editor_tagged(&self, tag_char: char) -> Option<CanonicalizedPath> {
+        self.background_suggestive_editors
+            .iter()
+            .find_map(|(_, editor)| {
+                let borrowed = editor.borrow();
+                let editor = borrowed.editor();
+
+                if editor.tag() == Some(tag_char) {
+                    editor.path().clone()
+                } else {
+                    None
+                }
+            })
+    }
+
     #[cfg(test)]
     pub(crate) fn completion_dropdown_is_open(&self) -> bool {
         self.current_completion_dropdown().is_some()

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -314,9 +314,8 @@ impl Layout {
         self.background_suggestive_editors
             .iter()
             .find_map(|(_, editor)| {
-                let borrowed = editor.borrow();
-                let editor = borrowed.editor();
-
+                let suggestive_editor = editor.borrow();
+                let editor = suggestive_editor.editor();
                 if editor.tag() == Some(tag_char) {
                     editor.path().clone()
                 } else {

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -313,14 +313,9 @@ impl Layout {
     pub(crate) fn find_editor_tagged(&self, tag_char: char) -> Option<CanonicalizedPath> {
         self.background_suggestive_editors
             .iter()
-            .find_map(|(_, editor)| {
-                let suggestive_editor = editor.borrow();
-                let editor = suggestive_editor.editor();
-                if editor.tag() == Some(tag_char) {
-                    editor.path().clone()
-                } else {
-                    None
-                }
+            .find_map(|(path, editor)| {
+                let editor_tag = editor.borrow().editor().tag();
+                (editor_tag == Some(tag_char)).then_some(path.clone())
             })
     }
 


### PR DESCRIPTION
The numbers 1-5 can be used to "tag" an editor with that number. When pressing the number:

1. If no editors are tagged with the number pressed, the current editor will be tagged with that number.
2. If the current editor is already tagged with the number pressed, the tag will be cleared.
3. If another editor is tagged with the number pressed, you will jump to that editor.

This provides a very quick and efficient way of managing the most important files to you for your given editing session. The idea was built from other editor's plugins such as Harpoon, Reach and Lasso for Neovim.