### PR TITLE
feat(editor): should look backward when cursor swapped

### DIFF
--- a/docs/docs/normal-mode/other-movements.md
+++ b/docs/docs/normal-mode/other-movements.md
@@ -1,3 +1,5 @@
+import {TutorialFallback} from '@site/src/components/TutorialFallback';
+
 # Other Movements
 
 ## Keymap
@@ -13,8 +15,8 @@
 │   ┆   ┆   ┆   ┆   ┆ ∅ ┆        ┆          ┆          ┆          ┆          │
 ├╌╌╌┼╌╌╌┼╌╌╌┼╌╌╌┼╌╌╌┼╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┤
 │   ┆   ┆   ┆   ┆   ┆ ⌥ ┆        ┆          ┆          ┆          ┆          │
-│   ┆   ┆   ┆   ┆   ┆ ⇧ ┆        ┆          ┆          ┆          ┆   ⇋ End  │
-│   ┆   ┆   ┆   ┆   ┆ ∅ ┆        ┆          ┆          ┆          ┆ ⇋ Anchor │
+│   ┆   ┆   ┆   ┆   ┆ ⇧ ┆        ┆          ┆          ┆          ┆ ⇋ Anchor │
+│   ┆   ┆   ┆   ┆   ┆ ∅ ┆        ┆          ┆          ┆          ┆  ⇋ Curs  │
 ╰───┴───┴───┴───┴───┴───┴────────┴──────────┴──────────┴──────────┴──────────╯
 ```
 
@@ -26,17 +28,15 @@ The movements categorized here are not affected or bounded by [Selection Modes](
 
 Scroll half-page up/down.
 
-### `⇋ Anchor`
+### `⇋ Curs`
 
-Swap cursor with anchor.
+Swap the primary cursor with the secondary cursor.
 
-In Ki, each selection contains a cursor and an anchor.
-
-By default, the cursor sits on the first character of the selection, and the anchor sits on the last character of the selection.
+By default, the primary cursor sits on the first character of the selection, and the secondary cursor sits on the last character of the selection.
 
 For example, if the current selection is `hello world`, then the cursor sits on `h`, while the anchor sits on `d`.
 
-The anchor serves as a visual aid, making it easier to recognize when the selection range has been modified.
+The secondary cursors serves as a visual aid, making it easier to recognize when the selection range has been modified.
 
 This is especially necessary when using selection modes such as [Fine Syntax Node](./selection-modes/primary.md#syntax-1), where occasionally, the start of a selection remains the same while the end of it changes.
 
@@ -47,9 +47,11 @@ Usefulness:
 - When you wish to start a new selection at the end of the current selection
   - For example, when you select a line and wish to change its last word.
 
-### `⇋ End`
+<TutorialFallback filename="swap-cursors"/>
 
-Swap extended selection ends.
+### `⇋ Anchor`
+
+Swap extended selection anchors.
 
 This is only applicable when the selection is extended.
 

--- a/src/components/editor.rs
+++ b/src/components/editor.rs
@@ -277,7 +277,7 @@ impl Component for Editor {
                 direction,
                 use_system_clipboard,
             } => return self.paste(direction, context, use_system_clipboard),
-            SwapCursorWithAnchor => self.swap_cursor_with_anchor(),
+            SwapCursor => self.swap_cursor(),
             SetDecorations(decorations) => self.buffer_mut().set_decorations(&decorations),
             MoveCharacterBack => self.selection_set.move_left(&self.cursor_direction),
             MoveCharacterForward => {
@@ -322,7 +322,7 @@ impl Component for Editor {
             Indent => return self.indent(),
             Dedent => return self.dedent(),
             CyclePrimarySelection(direction) => self.cycle_primary_selection(direction),
-            SwapExtensionDirection => self.selection_set.swap_initial_range_direction(),
+            SwapExtensionAnchor => self.selection_set.swap_anchor(),
             CollapseSelection(direction) => return self.collapse_selection(context, direction),
             FilterSelectionMatchingSearch { maintain, search } => {
                 self.mode = Mode::Normal;
@@ -1209,7 +1209,7 @@ impl Editor {
         self.navigate_undo_tree(Movement::Right)
     }
 
-    pub(crate) fn swap_cursor_with_anchor(&mut self) {
+    pub(crate) fn swap_cursor(&mut self) {
         self.cursor_direction = match self.cursor_direction {
             Direction::Start => Direction::End,
             Direction::End => Direction::Start,
@@ -3196,10 +3196,8 @@ impl Editor {
             SetSelectionMode(IfCurrentNotFound::LookForward, SelectionMode::Character);
         match direction {
             Direction::Start => self.handle_dispatch_editor(context, set_column_selection_mode),
-            Direction::End => self.handle_dispatch_editors(
-                context,
-                [SwapCursorWithAnchor, set_column_selection_mode].to_vec(),
-            ),
+            Direction::End => self
+                .handle_dispatch_editors(context, [SwapCursor, set_column_selection_mode].to_vec()),
         }
     }
 
@@ -3540,7 +3538,7 @@ pub(crate) enum DispatchEditor {
         direction: Direction,
         use_system_clipboard: bool,
     },
-    SwapCursorWithAnchor,
+    SwapCursor,
     MoveCharacterBack,
     MoveCharacterForward,
     DeleteSurround(EnclosureKind),
@@ -3559,7 +3557,7 @@ pub(crate) enum DispatchEditor {
     ShowCurrentTreeSitterNodeSexp,
     Indent,
     Dedent,
-    SwapExtensionDirection,
+    SwapExtensionAnchor,
     CollapseSelection(Direction),
     FilterSelectionMatchingSearch {
         search: String,

--- a/src/components/editor_keymap_legend.rs
+++ b/src/components/editor_keymap_legend.rs
@@ -162,15 +162,15 @@ impl Editor {
             ),
             Keymap::new_extended(
                 context.keyboard_layout_kind().get_key(&Meaning::SSEnd),
-                "⇋ End".to_string(),
-                "Switch extended selection end".to_string(),
-                Dispatch::ToEditor(SwapExtensionDirection),
+                "⇋ Anchor".to_string(),
+                "Swap Anchor".to_string(),
+                Dispatch::ToEditor(SwapExtensionAnchor),
             ),
             Keymap::new_extended(
                 context.keyboard_layout_kind().get_key(&Meaning::XAchr),
-                "⇋ Anchor".to_string(),
-                "Swap cursor with anchor".to_string(),
-                Dispatch::ToEditor(DispatchEditor::SwapCursorWithAnchor),
+                "⇋ Curs".to_string(),
+                "Swap cursor".to_string(),
+                Dispatch::ToEditor(DispatchEditor::SwapCursor),
             ),
         ]
         .to_vec()

--- a/src/components/test_editor.rs
+++ b/src/components/test_editor.rs
@@ -72,7 +72,7 @@ fn toggle_visual_mode() -> anyhow::Result<()> {
             Editor(MoveSelection(Right)),
             Editor(MoveSelection(Right)),
             Expect(CurrentSelectedTexts(&["fn f("])),
-            Editor(SwapExtensionDirection),
+            Editor(SwapExtensionAnchor),
             Editor(MoveSelection(Right)),
             Expect(CurrentSelectedTexts(&["f("])),
             Editor(Reset),
@@ -2263,7 +2263,7 @@ fn swap_cursor_with_anchor() -> anyhow::Result<()> {
             })),
             Editor(SetContent("fn main() { x.y() }  // hello ".to_string())),
             Editor(SetSelectionMode(IfCurrentNotFound::LookForward, SyntaxNode)),
-            Editor(SwapCursorWithAnchor),
+            Editor(SwapCursor),
             Expect(EditorGrid(
                 "
 🦀  src/main.rs [*]
@@ -4149,6 +4149,24 @@ fn search_current_selection() -> anyhow::Result<()> {
             )),
             Expect(CurrentSelectedTexts(&["foo bar"])),
             Expect(SelectionExtensionEnabled(false)),
+        ])
+    })
+}
+
+#[test]
+fn should_search_backward_if_primary_and_secondary_cursor_swapped() -> anyhow::Result<()> {
+    execute_test(|s| {
+        Box::new([
+            App(OpenFile {
+                path: s.main_rs(),
+                owner: BufferOwner::User,
+                focus: true,
+            }),
+            Editor(SetContent("hello world()".to_string())),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Line)),
+            Editor(SwapCursor),
+            App(HandleKeyEvent(key!("s"))), // Token selection mode (Qwerty)
+            Expect(CurrentSelectedTexts(&["world"])),
         ])
     })
 }

--- a/src/recipes.rs
+++ b/src/recipes.rs
@@ -3,11 +3,13 @@ use my_proc_macros::keys;
 use crate::{
     components::editor::Mode,
     generate_recipes::{Recipe, RecipeGroup},
+    position::Position,
     test_app::*,
 };
 
 pub(crate) fn recipe_groups() -> Vec<RecipeGroup> {
     [
+        swap_cursors(),
         reveal_selections(),
         reveal_cursors(),
         reveal_marks(),
@@ -1641,6 +1643,46 @@ fn reveal_cursors() -> RecipeGroup {
             similar_vim_combos: &[],
             only: false,
         }]
+        .to_vec(),
+    }
+}
+
+fn swap_cursors() -> RecipeGroup {
+    RecipeGroup {
+        filename: "swap-cursors",
+        recipes: [
+            Recipe {
+                description: "Swap Cursors to view out-of-bound selection end",
+                content: "
+fn main() {
+   foo();
+   bar();
+   spam();
+   baz();
+   bomb();
+} // Last line of main()
+"
+                .trim(),
+                file_extension: "rs",
+                prepare_events: &[],
+                events: keys!("d / /"),
+                expectations: &[EditorCursorPosition(Position { line: 0, column: 0 })],
+                terminal_height: Some(5),
+                similar_vim_combos: &[],
+                only: false,
+            },
+            Recipe {
+                description: "Swap Cursors to select last token of current line",
+                content: "foo bar spam baz()".trim(),
+                file_extension: "md",
+                prepare_events: &[],
+                events: keys!("a / s"),
+                expectations: &[CurrentSelectedTexts(&["baz"])],
+                terminal_height: None,
+                similar_vim_combos: &[],
+                only: false,
+            },
+        ]
         .to_vec(),
     }
 }

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -245,7 +245,7 @@ impl SelectionSet {
         self.apply_mut(|selection| selection.enable_selection_extension());
     }
 
-    pub(crate) fn swap_initial_range_direction(&mut self) {
+    pub(crate) fn swap_anchor(&mut self) {
         self.apply_mut(|selection| selection.swap_initial_range_direction());
     }
 


### PR DESCRIPTION
Also:
1. Renamed Swap Cursor with Anchor to Swap Cursor
2. Renamed Swap Selection End to Swap Anchor

These new naming are more consistent with their naming in the code.