### PR TITLE
perf(buffer/apply_edit): don't update out-of-view highlight spans

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -21,7 +21,7 @@ use shared::{
     language::{self, Language},
 };
 use std::{collections::HashSet, ops::Range};
-use tree_sitter::{Node, Parser, Tree};
+use tree_sitter::{Node, Parser, Point, Tree};
 use tree_sitter_traversal2::{traverse, Order};
 
 /// Determines the buffer's owner. Ki distinguishes buffer ownership during switches.
@@ -114,7 +114,7 @@ impl Buffer {
     pub(crate) fn reload(&mut self) -> anyhow::Result<()> {
         if let Some(path) = self.path() {
             let updated_content = path.read()?;
-            self.update_content(&updated_content, SelectionSet::default())?;
+            self.update_content(&updated_content, SelectionSet::default(), 0)?;
             self.dirty = false;
         }
         Ok(())
@@ -283,6 +283,10 @@ impl Buffer {
     }
 
     pub(crate) fn update_highlighted_spans(&mut self, spans: HighlightedSpans) {
+        // TODO: only update use the highlighted_spans if the last updated
+        // is the same as the last updated of this buffer
+        // use u8 and wrapping_add as ID generation.
+        // This is so that we don't get weird flicking
         self.highlighted_spans = spans;
     }
 
@@ -471,6 +475,7 @@ impl Buffer {
         current_selection_set: SelectionSet,
         reparse_tree: bool,
         update_undo_stack: bool,
+        last_visible_line: u16,
     ) -> Result<SelectionSet, anyhow::Error> {
         let new_selection_set = edit_transaction
             .non_empty_selections()
@@ -486,7 +491,7 @@ impl Buffer {
         edit_transaction
             .edits()
             .into_iter()
-            .try_fold((), |_, edit| self.apply_edit(edit))?;
+            .try_fold((), |_, edit| self.apply_edit(edit, last_visible_line))?;
 
         let new_buffer_state = BufferState {
             selection_set: new_selection_set.clone(),
@@ -512,7 +517,7 @@ impl Buffer {
     }
 
     // Add these methods for undo/redo
-    fn apply_edit(&mut self, edit: &Edit) -> Result<(), anyhow::Error> {
+    fn apply_edit(&mut self, edit: &Edit, last_visible_line: u16) -> Result<(), anyhow::Error> {
         // We have to get the char index range of positional spans before updating the content
         let quickfix_list_items_with_char_index_range =
             std::mem::take(&mut self.quickfix_list_items)
@@ -526,12 +531,28 @@ impl Buffer {
                 })
                 .collect_vec();
 
-        // Update the content
-        self.rope.try_remove(edit.range.start.0..edit.end().0)?;
-        self.rope
-            .try_insert(edit.range.start.0, edit.new.to_string().as_str())?;
-        self.dirty = true;
-        self.owner = BufferOwner::User;
+        if let Ok(byte_range) = self.char_index_range_to_byte_range(edit.range()) {
+            // println!("last_visible_]ine = {last_visible_line}");
+            let last_line_len_bytes = self
+                .get_line_by_line_index(last_visible_line as usize)
+                .map(|slice| slice.len_bytes())
+                .unwrap_or_default();
+
+            // println!("last_line_len_bytes = {last_line_len_bytes}");
+
+            let range_end = self
+                .line_to_byte(last_visible_line as usize)
+                .unwrap_or_default()
+                + last_line_len_bytes;
+            // println!("range_end = {range_end}");
+            let affected_range = byte_range.start..range_end;
+
+            self.highlighted_spans.apply_edit_mut(
+                // &byte_range,
+                &affected_range,
+                edit.new.len_bytes() as isize - byte_range.len() as isize,
+            );
+        }
 
         // Update all the positional spans (by using the char index ranges computed before the content is updated
         self.quickfix_list_items = quickfix_list_items_with_char_index_range
@@ -564,14 +585,13 @@ impl Buffer {
         let max_char_index = CharIndex(self.len_chars());
         self.selection_set_history = std::mem::take(&mut self.selection_set_history)
             .apply(|selection_set| selection_set.apply_edit(edit, max_char_index));
-        if let Ok(byte_range) = self.char_index_range_to_byte_range(edit.range()) {
-            // BOTTLENECK 2: Updating highlighted spans
-            // TODO: use binary tree to skip non-related range and update only related ranges
-            self.highlighted_spans.apply_edit_mut(
-                &byte_range,
-                edit.new.len_bytes() as isize - byte_range.len() as isize,
-            );
-        }
+
+        // Update the content
+        self.rope.try_remove(edit.range.start.0..edit.end().0)?;
+        self.rope
+            .try_insert(edit.range.start.0, edit.new.to_string().as_str())?;
+        self.dirty = true;
+        self.owner = BufferOwner::User;
         Ok(())
     }
 
@@ -663,10 +683,11 @@ impl Buffer {
         &mut self,
         current_selection_set: SelectionSet,
         force: bool,
+        last_visible_line: u16,
     ) -> anyhow::Result<Option<CanonicalizedPath>> {
         if force || self.dirty {
             if let Some(formatted_content) = self.get_formatted_content() {
-                self.update_content(&formatted_content, current_selection_set)?;
+                self.update_content(&formatted_content, current_selection_set, last_visible_line)?;
             }
         }
 
@@ -677,23 +698,21 @@ impl Buffer {
         &mut self,
         new_content: &str,
         current_selection_set: SelectionSet,
+        last_visible_line: u16,
     ) -> anyhow::Result<SelectionSet> {
         let edit_transaction = self.get_edit_transaction(new_content)?;
-        self.apply_edit_transaction(&edit_transaction, current_selection_set, true, true)
+        self.apply_edit_transaction(
+            &edit_transaction,
+            current_selection_set,
+            true,
+            true,
+            last_visible_line,
+        )
     }
 
     /// The resulting spans must be sorted by range
-    pub(crate) fn highlighted_spans(&self) -> Vec<HighlightedSpan> {
-        let spans = self.highlighted_spans.0.clone();
-        debug_assert!(
-            spans
-                .iter()
-                .enumerate()
-                .sorted_by_key(|(_, span)| (span.byte_range.start, span.byte_range.end))
-                .map(|(index, _)| index)
-                .collect_vec()
-                == (0..spans.len()).collect_vec(),
-        );
+    pub(crate) fn highlighted_spans(&self) -> &Vec<HighlightedSpan> {
+        let spans = self.highlighted_spans.0.as_ref(); // Don't clone this thing man
         spans
     }
 
@@ -873,6 +892,7 @@ impl Buffer {
         &mut self,
         config: LocalSearchConfig,
         current_selection_set: SelectionSet,
+        last_visible_line: u16,
     ) -> anyhow::Result<(bool, SelectionSet)> {
         let before = self.rope.to_string();
         let edit_transaction = match config.mode {
@@ -917,8 +937,13 @@ impl Buffer {
                 )
             }
         };
-        let selection_set =
-            self.apply_edit_transaction(&edit_transaction, current_selection_set, true, true)?;
+        let selection_set = self.apply_edit_transaction(
+            &edit_transaction,
+            current_selection_set,
+            true,
+            true,
+            last_visible_line,
+        )?;
         let after = self.content();
         let modified = before != after;
         Ok((modified, selection_set))
@@ -991,13 +1016,16 @@ impl Buffer {
         Ok(start..end)
     }
 
-    pub(crate) fn redo(&mut self) -> Result<Option<SelectionSet>, anyhow::Error> {
+    pub(crate) fn redo(
+        &mut self,
+        last_visible_line: u16,
+    ) -> Result<Option<SelectionSet>, anyhow::Error> {
         if let Some(history) = self.redo_stack.pop() {
             history
                 .edit_transaction
                 .edits()
                 .into_iter()
-                .try_fold((), |_, edit| self.apply_edit(edit))?;
+                .try_fold((), |_, edit| self.apply_edit(edit, last_visible_line))?;
             self.reparse_tree()?;
             let selection_set = history.old_state.selection_set.clone();
             self.undo_stack.push(history.inverse());
@@ -1007,13 +1035,16 @@ impl Buffer {
         }
     }
 
-    pub(crate) fn undo(&mut self) -> Result<Option<SelectionSet>, anyhow::Error> {
+    pub(crate) fn undo(
+        &mut self,
+        last_visible_line: u16,
+    ) -> Result<Option<SelectionSet>, anyhow::Error> {
         if let Some(history) = self.undo_stack.pop() {
             history
                 .edit_transaction
                 .edits()
                 .into_iter()
-                .try_fold((), |_, edit| self.apply_edit(edit))?;
+                .try_fold((), |_, edit| self.apply_edit(edit, last_visible_line))?;
             self.reparse_tree()?;
             let selection_set = history.old_state.selection_set.clone();
             self.redo_stack.push(history.inverse());
@@ -1113,7 +1144,7 @@ fn f(
                     .tree_sitter_language(),
                 input,
             );
-            buffer.replace(config, SelectionSet::default())?;
+            buffer.replace(config, SelectionSet::default(), 0)?;
             assert_eq!(buffer.content(), expected);
             Ok(())
         }
@@ -1195,7 +1226,7 @@ fn f(
                 buffer.update(" fn main\n() {}");
 
                 // Save the buffer
-                buffer.save(SelectionSet::default(), false).unwrap();
+                buffer.save(SelectionSet::default(), false, 0).unwrap();
 
                 // Expect the output is formatted
                 let saved_content = path.read().unwrap();
@@ -1223,13 +1254,13 @@ fn f(
                 let original = " fn main\n() {}";
                 buffer.update(original);
 
-                buffer.save(SelectionSet::default(), false).unwrap();
+                buffer.save(SelectionSet::default(), false, 0).unwrap();
 
                 // Expect the buffer is formatted
                 assert_ne!(buffer.rope.to_string(), original);
 
                 // Undo the buffer
-                buffer.undo().unwrap();
+                buffer.undo(0).unwrap();
 
                 let content = buffer.rope.to_string();
 
@@ -1245,7 +1276,7 @@ fn f(
                 buffer.update("fn main() {");
 
                 // Save the buffer
-                buffer.save(SelectionSet::default(), false).unwrap();
+                buffer.save(SelectionSet::default(), false, 0).unwrap();
 
                 // Expect the buffer remain unchanged,
                 // because the syntax node is invalid
@@ -1268,7 +1299,7 @@ fn f(
                 // but not to the formatter
                 assert!(!buffer.tree.as_ref().unwrap().root_node().has_error());
 
-                buffer.save(SelectionSet::default(), false).unwrap();
+                buffer.save(SelectionSet::default(), false, 0).unwrap();
 
                 // Expect the buffer remain unchanged
                 assert_eq!(buffer.rope.to_string(), code);
@@ -1291,6 +1322,7 @@ fn f(
                 SelectionSet::default(),
                 true,
                 true,
+                0,
             )?;
 
             // Expect the content to be the same as the 2nd files

--- a/src/components/editor.rs
+++ b/src/components/editor.rs
@@ -174,6 +174,7 @@ impl Component for Editor {
         context: &mut Context,
         dispatch: DispatchEditor,
     ) -> anyhow::Result<Dispatches> {
+        let last_visible_line = self.last_visible_line(context);
         match dispatch {
             #[cfg(test)]
             AlignViewTop => self.align_cursor_to_top(),
@@ -213,7 +214,9 @@ impl Component for Editor {
             EnterSwapMode => self.enter_swap_mode(),
             ReplacePattern { config } => {
                 let selection_set = self.selection_set.clone();
-                let (_, selection_set) = self.buffer_mut().replace(config, selection_set)?;
+                let (_, selection_set) =
+                    self.buffer_mut()
+                        .replace(config, selection_set, last_visible_line)?;
                 return Ok(self
                     .update_selection_set(selection_set, false, context)
                     .chain(self.get_document_did_change_dispatch()));
@@ -1159,11 +1162,13 @@ impl Editor {
         edit_transaction: EditTransaction,
         context: &Context,
     ) -> anyhow::Result<Dispatches> {
+        let last_visible_line = self.last_visible_line(context);
         let new_selection_set = self.buffer.borrow_mut().apply_edit_transaction(
             &edit_transaction,
             self.selection_set.clone(),
             self.mode != Mode::Insert,
             true,
+            last_visible_line,
         )?;
 
         self.set_selection_set(new_selection_set, context);
@@ -1658,6 +1663,7 @@ impl Editor {
                         self.selection_set.clone(),
                         true,
                         true,
+                        self.last_visible_line(context),
                     )
                     .is_err()
                 {
@@ -2316,10 +2322,11 @@ impl Editor {
     }
 
     fn do_save(&mut self, force: bool, context: &Context) -> anyhow::Result<Dispatches> {
-        let Some(path) = self
-            .buffer
-            .borrow_mut()
-            .save(self.selection_set.clone(), force)?
+        let Some(path) = self.buffer.borrow_mut().save(
+            self.selection_set.clone(),
+            force,
+            self.last_visible_line(context),
+        )?
         else {
             return Ok(Default::default());
         };
@@ -2656,10 +2663,11 @@ impl Editor {
     }
 
     fn undo_or_redo(&mut self, undo: bool, context: &Context) -> Result<Dispatches, anyhow::Error> {
+        let last_visible_line = self.last_visible_line(context);
         let selection_set = if undo {
-            self.buffer_mut().undo()?
+            self.buffer_mut().undo(last_visible_line)?
         } else {
-            self.buffer_mut().redo()?
+            self.buffer_mut().redo(last_visible_line)?
         };
 
         Ok(selection_set
@@ -3510,6 +3518,10 @@ impl Editor {
             // Otherwise, replace word under cursor(s) with replacement
             _ => self.try_replace_current_long_word(replacement, context),
         }
+    }
+
+    fn last_visible_line(&self, context: &Context) -> u16 {
+        (self.render_area(context).height + self.scroll_offset).saturating_sub(1)
     }
 }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -150,7 +150,10 @@ impl Context {
         language: shared::language::Language,
         source_code: &str,
     ) -> anyhow::Result<crate::syntax_highlight::HighlightedSpans> {
-        self.highlight_configs.highlight(language, source_code)
+        use std::sync::atomic::AtomicUsize;
+
+        self.highlight_configs
+            .highlight(language, source_code, &AtomicUsize::new(0))
     }
 
     pub(crate) fn current_working_directory(&self) -> &CanonicalizedPath {

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -657,6 +657,19 @@ pub(crate) enum StyleKey {
     UiFocusedTab,
 }
 
+impl StyleKey {
+    #[cfg(test)]
+    pub(crate) fn display(&self) -> String {
+        match self {
+            StyleKey::Syntax(highlight_group) => {
+                let str: &'static str = highlight_group.to_highlight_name().unwrap().into();
+                str.to_string()
+            }
+            _ => format!("{self:?}"),
+        }
+    }
+}
+
 /// TODO: in the future, tab size should be configurable
 pub(crate) fn get_string_width(str: &str) -> usize {
     str.chars().map(get_char_width).sum()

--- a/src/list/grep.rs
+++ b/src/list/grep.rs
@@ -42,7 +42,8 @@ pub(crate) fn replace(
         .run(Box::new(move |path, sender| {
             let path = path.try_into()?;
             let mut buffer = Buffer::from_path(&path, local_search_config.require_tree_sitter())?;
-            let (modified, _) = buffer.replace(local_search_config.clone(), Default::default())?;
+            let (modified, _) =
+                buffer.replace(local_search_config.clone(), Default::default(), 0)?;
             if modified {
                 buffer.save_without_formatting(false)?;
                 sender

--- a/src/syntax_highlight/mod.rs
+++ b/src/syntax_highlight/mod.rs
@@ -1,5 +1,11 @@
-use std::{collections::HashMap, ops::Range, sync::mpsc::Sender, time::Duration};
+use std::{
+    collections::HashMap,
+    ops::Range,
+    sync::{atomic::AtomicUsize, mpsc::Sender},
+    time::Duration,
+};
 
+use itertools::Itertools;
 use tree_sitter_highlight::{HighlightConfiguration, HighlightEvent, Highlighter};
 
 use crate::{
@@ -56,14 +62,27 @@ impl GetHighlightConfig for Language {
 }
 
 pub trait Highlight {
-    fn highlight(&self, source_code: &str) -> anyhow::Result<HighlightedSpans>;
+    fn highlight(
+        &self,
+        source_code: &str,
+        cancellation_flag: &AtomicUsize,
+    ) -> anyhow::Result<HighlightedSpans>;
 }
 
 impl Highlight for HighlightConfiguration {
-    fn highlight(&self, source_code: &str) -> anyhow::Result<HighlightedSpans> {
+    fn highlight(
+        &self,
+        source_code: &str,
+        cancellation_flag: &AtomicUsize,
+    ) -> anyhow::Result<HighlightedSpans> {
         let mut highlighter = Highlighter::new();
 
-        let highlights = highlighter.highlight(self, source_code.as_bytes(), None, |_| None)?;
+        let highlights = highlighter.highlight(
+            self,
+            source_code.as_bytes(),
+            Some(cancellation_flag),
+            |_| None,
+        )?;
 
         let mut highlight = None;
 
@@ -88,6 +107,16 @@ impl Highlight for HighlightConfiguration {
                 }
             }
         }
+
+        debug_assert!(
+            highlighted_spans
+                .iter()
+                .enumerate()
+                .sorted_by_key(|(_, span)| (span.byte_range.start, span.byte_range.end))
+                .map(|(index, _)| index)
+                .collect_vec()
+                == (0..highlighted_spans.len()).collect_vec(),
+        );
         Ok(HighlightedSpans(highlighted_spans))
     }
 }
@@ -95,13 +124,49 @@ impl Highlight for HighlightConfiguration {
 #[derive(Clone, Default, Debug)]
 pub(crate) struct HighlightedSpans(pub Vec<HighlightedSpan>);
 impl HighlightedSpans {
-    pub(crate) fn apply_edit_mut(&mut self, edited_range: &Range<usize>, change: isize) {
-        // let index = self .0 .partition_point(|span| range_intersects(&span.byte_range, edited_range));
+    /// This method only updates the highlight spans within the affected range.
+    /// The affected range starts from the smallest point of edit to the last visible range.
+    ///
+    /// We don't update highlight spans that are out of the visible bounds because:
+    /// 1. That is expensive due to the huge number of highlight spans
+    /// 2. The highlight spans will be recomputed quickly, so there's no point
+    ///    in updating the out-of-bound ones.
+    pub(crate) fn apply_edit_mut(&mut self, affected_range: &Range<usize>, change: isize) {
+        // self.0 .retain_mut(|span| span.apply_edit_mut(affected_range, change));
+        // return;
+        if self.0.is_empty() {
+            return;
+        }
+        let length = self.0.len();
+        // println!( "self.0 = {:#?}", self.0 .iter() .map(|span| span.byte_range.clone()) .collect_vec() );
+        debug_assert!(self
+            .0
+            .is_sorted_by_key(|span| (span.byte_range.start, span.byte_range.end)));
+        let start_index = self
+            .0
+            .partition_point(|span| span.byte_range.end <= affected_range.start);
 
-        // self.0[index..].iter_mut().for_each(|span| { span.byte_range.start = (span.byte_range.start as isize + change) as usize; span.byte_range.end = (span.byte_range.end as isize + change) as usize; });
+        let end_index = self.0.partition_point(|span| {
+            // println!("pp start = {}", span.byte_range.start);
+            // println!("pp end = {}", affected_range.end);
+            span.byte_range.start < affected_range.end
+        });
 
-        self.0
-            .retain_mut(|span| span.apply_edit_mut(edited_range, change))
+        // println!("edited_range = {affected_range:?}");
+        // println!("start_index = {start_index}");
+        // println!("end_index = {end_index}");
+
+        // TODO: this is working correctly, but we need to set an upper bound as the last visible line
+        // so that we only update the necessary spans, not all the spans after start_index
+
+        debug_assert!(start_index < length);
+        debug_assert!(end_index < length);
+        self.0[start_index..end_index.max(start_index)]
+            .iter_mut()
+            .for_each(|span| {
+                span.byte_range.start = (span.byte_range.start as isize + change) as usize;
+                span.byte_range.end = (span.byte_range.end as isize + change) as usize;
+            });
     }
 }
 
@@ -121,10 +186,36 @@ pub(crate) fn start_thread(callback: Sender<AppMessage>) -> Sender<SyntaxHighlig
         }
     }
 
+    use std::cell::RefCell;
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+
     std::thread::spawn(move || {
         let mut highlight_configs = HighlightConfigs::new();
+        // Use Arc<AtomicUsize> which can be cloned
+
+        let last_cancellation_flag = RefCell::new(None::<Arc<AtomicUsize>>);
+
         let debounce = EventDebouncer::new(Duration::from_millis(150), move |Event(request)| {
-            match highlight_configs.highlight(request.language, &request.source_code) {
+            // Cancel the previous operation if it exists
+            // The cancellation is done by unzeroing the atomic usize
+            if let Some(flag) = last_cancellation_flag.borrow_mut().take() {
+                flag.fetch_add(1, Ordering::Relaxed);
+            }
+
+            // Create a new cancellation flag for this operation
+            let new_cancellation_flag = Arc::new(AtomicUsize::new(0));
+
+            // Store a clone of the new flag for potential cancellation in the future
+            *last_cancellation_flag.borrow_mut() = Some(new_cancellation_flag.clone());
+
+            match highlight_configs.highlight(
+                request.language,
+                &request.source_code,
+                &new_cancellation_flag,
+            ) {
                 Ok(highlighted_spans) => {
                     let _ = callback.send(AppMessage::SyntaxHighlightResponse {
                         component_id: request.component_id,
@@ -159,6 +250,7 @@ impl HighlightConfigs {
         &mut self,
         language: Language,
         source_code: &str,
+        cancellation_flag: &AtomicUsize,
     ) -> Result<HighlightedSpans, anyhow::Error> {
         let Some(grammar_id) = language.tree_sitter_grammar_id() else {
             return Ok(Default::default());
@@ -177,6 +269,6 @@ impl HighlightConfigs {
                 }
             }
         };
-        config.highlight(source_code)
+        config.highlight(source_code, cancellation_flag)
     }
 }


### PR DESCRIPTION
# Benchmark

## Previous
![old-flamegraph](https://github.com/user-attachments/assets/9b5e39e4-f0a1-4a0c-9bec-314a6a004f86)


## Baseline (no updating highlight spans)
![baseline-flamegraph](https://github.com/user-attachments/assets/2a5379bf-5879-4345-a004-efc9ccae4a30)


## New (only update visible highlight spans)
![new-flamegraph](https://github.com/user-attachments/assets/cf751693-215a-4d6e-9cfa-a5db48b8f7f8)
