### PR TITLE
feat(multicursor/completion): should use word replacement instead

### DIFF
--- a/src/components/editor_keymap.rs
+++ b/src/components/editor_keymap.rs
@@ -106,10 +106,10 @@ pub(crate) const KEYMAP_FIND_GLOBAL_SHIFTED: KeyboardMeaningLayout = [
 
 pub(crate) const KEYMAP_SURROUND: KeyboardMeaningLayout = [
     [
-        _____, _____, _____, _____, _____, /****/ _____, _____, _____, _____, _____,
+        _____, _____, _____, _____, _____, /****/ _____, SQuot, DQuot, BckTk, _____,
     ],
     [
-        _____, SQuot, DQuot, BckTk, _____, /****/ _____, Paren, Brckt, Brace, Anglr,
+        _____, _____, _____, _____, _____, /****/ _____, Paren, Brckt, Brace, Anglr,
     ],
     [
         _____, _____, _____, _____, _____, /****/ _____, _____, _____, _____, _____,

--- a/src/lsp/completion.rs
+++ b/src/lsp/completion.rs
@@ -151,24 +151,16 @@ impl CompletionItem {
     }
 
     pub(crate) fn dispatches(&self) -> crate::app::Dispatches {
-        match &self.edit {
-            None => Dispatches::one(Dispatch::ToEditor(
-                DispatchEditor::TryReplaceCurrentLongWord(
-                    self.insert_text().unwrap_or_else(|| self.label()),
-                ),
-            ))
-            .append(Dispatch::ToEditor(DispatchEditor::ApplyPositionalEdits(
-                self.additional_text_edits(),
-            ))),
-            Some(edit) => {
-                Dispatches::one(Dispatch::ToEditor(DispatchEditor::ApplyPositionalEdits(
-                    Some(edit.clone())
-                        .into_iter()
-                        .chain(self.additional_text_edits())
-                        .collect_vec(),
-                )))
-            }
-        }
+        Dispatches::one(Dispatch::ToEditor(DispatchEditor::ExecuteCompletion {
+            replacement: self
+                .insert_text()
+                .or_else(|| self.insert_text())
+                .unwrap_or_else(|| self.label()),
+            edit: self.edit.clone(),
+        }))
+        .append(Dispatch::ToEditor(DispatchEditor::ApplyPositionalEdits(
+            self.additional_text_edits(),
+        )))
         .append_some(
             self.command()
                 .clone()


### PR DESCRIPTION
...of positional edit when there are more than one cursor.