### PR TITLE
feat(language): if other methods fail, detect language from first line

### DIFF
--- a/shared/src/language.rs
+++ b/shared/src/language.rs
@@ -207,7 +207,7 @@ use regex::Regex;
 /// - `# mode: bash
 ///
 /// Spaces and other content on the line do not matter.
-pub fn from_content(content: &str) -> Option<Language> {
+pub fn from_content_directive(content: &str) -> Option<Language> {
     let first_line = content.lines().next()?;
 
     let re = Regex::new(r"(?:(?:^#!.*/)|(?:mode:)|(?:ft\s*=))\s*(\w+)").unwrap();

--- a/shared/src/language.rs
+++ b/shared/src/language.rs
@@ -192,6 +192,41 @@ pub(crate) fn from_filename(path: &CanonicalizedPath) -> Option<Language> {
         .map(|language| (*language).clone())
 }
 
+use regex::Regex;
+
+/// Detect the language from the first line of the file content.
+///
+/// Standard shebang format is checked as well as vim's `ft=` method and various
+/// other editors supporting `mode:`.
+///
+/// For example, a file opened that has any of the following first lines will be
+/// detected as bash.
+///
+/// - `#!/bin/bash`
+/// - `# vim: ft=bash`
+/// - `# mode: bash
+///
+/// Spaces and other content on the line do not matter.
+pub fn from_content(content: &str) -> Option<Language> {
+    let first_line = content.lines().next()?;
+
+    let re = Regex::new(r"(?:(?:^#!.*/)|(?:mode:)|(?:ft\s*=))\s*(\w+)").unwrap();
+    let language_id = re
+        .captures(first_line)
+        .and_then(|captures| captures.get(1).map(|mode| mode.as_str().to_string()));
+
+    language_id.and_then(|id| {
+        LANGUAGES
+            .iter()
+            .find(|language| {
+                language
+                    .lsp_language_id
+                    .map_or(false, |lsp_id| lsp_id.0 == id)
+            })
+            .map(|language| (*language).clone())
+    })
+}
+
 #[cfg(test)]
 mod test_language {
     use super::*;
@@ -211,6 +246,27 @@ mod test_language {
         }
         run_test_case("hello.rs", "rust")?;
         run_test_case("justfile", "just")?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_from_content() -> anyhow::Result<()> {
+        fn run_test_case(content: &str, expected_language_id: &'static str) -> anyhow::Result<()> {
+            let result = from_content(content).unwrap();
+            assert_eq!(
+                result.tree_sitter_grammar_id().unwrap(),
+                expected_language_id
+            );
+            Ok(())
+        }
+
+        run_test_case("#!/bin/bash", "bash")?;
+        run_test_case("#!/usr/local/bin/bash", "bash")?;
+        run_test_case("// mode: python", "python")?;
+        run_test_case("-- tab_spaces: 5, mode: bash, use_tabs: false", "bash")?;
+        run_test_case("-- tab_spaces: 5, mode:bash, use_tabs: false", "bash")?;
+        run_test_case("-- vim: ft = bash", "bash")?;
+
         Ok(())
     }
 }

--- a/shared/src/language.rs
+++ b/shared/src/language.rs
@@ -250,9 +250,9 @@ mod test_language {
     }
 
     #[test]
-    fn test_from_content() -> anyhow::Result<()> {
+    fn test_from_content_directive() -> anyhow::Result<()> {
         fn run_test_case(content: &str, expected_language_id: &'static str) -> anyhow::Result<()> {
-            let result = from_content(content).unwrap();
+            let result = from_content_directive(content).unwrap();
             assert_eq!(
                 result.tree_sitter_grammar_id().unwrap(),
                 expected_language_id

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -603,7 +603,7 @@ impl Buffer {
     ) -> anyhow::Result<Buffer> {
         let content = path.read()?;
         let language = if enable_tree_sitter {
-            language::from_path(path).or_else(|| language::from_content(&content))
+            language::from_path(path).or_else(|| language::from_content_directive(&content))
         } else {
             None
         };

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -603,7 +603,7 @@ impl Buffer {
     ) -> anyhow::Result<Buffer> {
         let content = path.read()?;
         let language = if enable_tree_sitter {
-            language::from_path(path)
+            language::from_path(path).or_else(|| language::from_content(&content))
         } else {
             None
         };


### PR DESCRIPTION
The filename does not always tell the story as to what a file is. Shell scripts are a prime example. you may have a file named: `get_weather` and in it the first line contains `#!/bin/bash`. Currently, this file will not be detected as a bash script and will gain none of the LSP/Tree-sitter goodness that Ki has to offer.

With this change, if the filename and file extension does not yield a result on the language to use, the first line of the file content will be examined looking for a common shebang or mode header line. Mode header lines considered are the popular vim syntax and another syntax started by (I think) Emacs and used in other editors as well.

If the first line of a file contains any of the following, the Bash language will be assigned in Ki.

- `#!/bin/bash`
- `# vim: ft=bash`
- `# mode: bash`

For the mode comment lines, the position of where `ft=` or `mode:` appear does not matter. Nor does any additional spacing around special characters.