### PR TITLE
fix(flake): Build error by non-specifying Rust version

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -49,11 +49,46 @@
         "type": "github"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1728538411,
+        "narHash": "sha256-f0SBJz1eZ2yOuKUr5CA9BHULGXVSn6miBuUWdTyhUhU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "crane": "crane",
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1736303309,
+        "narHash": "sha256-IKrk7RL+Q/2NC6+Ql6dwwCNZI6T6JH2grTdJaVWHF0A=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "a0b81d4fa349d9af1765b0f0b4a899c13776f706",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,19 +4,42 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     crane.url = "github:ipetkov/crane";
     flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay.url = "github:oxalica/rust-overlay";
   };
   outputs =
-    {
-      self,
-      nixpkgs,
-      crane,
-      flake-utils,
+    { self
+    , nixpkgs
+    , crane
+    , flake-utils
+    , rust-overlay
     }:
+    let
+      # Normalizes Rust version string to ensure it has a patch version.
+      # - Returns version as-is if it matches "X.Y.Z" format (e.g. "1.83.0")
+      # - Appends ".0" if version matches "X.Y" format (e.g. "1.83" -> "1.83.0")
+      # - Throws an error for any other format
+      normalizeRustVersion = version:
+        let
+          majorMinorPatch = builtins.match "([0-9]+)[.]([0-9]+)[.]([0-9]+)" version;
+          majorMinor = builtins.match "([0-9]+)[.]([0-9]+)" version;
+        in
+        if majorMinorPatch != null then version
+        else if majorMinor != null then version + ".0"
+        else throw "Invalid Rust version format: ${version}. Expected format: X.Y.Z or X.Y";
+    in
     flake-utils.lib.eachDefaultSystem (
       system:
       let
-        pkgs = nixpkgs.legacyPackages.${system};
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ (import rust-overlay) ];
+        };
         craneLib = crane.mkLib pkgs;
+        cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+        rustVersion = normalizeRustVersion cargoToml.package.rust-version;
+        rustToolchain = pkgs.rust-bin.stable.${rustVersion}.default.override {
+          extensions = [ "rust-src" "rust-analyzer" ];
+        };
         commonArgs = {
           src = ./.;
           strictDeps = true;
@@ -25,6 +48,7 @@
           nativeBuildInputs = with pkgs; [
             pkg-config
             git
+            rustToolchain
           ];
         };
         ki-editor = craneLib.buildPackage (

--- a/flake.nix
+++ b/flake.nix
@@ -44,7 +44,16 @@
           src = ./.;
           strictDeps = true;
           doCheck = false;
-          buildInputs = [ pkgs.openssl ];
+          buildInputs = with pkgs; [
+            openssl
+          ] ++ lib.optionals stdenv.isDarwin [
+            darwin.apple_sdk.frameworks.Security
+            darwin.apple_sdk.frameworks.SystemConfiguration
+            darwin.apple_sdk.frameworks.CoreServices
+            darwin.apple_sdk.frameworks.CoreFoundation
+            darwin.apple_sdk.frameworks.CoreGraphics
+            darwin.apple_sdk.frameworks.AppKit
+          ];
           nativeBuildInputs = with pkgs; [
             pkg-config
             git


### PR DESCRIPTION
# Problem

Related with #514:

1. A build error occurs due to the Rust version not being specified in `flake.nix`.
2. A build error occurs due to missing dependencies on macOS.

# Solution

1. Use the Rust version specified in `Cargo.toml` when build with Nix by rust-overlay.
2. Add the required dependencies for Darwin.