### PR TITLE
feat(layout): only use Wide layout

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -554,5 +554,5 @@ impl Layout {
     }
 }
 fn layout_kind() -> (LayoutKind, f32) {
-    (LayoutKind::Tall, 0.70)
+    (LayoutKind::Wide, 0.70)
 }

--- a/src/rectangle.rs
+++ b/src/rectangle.rs
@@ -467,8 +467,8 @@ impl Rectangle {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum LayoutKind {
-    Tall,
     #[allow(unused)]
+    Tall,
     Wide,
 }
 


### PR DESCRIPTION
This is because the Tall layout is not suitable for displaying positional keymap.