### PR TITLE
fix(git_hunk): use buffer content instead of file content

### DIFF
--- a/src/components/render_editor.rs
+++ b/src/components/render_editor.rs
@@ -55,7 +55,10 @@ impl Editor {
         let theme = context.theme();
 
         let possible_selections = self
-            .possible_selections_in_line_number_range(self.selection_set.primary_selection())
+            .possible_selections_in_line_number_range(
+                self.selection_set.primary_selection(),
+                context,
+            )
             .unwrap_or_default()
             .into_iter()
             .map(|range| HighlightSpan {
@@ -423,8 +426,9 @@ impl Editor {
     pub(crate) fn possible_selections_in_line_number_range(
         &self,
         selection: &Selection,
+        context: &Context,
     ) -> anyhow::Result<Vec<ByteRange>> {
-        let object = self.get_selection_mode_trait_object(selection, true)?;
+        let object = self.get_selection_mode_trait_object(selection, true, context)?;
         if self.selection_set.mode.is_contiguous() {
             return Ok(Vec::new());
         }

--- a/src/components/test_editor.rs
+++ b/src/components/test_editor.rs
@@ -4108,3 +4108,23 @@ fn jump_editor_tag() -> anyhow::Result<()> {
         ])
     })
 }
+
+#[test]
+fn git_hunk_should_compare_against_buffer_content_not_file_content() -> anyhow::Result<()> {
+    execute_test(|s| {
+        Box::new([
+            App(OpenFile {
+                path: s.main_rs(),
+                owner: BufferOwner::User,
+                focus: true,
+            }),
+            Editor(Insert("hello".to_string())),
+            Editor(SetSelectionMode(
+                IfCurrentNotFound::LookForward,
+                GitHunk(crate::git::DiffMode::UnstagedAgainstCurrentBranch),
+            )),
+            Editor(CursorAddToAllSelections),
+            Expect(CurrentSelectedTexts(&["hellomod foo;\n"])),
+        ])
+    })
+}

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -144,8 +144,12 @@ impl FileDiff {
 }
 
 pub trait GitOperation {
-    fn file_diff(&self, diff_mode: &DiffMode, repo: &CanonicalizedPath)
-        -> anyhow::Result<FileDiff>;
+    fn file_diff(
+        &self,
+        current_content: &str,
+        diff_mode: &DiffMode,
+        repo: &CanonicalizedPath,
+    ) -> anyhow::Result<FileDiff>;
     fn content_at_last_commit(
         &self,
         diff_mode: &DiffMode,
@@ -156,14 +160,14 @@ pub trait GitOperation {
 impl GitOperation for CanonicalizedPath {
     fn file_diff(
         &self,
+        current_content: &str,
         diff_mode: &DiffMode,
         repo_path: &CanonicalizedPath,
     ) -> anyhow::Result<FileDiff> {
         if let Ok(latest_committed_content) =
             self.content_at_last_commit(diff_mode, &repo_path.try_into()?)
         {
-            let current_content = self.read()?;
-            let hunks = Hunk::get(&latest_committed_content, &current_content);
+            let hunks = Hunk::get(&latest_committed_content, current_content);
 
             Ok(FileDiff {
                 path: self.clone(),

--- a/src/selection_mode/git_hunk.rs
+++ b/src/selection_mode/git_hunk.rs
@@ -1,4 +1,4 @@
-use crate::{buffer::Buffer, git::GitOperation};
+use crate::{buffer::Buffer, context::Context, git::GitOperation};
 use itertools::Itertools;
 
 use super::{ByteRange, SelectionMode};
@@ -11,12 +11,16 @@ impl GitHunk {
     pub(crate) fn new(
         diff_mode: &crate::git::DiffMode,
         buffer: &Buffer,
+        context: &Context,
     ) -> anyhow::Result<GitHunk> {
         let Some(path) = buffer.path() else {
             return Ok(GitHunk { ranges: Vec::new() });
         };
-        // TODO: pass in current working directory
-        let binding = path.file_diff(diff_mode, &".".try_into()?)?;
+        let binding = path.file_diff(
+            &buffer.content(),
+            diff_mode,
+            context.current_working_directory(),
+        )?;
         let hunks = binding.hunks();
         let ranges = hunks
             .iter()


### PR DESCRIPTION
This is so that when a hunk is deleted, the range of all other hunks within the same file will also be updated immediately.

Otherwise, the ranges will only be updated after the file is saved.