### PR TITLE
feat(buffer/highlighting): introduce batch IDs to prevent UI flicker

### DIFF
--- a/src/components/editor.rs
+++ b/src/components/editor.rs
@@ -1183,6 +1183,7 @@ impl Editor {
     pub(crate) fn get_document_did_change_dispatch(&mut self) -> Dispatches {
         [Dispatch::DocumentDidChange {
             component_id: self.id(),
+            batch_id: self.buffer().batch_id().clone(),
             path: self.buffer().path(),
             content: self.buffer().rope().to_string(),
             language: self.buffer().language(),
@@ -2706,7 +2707,7 @@ impl Editor {
         let mut buffer = self.buffer_mut();
         if let Some(language) = buffer.language() {
             let highlighted_spans = context.highlight(language, &source_code)?;
-            buffer.update_highlighted_spans(highlighted_spans);
+            buffer.update_highlighted_spans(Default::default(), highlighted_spans);
         }
         Ok(())
     }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1,5 +1,6 @@
 use crate::context::Context;
 use crate::quickfix_list::QuickfixList;
+use crate::syntax_highlight::SyntaxHighlightRequestBatchId;
 use crate::ui_tree::{ComponentKind, KindedComponent, UiTree};
 use crate::{
     app::{Dimension, Dispatches},
@@ -291,6 +292,7 @@ impl Layout {
     pub(crate) fn update_highlighted_spans(
         &self,
         component_id: ComponentId,
+        batch_id: SyntaxHighlightRequestBatchId,
         highlighted_spans: crate::syntax_highlight::HighlightedSpans,
     ) -> Result<(), anyhow::Error> {
         let component = self
@@ -304,7 +306,7 @@ impl Layout {
         component
             .editor_mut()
             .buffer_mut()
-            .update_highlighted_spans(highlighted_spans);
+            .update_highlighted_spans(batch_id, highlighted_spans);
 
         Ok(())
     }


### PR DESCRIPTION
## Description
Implements a new batch ID system for syntax highlighting requests to track and validate the recency of updates. Only applies highlightings from the most recent batch, discarding outdated updates to eliminate visual flickering during rapid edits with concurrent syntax highlighting operations.


## Comparison
### Before (flickering during edits)

https://github.com/user-attachments/assets/10eeefb5-5a48-430f-ab01-f875b228f393


### After (No flickering)
https://github.com/user-attachments/assets/7244208d-b9ca-4f0a-b66a-ce87e2cf6d42


