### PR TITLE
feat(languages/idris): Add support for Idris

### DIFF
--- a/shared/src/languages.rs
+++ b/shared/src/languages.rs
@@ -21,6 +21,7 @@ pub const LANGUAGES: &[&Language] = &[
     &hare(),
     &heex(),
     &html(),
+    &idris(),
     &javascript(),
     &javascript_react(),
     &json(),
@@ -358,6 +359,24 @@ const fn html() -> Language {
             id: "html",
             url: "https://github.com/tree-sitter/tree-sitter-html",
             commit: "master",
+            subpath: None,
+        }),
+        ..Language::new()
+    }
+}
+
+const fn idris() -> Language {
+    Language {
+        extensions: &["idr", "lidr", "ipkg"],
+        lsp_command: Some(LspCommand {
+            command: Command("idris2-lsp", &[]),
+            ..LspCommand::default()
+        }),
+        lsp_language_id: Some(LanguageId::new("idris")),
+        tree_sitter_grammar_config: Some(GrammarConfig {
+            id: "idris",
+            url: "https://github.com/kayhide/tree-sitter-idris",
+            commit: "main",
             subpath: None,
         }),
         ..Language::new()


### PR DESCRIPTION
# Support for Idris2
* Added grammar
* Added LSP command

# Background
Idris is a programming language designed to encourage Type-Driven Development. It is a pure, dependently typed, total functional programming language. In Idris, types are first-class constructs in the langauge. This means types can be passed as arguments to functions, and returned from functions just like any other value, such as numbers, strings, or lists.

# Website
https://www.idris-lang.org/