### PR TITLE
perf(render_editor): change StyleKey::Syntax payload from String to usize

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -33,7 +33,7 @@ use crate::{
     quickfix_list::{Location, QuickfixList, QuickfixListItem, QuickfixListType},
     screen::{Screen, Window},
     selection::SelectionMode,
-    syntax_highlight::{HighlighedSpans, SyntaxHighlightRequest},
+    syntax_highlight::{HighlightedSpans, SyntaxHighlightRequest},
     ui_tree::{ComponentKind, KindedComponent},
 };
 use event::event::Event;
@@ -149,7 +149,7 @@ impl<T: Frontend> App<T> {
     fn update_highlighted_spans(
         &self,
         component_id: ComponentId,
-        highlighted_spans: HighlighedSpans,
+        highlighted_spans: HighlightedSpans,
     ) -> Result<(), anyhow::Error> {
         self.layout
             .update_highlighted_spans(component_id, highlighted_spans)
@@ -2707,7 +2707,7 @@ pub(crate) enum AppMessage {
     QuitAll,
     SyntaxHighlightResponse {
         component_id: ComponentId,
-        highlighted_spans: HighlighedSpans,
+        highlighted_spans: HighlightedSpans,
     },
 }
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -10,7 +10,7 @@ use crate::{
     position::Position,
     selection::{CharIndex, Selection, SelectionSet},
     selection_mode::{AstGrep, ByteRange},
-    syntax_highlight::{HighlighedSpan, HighlighedSpans},
+    syntax_highlight::{HighlightedSpan, HighlightedSpans},
     undo_tree::{Applicable, OldNew, UndoTree},
     utils::find_previous,
 };
@@ -43,7 +43,7 @@ pub(crate) struct Buffer {
     undo_tree: UndoTree<Patch>,
     language: Option<Language>,
     path: Option<CanonicalizedPath>,
-    highlighted_spans: HighlighedSpans,
+    highlighted_spans: HighlightedSpans,
     marks: Vec<CharIndexRange>,
     diagnostics: Vec<Diagnostic>,
     quickfix_list_items: Vec<QuickfixListItem>,
@@ -77,7 +77,7 @@ impl Buffer {
                 })
             },
             path: None,
-            highlighted_spans: HighlighedSpans::default(),
+            highlighted_spans: HighlightedSpans::default(),
             marks: Vec::new(),
             decorations: Vec::new(),
             undo_tree: UndoTree::new(),
@@ -281,7 +281,7 @@ impl Buffer {
             .unwrap_or(false)
     }
 
-    pub(crate) fn update_highlighted_spans(&mut self, spans: HighlighedSpans) {
+    pub(crate) fn update_highlighted_spans(&mut self, spans: HighlightedSpans) {
         self.highlighted_spans = spans;
     }
 
@@ -490,6 +490,8 @@ impl Buffer {
             marks: self.marks.clone(),
         };
 
+        // Add undo patch is heavy for many multi cursors
+        // it is very slow
         self.add_undo_patch(current_buffer_state, new_buffer_state.clone(), &before);
         if reparse_tree {
             self.reparse_tree()?;
@@ -531,27 +533,27 @@ impl Buffer {
             .collect_vec();
 
         // Update all the non-positional spans
-        self.marks = std::mem::take(&mut self.marks)
-            .into_iter()
-            .filter_map(|mark| mark.apply_edit(edit))
-            .collect();
-        self.diagnostics = std::mem::take(&mut self.diagnostics)
-            .into_iter()
-            .filter_map(|diagnostic| {
-                Some(Diagnostic {
-                    range: diagnostic.range.apply_edit(edit)?,
-                    ..diagnostic
-                })
-            })
-            .collect_vec();
+        self.marks.retain_mut(|mark| {
+            if let Some(range) = mark.apply_edit(edit) {
+                *mark = range;
+                true
+            } else {
+                false
+            }
+        });
+        self.diagnostics.retain_mut(|diagnostic| {
+            if let Some(range) = diagnostic.range.apply_edit(edit) {
+                diagnostic.range = range;
+                true
+            } else {
+                false
+            }
+        });
         let max_char_index = CharIndex(self.len_chars());
         self.selection_set_history = std::mem::take(&mut self.selection_set_history)
             .apply(|selection_set| selection_set.apply_edit(edit, max_char_index));
         if let Ok(byte_range) = self.char_index_range_to_byte_range(edit.range()) {
-            self.highlighted_spans = std::mem::take(&mut self.highlighted_spans).apply_edit(
-                &byte_range,
-                edit.new.len_bytes() as isize - byte_range.len() as isize,
-            )
+            // self.highlighted_spans.apply_edit_mut( &byte_range, edit.new.len_bytes() as isize - byte_range.len() as isize, );
         }
         Ok(())
     }
@@ -715,7 +717,7 @@ impl Buffer {
     }
 
     /// The resulting spans must be sorted by range
-    pub(crate) fn highlighted_spans(&self) -> Vec<HighlighedSpan> {
+    pub(crate) fn highlighted_spans(&self) -> Vec<HighlightedSpan> {
         let spans = self.highlighted_spans.0.clone();
         debug_assert!(
             spans

--- a/src/components/component.rs
+++ b/src/components/component.rs
@@ -23,7 +23,7 @@ impl std::fmt::Display for GetGridResult {
                 .grid
                 .clone()
                 .apply_cell_update(
-                    crate::grid::CellUpdate::new(cursor.position).set_symbol(Some("█".to_string())),
+                    crate::grid::CellUpdate::new(cursor.position).set_symbol(Some('█')),
                 )
                 .to_string(),
             None => self.grid.to_string(),

--- a/src/components/test_editor.rs
+++ b/src/components/test_editor.rs
@@ -4,6 +4,7 @@ use crate::char_index_range::CharIndexRange;
 use crate::clipboard::CopiedTexts;
 use crate::components::editor::{DispatchEditor::*, Movement::*};
 use crate::context::{Context, LocalSearchConfigMode, Search};
+use crate::grid::IndexedHighlightGroup;
 use crate::list::grep::RegexConfig;
 use crate::lsp::process::LspNotification;
 use crate::quickfix_list::{Location, QuickfixListItem};
@@ -1998,14 +1999,14 @@ fn syntax_highlight_spans_updated_by_edit() -> anyhow::Result<()> {
             Editor(ApplySyntaxHighlight),
             Expect(ExpectKind::HighlightSpans(
                 0..2,
-                StyleKey::Syntax("keyword.function".to_string()),
+                StyleKey::Syntax(IndexedHighlightGroup::from_str("keyword.function").unwrap()),
             )),
             Editor(MatchLiteral("fn".to_string())),
             Editor(EnterInsertMode(Direction::Start)),
             Editor(Insert("hello".to_string())),
             Expect(ExpectKind::HighlightSpans(
                 5..7,
-                StyleKey::Syntax("keyword.function".to_string()),
+                StyleKey::Syntax(IndexedHighlightGroup::from_str("keyword.function").unwrap()),
             )),
         ])
     })
@@ -2067,7 +2068,9 @@ fn main() { // too long
                 .map(|position| {
                     ExpectKind::GridCellStyleKey(
                         position,
-                        Some(StyleKey::Syntax("keyword.function".to_string())),
+                        Some(StyleKey::Syntax(
+                            IndexedHighlightGroup::from_str("keyword.function").unwrap(),
+                        )),
                     )
                 })
                 .collect(),
@@ -2076,7 +2079,9 @@ fn main() { // too long
                 // Expect the left parenthesis of the outbound parent line "fn main() { // too long" is highlighted properly
                 ExpectKind::GridCellStyleKey(
                     Position::new(1, 9),
-                    Some(StyleKey::Syntax("punctuation.bracket".to_string())),
+                    Some(StyleKey::Syntax(
+                        IndexedHighlightGroup::from_str("punctuation.bracket").unwrap(),
+                    )),
                 ),
             ),
             ExpectMulti(
@@ -2095,7 +2100,9 @@ fn main() { // too long
                 .map(|position| {
                     ExpectKind::GridCellStyleKey(
                         position,
-                        Some(StyleKey::Syntax("keyword".to_string())),
+                        Some(StyleKey::Syntax(
+                            IndexedHighlightGroup::from_str("keyword").unwrap(),
+                        )),
                     )
                 })
                 .collect(),

--- a/src/context.rs
+++ b/src/context.rs
@@ -149,7 +149,7 @@ impl Context {
         &mut self,
         language: shared::language::Language,
         source_code: &str,
-    ) -> anyhow::Result<crate::syntax_highlight::HighlighedSpans> {
+    ) -> anyhow::Result<crate::syntax_highlight::HighlightedSpans> {
         self.highlight_configs.highlight(language, source_code)
     }
 

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -83,7 +83,7 @@ pub(crate) trait Frontend {
                 ),
                 SetBackgroundColor(cell.cell.background_color.into()),
                 SetForegroundColor(cell.cell.foreground_color.into()),
-                Print(reveal(&cell.cell.symbol)),
+                Print(reveal(cell.cell.symbol)),
                 SetAttribute(Attribute::Reset),
             )?;
         }
@@ -91,11 +91,11 @@ pub(crate) trait Frontend {
     }
 }
 /// Convert invisible character to visible character
-fn reveal(s: &str) -> String {
+fn reveal(s: char) -> char {
     match s {
-        "\n" => " ".to_string(),
-        "\t" => " ".to_string(),
-        _ => s.into(),
+        '\n' => ' ',
+        '\t' => ' ',
+        _ => s,
     }
 }
 

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -3,7 +3,7 @@ use crate::{
     position::Position,
     soft_wrap::{self},
     style::Style,
-    themes::{highlight_names, Color, HighlightName, Theme},
+    themes::{Color, HighlightName, Theme},
 };
 
 use itertools::Itertools;

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -3,13 +3,14 @@ use crate::{
     position::Position,
     soft_wrap::{self},
     style::Style,
-    themes::{Color, Theme},
+    themes::{highlight_names, Color, HighlightName, Theme},
 };
 
 use itertools::Itertools;
 use my_proc_macros::hex;
 #[cfg(test)]
 use ropey::Rope;
+use strum::IntoEnumIterator;
 use unicode_width::UnicodeWidthChar;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -22,7 +23,7 @@ const DEFAULT_TAB_SIZE: usize = 4;
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub(crate) struct Cell {
-    pub(crate) symbol: String,
+    pub(crate) symbol: char,
     pub(crate) foreground_color: Color,
     pub(crate) background_color: Color,
     pub(crate) line: Option<CellLine>,
@@ -51,14 +52,14 @@ impl Cell {
     #[cfg(test)]
     pub(crate) fn from_char(c: char) -> Self {
         Cell {
-            symbol: c.to_string(),
+            symbol: c,
             ..Default::default()
         }
     }
 
     fn apply_update(&self, update: CellUpdate) -> Cell {
         Cell {
-            symbol: update.symbol.clone().unwrap_or_else(|| self.symbol.clone()),
+            symbol: update.symbol.unwrap_or(self.symbol),
             foreground_color: update
                 .style
                 .foreground_color
@@ -80,7 +81,7 @@ impl Cell {
 impl Default for Cell {
     fn default() -> Self {
         Cell {
-            symbol: " ".to_string(),
+            symbol: ' ',
             foreground_color: hex!("#ffffff"),
             background_color: hex!("#ffffff"),
             line: None,
@@ -95,7 +96,7 @@ impl Default for Cell {
 #[derive(Clone, Debug, Default)]
 pub(crate) struct CellUpdate {
     pub(crate) position: Position,
-    pub(crate) symbol: Option<String>,
+    pub(crate) symbol: Option<char>,
     pub(crate) style: Style,
     pub(crate) is_cursor: bool,
 
@@ -128,7 +129,7 @@ impl CellUpdate {
     }
 
     #[cfg(test)]
-    pub(crate) fn set_symbol(self, symbol: Option<String>) -> CellUpdate {
+    pub(crate) fn set_symbol(self, symbol: Option<char>) -> CellUpdate {
         CellUpdate { symbol, ..self }
     }
 
@@ -232,7 +233,7 @@ impl Grid {
                 .enumerate()
                 .for_each(|(column_index, character)| {
                     grid.rows[row_index][column_index] = Cell {
-                        symbol: character.to_string(),
+                        symbol: character,
                         ..Cell::default()
                     }
                 })
@@ -315,7 +316,7 @@ impl Grid {
                         line: row_index,
                         column: column_index,
                     },
-                    symbol: Some(character.to_string()),
+                    symbol: Some(character),
                     style: *style,
                     ..CellUpdate::default()
                 }
@@ -369,7 +370,7 @@ impl Grid {
                                 line: line_index,
                                 column: column_index,
                             },
-                            symbol: Some(character.to_string()),
+                            symbol: Some(character),
                             style: Style::default().foreground_color(theme.ui.text_foreground),
                             ..CellUpdate::default()
                         })
@@ -516,7 +517,7 @@ impl Grid {
                                     (max_line_number_len + line_number_separator_width) as u16,
                                 ),
                                 symbol: if index == 0 {
-                                    update.cell_update.symbol.clone()
+                                    update.cell_update.symbol
                                 } else {
                                     // Fill extra paddings with no-symbol cells
                                     None
@@ -598,9 +599,34 @@ impl Grid {
     }
 }
 
+/// This is created so the payload of `StyleKey::Syntax`
+/// can be usize instead of String.
+///
+/// The impact of this is huge because for a 3k Rust files
+/// there are over 50,000 highlight spans,
+/// and copying the style key as strings are very expensive.
+#[derive(Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord)]
+pub(crate) struct IndexedHighlightGroup(usize);
+impl IndexedHighlightGroup {
+    pub(crate) fn new(index: usize) -> Self {
+        Self(index)
+    }
+    pub(crate) fn from_str(name: &str) -> Option<Self> {
+        highlight_names()
+            .iter()
+            .position(|highlight_name| highlight_name == &name)
+            .map(|index| Self(index))
+    }
+
+    pub(crate) fn to_highlight_name(&self) -> Option<crate::themes::HighlightName> {
+        HighlightName::iter().nth(self.0)
+    }
+}
+
 #[derive(Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord)]
 pub(crate) enum StyleKey {
-    Syntax(String),
+    // BOTTLENECK 4: Should use Enum not String!
+    Syntax(IndexedHighlightGroup),
     UiPrimarySelection,
 
     UiPrimarySelectionAnchors,
@@ -767,7 +793,7 @@ mod test_grid {
                     start_line_index: 1,
                 },
                 [CellUpdate {
-                    symbol: Some(cursor.to_string()),
+                    symbol: Some(cursor),
                     position: Position::new(0, 3),
                     ..Default::default()
                 }]
@@ -806,7 +832,7 @@ mod test_grid {
                     start_line_index: 1,
                 },
                 [CellUpdate {
-                    symbol: Some(cursor.to_string()),
+                    symbol: Some(cursor),
                     position: Position::new(0, 8), // 3rd space
                     ..Default::default()
                 }]
@@ -963,7 +989,7 @@ mod test_grid {
                 .into_iter()
                 .map(|cell| cell.cell.symbol)
                 .collect_vec();
-            assert_eq!(["\t", " ", " ", " ", "h", "e", "l", " "].to_vec(), actual)
+            assert_eq!(['\t', ' ', ' ', ' ', 'h', 'e', 'l', ' '].to_vec(), actual)
         }
 
         #[test]
@@ -1029,7 +1055,7 @@ x
                 .collect_vec();
             let expected = PositionedCell {
                 cell: Cell {
-                    symbol: "h".to_string(),
+                    symbol: 'h',
                     foreground_color: color,
                     ..Default::default()
                 },
@@ -1051,7 +1077,7 @@ mod test_cell {
     #[test]
     fn apply_update() {
         let cell = Cell {
-            symbol: "a".to_string(),
+            symbol: 'a',
             foreground_color: hex!("#aaaaaa"),
             background_color: hex!("#bbbbbb"),
             line: Some(CellLine {
@@ -1065,7 +1091,7 @@ mod test_cell {
         };
         let cell = cell.apply_update(CellUpdate {
             position: Position::default(),
-            symbol: Some("b".to_string()),
+            symbol: Some('b'),
             style: Style::new()
                 .foreground_color(hex!("#dddddd"))
                 .background_color(hex!("#eeeeee"))
@@ -1077,7 +1103,7 @@ mod test_cell {
             source: Some(StyleKey::KeymapHint),
             is_protected_range_start: true,
         });
-        assert_eq!(cell.symbol, "b");
+        assert_eq!(cell.symbol, 'b');
         assert_eq!(cell.foreground_color, hex!("#dddddd"));
         assert_eq!(cell.background_color, hex!("#eeeeee"));
         assert!(cell.is_cursor);

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -611,11 +611,13 @@ impl IndexedHighlightGroup {
     pub(crate) fn new(index: usize) -> Self {
         Self(index)
     }
+
+    #[cfg(test)]
     pub(crate) fn from_str(name: &str) -> Option<Self> {
         highlight_names()
             .iter()
             .position(|highlight_name| highlight_name == &name)
-            .map(|index| Self(index))
+            .map(Self)
     }
 
     pub(crate) fn to_highlight_name(&self) -> Option<crate::themes::HighlightName> {
@@ -625,7 +627,6 @@ impl IndexedHighlightGroup {
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord)]
 pub(crate) enum StyleKey {
-    // BOTTLENECK 4: Should use Enum not String!
     Syntax(IndexedHighlightGroup),
     UiPrimarySelection,
 

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -614,7 +614,7 @@ impl IndexedHighlightGroup {
 
     #[cfg(test)]
     pub(crate) fn from_str(name: &str) -> Option<Self> {
-        highlight_names()
+        crate::themes::highlight_names()
             .iter()
             .position(|highlight_name| highlight_name == &name)
             .map(Self)

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -291,7 +291,7 @@ impl Layout {
     pub(crate) fn update_highlighted_spans(
         &self,
         component_id: ComponentId,
-        highlighted_spans: crate::syntax_highlight::HighlighedSpans,
+        highlighted_spans: crate::syntax_highlight::HighlightedSpans,
     ) -> Result<(), anyhow::Error> {
         let component = self
             .background_suggestive_editors

--- a/src/rectangle.rs
+++ b/src/rectangle.rs
@@ -63,8 +63,8 @@ impl Border {
                 position,
                 cell: Cell {
                     symbol: match self.direction {
-                        BorderDirection::Horizontal => "─".to_string(),
-                        BorderDirection::Vertical => "│".to_string(),
+                        BorderDirection::Horizontal => '─',
+                        BorderDirection::Vertical => '│',
                     },
                     foreground_color: border_style.foreground_color.unwrap_or_default(),
                     background_color: border_style.background_color.unwrap_or_default(),

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -85,7 +85,7 @@ impl Screen {
                     .sorted_by(|a, b| a.position.column.cmp(&b.position.column))
                     .map(|cell| {
                         if cell.cell.is_cursor {
-                            "█".to_string()
+                            '█'
                         } else {
                             cell.cell.symbol
                         }

--- a/src/syntax_highlight/mod.rs
+++ b/src/syntax_highlight/mod.rs
@@ -7,7 +7,6 @@ use crate::{
     char_index_range::apply_edit,
     components::component::ComponentId,
     grid::{IndexedHighlightGroup, StyleKey},
-    themes::highlight_names,
 };
 use shared::language::Language;
 
@@ -17,12 +16,6 @@ pub(crate) struct HighlightedSpan {
     pub(crate) style_key: StyleKey,
 }
 impl HighlightedSpan {
-    fn apply_edit(self, edited_range: &Range<usize>, change: isize) -> Option<HighlightedSpan> {
-        Some(HighlightedSpan {
-            byte_range: apply_edit(self.byte_range, edited_range, change)?,
-            ..self
-        })
-    }
     /// Return `true` if this `HighlightedSpan` should be retained after applying the edit
     fn apply_edit_mut(&mut self, edited_range: &Range<usize>, change: isize) -> bool {
         let byte_range = std::mem::take(&mut self.byte_range);
@@ -102,14 +95,6 @@ impl Highlight for HighlightConfiguration {
 #[derive(Clone, Default, Debug)]
 pub(crate) struct HighlightedSpans(pub Vec<HighlightedSpan>);
 impl HighlightedSpans {
-    pub(crate) fn apply_edit(self, edited_range: &Range<usize>, change: isize) -> HighlightedSpans {
-        HighlightedSpans(
-            self.0
-                .into_iter()
-                .filter_map(|span| span.apply_edit(edited_range, change))
-                .collect(),
-        )
-    }
     pub(crate) fn apply_edit_mut(&mut self, edited_range: &Range<usize>, change: isize) {
         self.0
             .retain_mut(|span| span.apply_edit_mut(edited_range, change))

--- a/src/themes/mod.rs
+++ b/src/themes/mod.rs
@@ -11,7 +11,11 @@ use strum::IntoEnumIterator as _;
 pub(crate) use vscode_dark::vscode_dark;
 pub(crate) use vscode_light::vscode_light;
 
-use crate::{env::parse_env, grid::StyleKey, style::Style};
+use crate::{
+    env::parse_env,
+    grid::{IndexedHighlightGroup, StyleKey},
+    style::Style,
+};
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub(crate) struct Theme {
@@ -84,9 +88,10 @@ impl Theme {
                 Style::new().background_color(self.hunk.new_emphasized_background)
             }
 
-            StyleKey::Syntax(highlight_group) => {
-                self.syntax.get_style(highlight_group).unwrap_or_default()
-            }
+            StyleKey::Syntax(highlight_group) => highlight_group
+                .to_highlight_name()
+                .and_then(|name| self.syntax.get_style(&name))
+                .unwrap_or_default(),
             StyleKey::KeymapHint => self.ui.keymap_hint,
             StyleKey::KeymapArrow => self.ui.keymap_arrow,
             StyleKey::KeymapKey => self.ui.keymap_key,
@@ -175,7 +180,7 @@ pub(crate) struct UiStyles {
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
 pub(crate) struct SyntaxStyles {
-    map: once_cell::sync::OnceCell<HashMap<&'static str, Style>>,
+    map: once_cell::sync::OnceCell<HashMap<HighlightName, Style>>,
     groups: Vec<(HighlightName, Style)>,
 }
 
@@ -187,26 +192,27 @@ impl SyntaxStyles {
         }
     }
 
-    fn map(&self) -> &HashMap<&'static str, Style> {
+    fn map(&self) -> &HashMap<HighlightName, Style> {
         self.map.get_or_init(|| {
             self.groups
                 .iter()
-                .map(|(key, style)| (key.into(), style.to_owned()))
+                .map(|(key, style)| (key.clone(), style.to_owned()))
                 .collect()
         })
     }
 
-    fn get_style(&self, highlight_group: &str) -> Option<Style> {
-        let group = HighlightGroup::new(highlight_group);
+    fn get_style(&self, highlight_name: &HighlightName) -> Option<Style> {
         self.map()
-            .get(group.full_name.as_str())
+            .get(&highlight_name)
+            .or_else(|| self.map().get(&highlight_name.parent()?))
             .cloned()
-            .or_else(|| self.get_style(&group.parent?))
     }
 }
 
 #[cfg(test)]
 mod test_syntax_styles {
+    use std::str::FromStr;
+
     use my_proc_macros::hex;
 
     use crate::style::fg;
@@ -225,24 +231,33 @@ mod test_syntax_styles {
     #[test]
     fn test_get_style() {
         assert_eq!(
-            syntax_style().get_style("string").unwrap(),
+            syntax_style()
+                .get_style(&HighlightName::from_str("string").unwrap())
+                .unwrap(),
             fg(hex!("#267f99"))
         );
         assert_eq!(
-            syntax_style().get_style("string.special").unwrap(),
-            fg(hex!("#e50000"))
-        );
-        assert_eq!(
-            syntax_style().get_style("string.special.symbol").unwrap(),
+            syntax_style()
+                .get_style(&HighlightName::from_str("string.special").unwrap())
+                .unwrap(),
             fg(hex!("#e50000"))
         );
         assert_eq!(
             syntax_style()
-                .get_style("variable.parameter.builtin")
+                .get_style(&HighlightName::from_str("string.special.symbol").unwrap())
+                .unwrap(),
+            fg(hex!("#e50000"))
+        );
+        assert_eq!(
+            syntax_style()
+                .get_style(&HighlightName::from_str("variable.parameter.builtin").unwrap())
                 .unwrap(),
             fg(hex!("#abcdef"))
         );
-        assert_eq!(syntax_style().get_style("character"), None);
+        assert_eq!(
+            syntax_style().get_style(&HighlightName::from_str("character").unwrap()),
+            None
+        );
     }
 }
 
@@ -278,6 +293,7 @@ impl HighlightGroup {
     PartialEq,
     Eq,
     Clone,
+    Hash,
 )]
 pub enum HighlightName {
     #[strum(serialize = "ui.bar")]
@@ -468,6 +484,150 @@ pub enum HighlightName {
     TagAttribute,
     #[strum(serialize = "tag.delimiter")]
     TagDelimiter,
+}
+impl HighlightName {
+    fn parent(&self) -> Option<HighlightName> {
+        use HighlightName::*;
+        match self {
+            // UI related
+            UiBar => Some(Ui),
+            Ui => None,
+
+            // Syntax related
+            SyntaxKeyword => None,
+            SyntaxKeywordAsync => Some(SyntaxKeyword),
+
+            // Variables
+            Variable => None,
+            VariableBuiltin => Some(Variable),
+            VariableParameter => Some(Variable),
+            VariableParameterBuiltin => Some(VariableParameter),
+            VariableMember => Some(Variable),
+
+            // Constants
+            Constant => None,
+            ConstantBuiltin => Some(Constant),
+            ConstantMacro => Some(Constant),
+
+            // Modules
+            Module => None,
+            ModuleBuiltin => Some(Module),
+
+            // Label
+            Label => None,
+
+            // Strings
+            String => None,
+            StringDocumentation => Some(String),
+            StringRegexp => Some(String),
+            StringEscape => Some(String),
+            StringSpecial => Some(String),
+            StringSpecialSymbol => Some(StringSpecial),
+            StringSpecialUrl => Some(StringSpecial),
+            StringSpecialPath => Some(StringSpecial),
+
+            // Characters
+            Character => None,
+            CharacterSpecial => Some(Character),
+
+            // Boolean
+            Boolean => None,
+
+            // Numbers
+            Number => None,
+            NumberFloat => Some(Number),
+
+            // Types
+            Type => None,
+            TypeBuiltin => Some(Type),
+            TypeDefinition => Some(Type),
+
+            // Attributes
+            Attribute => None,
+            AttributeBuiltin => Some(Attribute),
+
+            // Properties
+            Property => None,
+
+            // Functions
+            Function => None,
+            FunctionBuiltin => Some(Function),
+            FunctionCall => Some(Function),
+            FunctionMacro => Some(Function),
+            FunctionMethod => Some(Function),
+            FunctionMethodCall => Some(FunctionMethod),
+
+            // Constructor
+            Constructor => None,
+
+            // Operator
+            Operator => None,
+
+            // Keywords
+            Keyword => None,
+            KeywordCoroutine => Some(Keyword),
+            KeywordFunction => Some(Keyword),
+            KeywordOperator => Some(Keyword),
+            KeywordImport => Some(Keyword),
+            KeywordType => Some(Keyword),
+            KeywordModifier => Some(Keyword),
+            KeywordRepeat => Some(Keyword),
+            KeywordReturn => Some(Keyword),
+            KeywordDebug => Some(Keyword),
+            KeywordException => Some(Keyword),
+            KeywordConditional => Some(Keyword),
+            KeywordConditionalTernary => Some(KeywordConditional),
+            KeywordDirective => Some(Keyword),
+            KeywordDirectiveDefine => Some(KeywordDirective),
+
+            // Punctuation
+            PunctuationDelimiter => None,
+            PunctuationBracket => None,
+            PunctuationSpecial => None,
+
+            // Comments
+            Comment => None,
+            CommentDocumentation => Some(Comment),
+            CommentError => Some(Comment),
+            CommentWarning => Some(Comment),
+            CommentTodo => Some(Comment),
+            CommentNote => Some(Comment),
+
+            // Markup
+            MarkupStrong => None,
+            MarkupItalic => None,
+            MarkupStrikethrough => None,
+            MarkupUnderline => None,
+            MarkupHeading => None,
+            MarkupHeading1 => Some(MarkupHeading),
+            MarkupHeading2 => Some(MarkupHeading),
+            MarkupHeading3 => Some(MarkupHeading),
+            MarkupHeading4 => Some(MarkupHeading),
+            MarkupHeading5 => Some(MarkupHeading),
+            MarkupHeading6 => Some(MarkupHeading),
+            MarkupQuote => None,
+            MarkupMath => None,
+            MarkupLink => None,
+            MarkupLinkLabel => Some(MarkupLink),
+            MarkupLinkUrl => Some(MarkupLink),
+            MarkupRaw => None,
+            MarkupRawBlock => Some(MarkupRaw),
+            MarkupList => None,
+            MarkupListChecked => Some(MarkupList),
+            MarkupListUnchecked => Some(MarkupList),
+
+            // Diff
+            DiffPlus => None,
+            DiffMinus => None,
+            DiffDelta => None,
+
+            // Tags
+            Tag => None,
+            TagBuiltin => Some(Tag),
+            TagAttribute => Some(Tag),
+            TagDelimiter => Some(Tag),
+        }
+    }
 }
 
 pub fn highlight_names() -> &'static Vec<&'static str> {

--- a/src/themes/mod.rs
+++ b/src/themes/mod.rs
@@ -197,11 +197,13 @@ impl SyntaxStyles {
         })
     }
 
+    /// Obtain the style of a given highlight_name
+    /// by recursively looking up its parent's name
     fn get_style(&self, highlight_name: &HighlightName) -> Option<Style> {
         self.map()
             .get(highlight_name)
-            .or_else(|| self.map().get(&highlight_name.parent()?))
             .cloned()
+            .or_else(|| self.get_style(&highlight_name.parent()?))
     }
 }
 


### PR DESCRIPTION
This is significant because the number of highlight spans for a medium-sized (~3k lines) Rust file can easily reach 50k.

And having to allocate and deallocate 50k Strings severely hurts performance.