### PR TITLE
Fix grammar command

### DIFF
--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -70,5 +70,5 @@ nix profile install github:ki-editor/ki-editor
 2. Build tree-sitter grammars:
 
 ```sh
-ki grammar fetch && ki grammar build
+ki @ grammar fetch && ki @ grammar build
 ```


### PR DESCRIPTION
Personally I used
```sh
nix shell github:ki-editor/ki-editor nixpkgs#clang -c sh -c 'ki @ grammar fetch && ki @ grammar build'
```
to build the grammars ((the zig???) expects to see `c++`), after which 
```sh
nix shell github:ki-editor/ki-editor
```
is enough to have the editor available.