### PR TITLE
perf(selection_mode): replace `iter` with `get_current_selection_by_cursor`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: 1.80.0
+          toolchain: 1.83.0
           components: rustfmt, clippy
       - uses: extractions/setup-just@v1
       - name: Just

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1068,9 +1068,7 @@ impl Buffer {
 
     pub(crate) fn line_to_char_range(&self, line: usize) -> anyhow::Result<CharIndexRange> {
         let start = self.line_to_char(line)?;
-        println!("line = {line} line_to_char_range start = {start:?}");
         let end = self.line_to_char(line + 1)?;
-        println!("line_to_char_range end = {end:?}");
         Ok((start..end).into())
     }
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -9,7 +9,7 @@ use crate::{
     context::{LocalSearchConfig, LocalSearchConfigMode},
     edit::{Action, ActionGroup, Edit, EditTransaction},
     position::Position,
-    selection::{CharIndex, Selection, SelectionSet},
+    selection::{CharIndex, SelectionSet},
     selection_mode::{AstGrep, ByteRange},
     syntax_highlight::{HighlightedSpan, HighlightedSpans},
     utils::find_previous,
@@ -420,13 +420,12 @@ impl Buffer {
 
     pub(crate) fn get_current_node<'a>(
         &'a self,
-        selection: &Selection,
+        range: CharIndexRange,
         get_largest_end: bool,
     ) -> anyhow::Result<Option<Node<'a>>> {
         let Some(tree) = self.tree.as_ref() else {
             return Ok(None);
         };
-        let range = selection.range();
         let start = self.char_to_byte(range.start)?;
         let (start, end) = if get_largest_end {
             (start, start + 1)
@@ -1063,6 +1062,16 @@ impl Buffer {
         } else {
             Ok(None)
         }
+    }
+
+    pub(crate) fn line_to_char_range(&self, line: usize) -> anyhow::Result<CharIndexRange> {
+        let start = self.line_to_char(line)?;
+        let end = self.line_to_char(line + 1)? - (1);
+        Ok((start..end).into())
+    }
+
+    pub(crate) fn char(&self, cursor_char_index: CharIndex) -> char {
+        self.rope.char(cursor_char_index.0)
     }
 }
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,6 +1,7 @@
 use crate::history::History;
 use crate::lsp::diagnostic::Diagnostic;
 use crate::quickfix_list::QuickfixListItem;
+use crate::selection::Selection;
 use crate::selection_mode::naming_convention_agnostic::NamingConventionAgnostic;
 use crate::syntax_highlight::SyntaxHighlightRequestBatchId;
 use crate::{
@@ -420,12 +421,13 @@ impl Buffer {
 
     pub(crate) fn get_current_node<'a>(
         &'a self,
-        range: CharIndexRange,
+        selection: &Selection,
         get_largest_end: bool,
     ) -> anyhow::Result<Option<Node<'a>>> {
         let Some(tree) = self.tree.as_ref() else {
             return Ok(None);
         };
+        let range = selection.range();
         let start = self.char_to_byte(range.start)?;
         let (start, end) = if get_largest_end {
             (start, start + 1)
@@ -1066,7 +1068,9 @@ impl Buffer {
 
     pub(crate) fn line_to_char_range(&self, line: usize) -> anyhow::Result<CharIndexRange> {
         let start = self.line_to_char(line)?;
+        println!("line = {line} line_to_char_range start = {start:?}");
         let end = self.line_to_char(line + 1)?;
+        println!("line_to_char_range end = {end:?}");
         Ok((start..end).into())
     }
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1066,7 +1066,7 @@ impl Buffer {
 
     pub(crate) fn line_to_char_range(&self, line: usize) -> anyhow::Result<CharIndexRange> {
         let start = self.line_to_char(line)?;
-        let end = self.line_to_char(line + 1)? - (1);
+        let end = self.line_to_char(line + 1)?;
         Ok((start..end).into())
     }
 

--- a/src/components/editor.rs
+++ b/src/components/editor.rs
@@ -786,7 +786,7 @@ impl Editor {
             .chain(self.hidden_parent_line_ranges()?)
             .collect_vec();
         let jumps = object.jumps(
-            selection_mode::SelectionModeParams {
+            &selection_mode::SelectionModeParams {
                 buffer: &self.buffer(),
                 current_selection: selection,
                 cursor_direction: &self.cursor_direction,
@@ -1858,7 +1858,7 @@ impl Editor {
                         };
                         let first = selection_mode.first(&params).ok()??.range();
                         // Find the before current selection
-                        let before_current = selection_mode.left(params).ok()??.range();
+                        let before_current = selection_mode.left(&params).ok()??.range();
                         let first_range = current_selection.range();
                         let second_range: CharIndexRange =
                             (first.start()..before_current.end()).into();
@@ -1907,7 +1907,7 @@ impl Editor {
                         // Select from the first until before current
                         let last = selection_mode.last(&params).ok()??.range();
                         // Find the before current selection
-                        let after_current = selection_mode.right(params).ok()??.range();
+                        let after_current = selection_mode.right(&params).ok()??.range();
                         let first_range = current_selection.range();
                         let second_range: CharIndexRange =
                             (after_current.start()..last.end()).into();

--- a/src/components/editor.rs
+++ b/src/components/editor.rs
@@ -483,6 +483,15 @@ pub(crate) enum IfCurrentNotFound {
     LookForward,
     LookBackward,
 }
+impl IfCurrentNotFound {
+    pub(crate) fn inverse(&self) -> IfCurrentNotFound {
+        use IfCurrentNotFound::*;
+        match self {
+            LookForward => LookBackward,
+            LookBackward => LookForward,
+        }
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Movement {
@@ -1847,7 +1856,7 @@ impl Editor {
                             current_selection,
                             cursor_direction: &self.cursor_direction,
                         };
-                        let first = selection_mode.first(params.clone()).ok()??.range();
+                        let first = selection_mode.first(&params).ok()??.range();
                         // Find the before current selection
                         let before_current = selection_mode.left(params).ok()??.range();
                         let first_range = current_selection.range();
@@ -1896,7 +1905,7 @@ impl Editor {
                         };
 
                         // Select from the first until before current
-                        let last = selection_mode.last(params.clone()).ok()??.range();
+                        let last = selection_mode.last(&params).ok()??.range();
                         // Find the before current selection
                         let after_current = selection_mode.right(params).ok()??.range();
                         let first_range = current_selection.range();

--- a/src/components/editor.rs
+++ b/src/components/editor.rs
@@ -1654,7 +1654,8 @@ impl Editor {
         loop {
             let edit_transaction =
                 get_actual_edit_transaction(&current_selection, &next_selection)?;
-            let current_node = buffer.get_current_node(&current_selection, false)?;
+            let current_node =
+                buffer.get_current_node(current_selection.extended_range(), false)?;
 
             let new_buffer = {
                 let mut new_buffer = self.buffer.borrow().clone();
@@ -1679,7 +1680,7 @@ impl Editor {
                 .selections()
                 .into_iter()
                 .map(|selection| -> anyhow::Result<_> {
-                    new_buffer.get_current_node(selection, false)
+                    new_buffer.get_current_node(selection.extended_range(), false)
                 })
                 .collect::<Result<Vec<_>, _>>()?;
 
@@ -3057,7 +3058,10 @@ impl Editor {
 
     fn show_current_tree_sitter_node_sexp(&self) -> Result<Dispatches, anyhow::Error> {
         let buffer = self.buffer();
-        let node = buffer.get_current_node(self.selection_set.primary_selection(), false)?;
+        let node = buffer.get_current_node(
+            self.selection_set.primary_selection().extended_range(),
+            false,
+        )?;
         let info = node
             .map(|node| node.to_sexp())
             .unwrap_or("[No node found]".to_string());

--- a/src/components/render_editor.rs
+++ b/src/components/render_editor.rs
@@ -835,13 +835,12 @@ impl Editor {
         selection: &Selection,
         context: &Context,
     ) -> anyhow::Result<Vec<ByteRange>> {
-        Ok(self
-            .get_selection_mode_trait_object(selection, true, context)?
+        self.get_selection_mode_trait_object(selection, true, context)?
             .revealed_selections(&selection_mode::SelectionModeParams {
                 buffer: &self.buffer(),
                 current_selection: selection,
                 cursor_direction: &self.cursor_direction,
-            })?)
+            })
     }
 }
 

--- a/src/components/render_editor.rs
+++ b/src/components/render_editor.rs
@@ -837,12 +837,11 @@ impl Editor {
     ) -> anyhow::Result<Vec<ByteRange>> {
         Ok(self
             .get_selection_mode_trait_object(selection, true, context)?
-            .iter_revealed(selection_mode::SelectionModeParams {
+            .revealed_selections(selection_mode::SelectionModeParams {
                 buffer: &self.buffer(),
                 current_selection: selection,
                 cursor_direction: &self.cursor_direction,
-            })?
-            .collect())
+            })?)
     }
 }
 

--- a/src/components/render_editor.rs
+++ b/src/components/render_editor.rs
@@ -820,7 +820,7 @@ impl Editor {
             return Ok(Vec::new());
         }
 
-        object.selections_in_line_number_range(
+        object.selections_in_line_number_ranges(
             &selection_mode::SelectionModeParams {
                 buffer: &self.buffer(),
                 current_selection: selection,
@@ -837,7 +837,7 @@ impl Editor {
     ) -> anyhow::Result<Vec<ByteRange>> {
         Ok(self
             .get_selection_mode_trait_object(selection, true, context)?
-            .revealed_selections(selection_mode::SelectionModeParams {
+            .revealed_selections(&selection_mode::SelectionModeParams {
                 buffer: &self.buffer(),
                 current_selection: selection,
                 cursor_direction: &self.cursor_direction,

--- a/src/components/suggestive_editor.rs
+++ b/src/components/suggestive_editor.rs
@@ -291,6 +291,7 @@ mod test_suggestive_editor {
     use crate::lsp::completion::{CompletionItemEdit, PositionalEdit};
     use crate::lsp::documentation::Documentation;
     use crate::position::Position;
+    use crate::selection::SelectionMode;
     use crate::{
         app::Dispatch,
         buffer::{Buffer, BufferOwner},
@@ -929,6 +930,7 @@ mod test_suggestive_editor {
                 // Expect the completion dropdown to not be opened,
                 // since the editor is not in insert mode
                 Expect(CompletionDropdownIsOpen(false)),
+                Expect(CurrentSelectionMode(SelectionMode::Line)),
                 Editor(MoveSelection(crate::components::editor::Movement::Right)),
                 Expect(CompletionDropdownIsOpen(false)),
             ])

--- a/src/components/test_editor.rs
+++ b/src/components/test_editor.rs
@@ -2976,12 +2976,14 @@ Editor(MatchLiteral(amos.foo())),
                 Editor(MatchLiteral("Editor".to_string())),
                 Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Line)),
                 App(HandleKeyEvents(keys!("Q ( enter").to_vec())),
+                Expect(CurrentSelectedTexts(&["("])),
                 Editor(SetSelectionMode(
                     IfCurrentNotFound::LookForward,
                     Token {
                         skip_symbols: false,
                     },
                 )),
+                Expect(CurrentSelectedTexts(&["("])),
                 Editor(MoveSelection(Left)),
                 Expect(CurrentSelectedTexts(&["to_string"])),
             ])

--- a/src/components/test_editor.rs
+++ b/src/components/test_editor.rs
@@ -1580,10 +1580,10 @@ fn highlight_and_jump() -> anyhow::Result<()> {
             Editor(ShowJumps {
                 use_current_selection_mode: false,
             }),
-            // Expect the jump to be the first character of each word (except the current word 'lives')
+            // Expect the jump to be the first character of each word
             // Note 'y' and 'd' are excluded because they are out of view,
             // since the viewbox has only height of 1
-            Expect(JumpChars(&['w', 'o', 's', 's', '?'])),
+            Expect(JumpChars(&['w', 'l', 'o', 's', 's', '?'])),
             App(HandleKeyEvent(key!("s"))),
             App(HandleKeyEvent(key!("k"))),
             Expect(CurrentSelectedTexts(&["lives on sea shore"])),
@@ -3665,7 +3665,7 @@ fn select_current_line_when_cursor_is_at_last_space_of_current_line() -> anyhow:
             Editor(MoveSelection(Right)),
             Expect(CurrentSelectedTexts(&[" "])),
             Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Line)),
-            Expect(CurrentSelectedTexts(&["abc "])),
+            Expect(CurrentSelectedTexts(&["abc"])),
         ])
     })
 }
@@ -4504,6 +4504,66 @@ foo bar
             Expect(CurrentSelectedTexts(&["foo"])),
             Editor(MoveSelection(Down)),
             Expect(CurrentSelectedTexts(&["spam"])),
+        ])
+    })
+}
+
+#[test]
+fn move_line_down() -> anyhow::Result<()> {
+    execute_test(|s| {
+        Box::new([
+            App(OpenFile {
+                path: s.main_rs(),
+                owner: BufferOwner::User,
+                focus: true,
+            }),
+            Editor(SetContent(
+                "
+foo bar
+    spam
+    baz
+"
+                .trim()
+                .to_string(),
+            )),
+            Editor(SetSelectionMode(
+                IfCurrentNotFound::LookForward,
+                SelectionMode::Line,
+            )),
+            Expect(CurrentSelectedTexts(&["foo bar"])),
+            Editor(MoveSelection(Down)),
+            Expect(CurrentSelectedTexts(&["spam"])),
+        ])
+    })
+}
+
+#[test]
+fn move_line_up() -> anyhow::Result<()> {
+    execute_test(|s| {
+        Box::new([
+            App(OpenFile {
+                path: s.main_rs(),
+                owner: BufferOwner::User,
+                focus: true,
+            }),
+            Editor(SetContent(
+                "
+    spam
+    baz
+foo bar
+hello
+"
+                .trim()
+                .to_string(),
+            )),
+            Editor(MatchLiteral("foo bar".to_string())),
+            Editor(SetSelectionMode(
+                IfCurrentNotFound::LookForward,
+                SelectionMode::Line,
+            )),
+            Expect(CurrentSelectedTexts(&["foo bar"])),
+            Editor(MoveSelection(Up)),
+            Expect(CurrentSelectedTexts(&["baz"])),
         ])
     })
 }

--- a/src/components/test_editor.rs
+++ b/src/components/test_editor.rs
@@ -1540,6 +1540,7 @@ fn main() {
                 .trim(),
             )),
             Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Line)),
+            Expect(CurrentSelectedTexts(&["beta()"])),
             Editor(ShowJumps {
                 use_current_selection_mode: true,
             }),
@@ -1574,14 +1575,15 @@ fn highlight_and_jump() -> anyhow::Result<()> {
                 },
             )),
             Editor(MoveSelection(Right)),
+            Expect(CurrentSelectedTexts(&["lives"])),
             Editor(EnableSelectionExtension),
             Editor(ShowJumps {
                 use_current_selection_mode: false,
             }),
-            // Expect the jump to be the first character of each word
+            // Expect the jump to be the first character of each word (except the current word 'lives')
             // Note 'y' and 'd' are excluded because they are out of view,
             // since the viewbox has only height of 1
-            Expect(JumpChars(&['w', 'l', 'o', 's', 's', '?'])),
+            Expect(JumpChars(&['w', 'o', 's', 's', '?'])),
             App(HandleKeyEvent(key!("s"))),
             App(HandleKeyEvent(key!("k"))),
             Expect(CurrentSelectedTexts(&["lives on sea shore"])),
@@ -1604,15 +1606,15 @@ fn jump_all_selection_start_with_same_char() -> anyhow::Result<()> {
                 width: 100,
                 height: 1,
             })),
-            Editor(ShowJumps {
-                use_current_selection_mode: false,
-            }),
             Editor(SetSelectionMode(
                 IfCurrentNotFound::LookForward,
                 Word {
                     skip_symbols: false,
                 },
             )),
+            Editor(ShowJumps {
+                use_current_selection_mode: false,
+            }),
             // Expect the jump to NOT be the first character of each word
             // Since, the first character of each selection are the same, which is 'w'
             Expect(JumpChars(&['d', 'k', 's', 'l'])),

--- a/src/components/test_editor.rs
+++ b/src/components/test_editor.rs
@@ -4440,3 +4440,66 @@ fn multicursor_insertion_at_same_range_is_not_counted_as_intersected_edits() -> 
         ])
     })
 }
+
+#[test]
+fn movement_up() -> anyhow::Result<()> {
+    execute_test(|s| {
+        Box::new([
+            App(OpenFile {
+                path: s.main_rs(),
+                owner: BufferOwner::User,
+                focus: true,
+            }),
+            Editor(SetContent(
+                "
+foo bar
+    spam
+    baz
+tim
+"
+                .to_string(),
+            )),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Line)),
+            Editor(MoveSelection(Last)),
+            Expect(CurrentSelectedTexts(&["tim"])),
+            Editor(SetSelectionMode(
+                IfCurrentNotFound::LookForward,
+                Token {
+                    skip_symbols: false,
+                },
+            )),
+            Editor(MoveSelection(Up)),
+            Expect(CurrentSelectedTexts(&["baz"])),
+        ])
+    })
+}
+
+#[test]
+fn movement_down() -> anyhow::Result<()> {
+    execute_test(|s| {
+        Box::new([
+            App(OpenFile {
+                path: s.main_rs(),
+                owner: BufferOwner::User,
+                focus: true,
+            }),
+            Editor(SetContent(
+                "
+foo bar
+    spam
+    baz
+"
+                .to_string(),
+            )),
+            Editor(SetSelectionMode(
+                IfCurrentNotFound::LookForward,
+                Token {
+                    skip_symbols: false,
+                },
+            )),
+            Expect(CurrentSelectedTexts(&["foo"])),
+            Editor(MoveSelection(Down)),
+            Expect(CurrentSelectedTexts(&["spam"])),
+        ])
+    })
+}

--- a/src/generate_recipes.rs
+++ b/src/generate_recipes.rs
@@ -19,14 +19,14 @@ fn generate_recipes() -> anyhow::Result<()> {
         })
     });
     recipe_groups
-        .into_par_iter()
+        .into_iter()
         .filter(|recipe_group| {
             !contains_only_recipes || recipe_group.recipes.iter().any(|recipe| recipe.only)
         })
         .map(|recipe_group| -> anyhow::Result<_> {
             let recipes = recipe_group.recipes;
             let (errors, recipes_output): (Vec<_>, Vec<_>) = recipes
-                .into_par_iter()
+                .into_iter()
                 .filter(|recipe| !contains_only_recipes || recipe.only)
                 .map(|recipe| -> Result<RecipeOutput, String> {
                     let run = || {

--- a/src/generate_recipes.rs
+++ b/src/generate_recipes.rs
@@ -19,14 +19,14 @@ fn generate_recipes() -> anyhow::Result<()> {
         })
     });
     recipe_groups
-        .into_iter()
+        .into_par_iter()
         .filter(|recipe_group| {
             !contains_only_recipes || recipe_group.recipes.iter().any(|recipe| recipe.only)
         })
         .map(|recipe_group| -> anyhow::Result<_> {
             let recipes = recipe_group.recipes;
             let (errors, recipes_output): (Vec<_>, Vec<_>) = recipes
-                .into_iter()
+                .into_par_iter()
                 .filter(|recipe| !contains_only_recipes || recipe.only)
                 .map(|recipe| -> Result<RecipeOutput, String> {
                     let run = || {

--- a/src/recipes.rs
+++ b/src/recipes.rs
@@ -1595,7 +1595,7 @@ head
                 expectations: Box::new([CurrentSelectedTexts(&["foo"])]),
                 terminal_height: Some(9),
                 similar_vim_combos: &[],
-                only: false,
+                only: true,
             },
             Recipe {
                 description: "Reveal Sibling Nodes",

--- a/src/recipes.rs
+++ b/src/recipes.rs
@@ -1595,7 +1595,7 @@ head
                 expectations: Box::new([CurrentSelectedTexts(&["foo"])]),
                 terminal_height: Some(9),
                 similar_vim_combos: &[],
-                only: true,
+                only: false,
             },
             Recipe {
                 description: "Reveal Sibling Nodes",

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -1,9 +1,6 @@
 use itertools::Itertools;
 use nonempty::NonEmpty;
-use std::{
-    ops::{Add, Sub},
-    rc::Rc,
-};
+use std::ops::{Add, Sub};
 
 use crate::{
     buffer::Buffer,

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -16,7 +16,7 @@ use crate::{
     non_empty_extensions::{NonEmptyTryCollectOption, NonEmptyTryCollectResult},
     position::Position,
     quickfix_list::DiagnosticSeverityRange,
-    selection_mode::{self, ApplyMovementResult, PositionBased, SelectionModeParams, VectorBased},
+    selection_mode::{self, ApplyMovementResult, IterBased, PositionBased, SelectionModeParams},
 };
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -198,7 +198,7 @@ impl SelectionSet {
                     .ok()?;
 
                 let iter = object
-                    .all_selections(SelectionModeParams {
+                    .all_selections(&SelectionModeParams {
                         buffer,
                         current_selection: selection,
                         cursor_direction,
@@ -498,35 +498,35 @@ impl SelectionMode {
                     current_column,
                 )))
             }
-            SelectionMode::Custom => Box::new(PositionBased(selection_mode::Custom::new(
+            SelectionMode::Custom => Box::new(IterBased(selection_mode::Custom::new(
                 current_selection.clone(),
             ))),
             SelectionMode::Find { search } => match search.mode {
-                LocalSearchConfigMode::Regex(regex) => Box::new(VectorBased(
+                LocalSearchConfigMode::Regex(regex) => Box::new(IterBased(
                     selection_mode::Regex::from_config(buffer, &search.search, regex)?,
                 )),
-                LocalSearchConfigMode::AstGrep => Box::new(VectorBased(
+                LocalSearchConfigMode::AstGrep => Box::new(IterBased(
                     selection_mode::AstGrep::new(buffer, &search.search)?,
                 )),
-                LocalSearchConfigMode::NamingConventionAgnostic => Box::new(VectorBased(
+                LocalSearchConfigMode::NamingConventionAgnostic => Box::new(IterBased(
                     selection_mode::NamingConventionAgnostic::new(search.search.clone()),
                 )),
             },
             SelectionMode::SyntaxNode => {
-                Box::new(PositionBased(selection_mode::SyntaxNode { coarse: true }))
+                Box::new(IterBased(selection_mode::SyntaxNode { coarse: true }))
             }
             SelectionMode::SyntaxNodeFine => {
-                Box::new(PositionBased(selection_mode::SyntaxNode { coarse: false }))
+                Box::new(IterBased(selection_mode::SyntaxNode { coarse: false }))
             }
-            SelectionMode::Diagnostic(severity) => Box::new(VectorBased(
+            SelectionMode::Diagnostic(severity) => Box::new(IterBased(
                 selection_mode::Diagnostic::new(*severity, params),
             )),
-            SelectionMode::GitHunk(diff_mode) => Box::new(VectorBased(
-                selection_mode::GitHunk::new(diff_mode, buffer, context)?,
-            )),
-            SelectionMode::Mark => Box::new(VectorBased(selection_mode::Mark::new(buffer)?)),
+            SelectionMode::GitHunk(diff_mode) => Box::new(IterBased(selection_mode::GitHunk::new(
+                diff_mode, buffer, context,
+            )?)),
+            SelectionMode::Mark => Box::new(IterBased(selection_mode::Mark)),
             SelectionMode::LocalQuickfix { .. } => {
-                Box::new(VectorBased(selection_mode::LocalQuickfix::new(params)))
+                Box::new(IterBased(selection_mode::LocalQuickfix::new(params)))
             }
         })
     }

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -202,6 +202,7 @@ impl SelectionSet {
                     })
                     .ok()?;
                 let result = iter
+                    .into_iter()
                     .filter_map(|range| -> Option<Selection> {
                         range.to_selection(buffer, &self.selections.head).ok()
                     })
@@ -482,7 +483,7 @@ impl SelectionMode {
                 Box::new(selection_mode::Word::new(buffer, *skip_symbols)?)
             }
             SelectionMode::Token { skip_symbols } => {
-                Box::new(selection_mode::Token::new(buffer, *skip_symbols)?)
+                Box::new(selection_mode::Token::new(*skip_symbols)?)
             }
             SelectionMode::Line => Box::new(selection_mode::LineTrimmed),
             SelectionMode::LineFull => Box::new(selection_mode::LineFull),
@@ -739,6 +740,16 @@ impl Selection {
             self.range
         };
         self.set_range(range).set_initial_range(None)
+    }
+
+    pub(crate) fn update_with_byte_range(
+        self,
+        buffer: &Buffer,
+        byte_range: selection_mode::ByteRange,
+    ) -> anyhow::Result<Selection> {
+        Ok(self
+            .set_info(byte_range.info())
+            .set_range(buffer.byte_range_to_char_index_range(byte_range.range())?))
     }
 }
 

--- a/src/selection_mode/ast_grep.rs
+++ b/src/selection_mode/ast_grep.rs
@@ -1,6 +1,6 @@
 use ast_grep_core::{language::TSLanguage, NodeMatch, StrDoc};
 
-use super::{ByteRange, IterBasedSelectionMode, SelectionMode};
+use super::{ByteRange, IterBasedSelectionMode};
 
 pub(crate) struct AstGrep {
     pattern: ast_grep_core::matcher::Pattern<TSLanguage>,

--- a/src/selection_mode/ast_grep.rs
+++ b/src/selection_mode/ast_grep.rs
@@ -43,6 +43,7 @@ impl SelectionMode for AstGrep {
         &self,
         buffer: &crate::buffer::Buffer,
         cursor_char_index: crate::selection::CharIndex,
+        if_current_not_found: crate::components::editor::IfCurrentNotFound,
     ) -> anyhow::Result<Option<ByteRange>> {
         let cursor_byte = buffer.char_to_byte(cursor_char_index)?;
         Ok(self

--- a/src/selection_mode/character.rs
+++ b/src/selection_mode/character.rs
@@ -1,6 +1,9 @@
 use ropey::Rope;
 
-use crate::selection::{CharIndex, Selection};
+use crate::{
+    components::editor::IfCurrentNotFound,
+    selection::{CharIndex, Selection},
+};
 
 use super::{word::SelectionPosition, ByteRange, SelectionMode, SelectionModeParams, Word};
 
@@ -17,14 +20,14 @@ impl Character {
 impl SelectionMode for Character {
     fn first(
         &self,
-        params: super::SelectionModeParams,
+        params: &super::SelectionModeParams,
     ) -> anyhow::Result<Option<crate::selection::Selection>> {
         get_char(params, SelectionPosition::First)
     }
 
     fn last(
         &self,
-        params: super::SelectionModeParams,
+        params: &super::SelectionModeParams,
     ) -> anyhow::Result<Option<crate::selection::Selection>> {
         get_char(params, SelectionPosition::Last)
     }
@@ -33,6 +36,7 @@ impl SelectionMode for Character {
         &self,
         buffer: &crate::buffer::Buffer,
         cursor_char_index: crate::selection::CharIndex,
+        _: IfCurrentNotFound,
     ) -> anyhow::Result<Option<ByteRange>> {
         let cursor_byte = buffer.char_to_byte(cursor_char_index)?;
         Ok(Some(ByteRange::new(cursor_byte..cursor_byte + 1)))
@@ -98,10 +102,10 @@ impl Character {
 }
 
 fn get_char(
-    params: super::SelectionModeParams,
+    params: &super::SelectionModeParams,
     position: SelectionPosition,
 ) -> anyhow::Result<Option<crate::selection::Selection>> {
-    if let Some(current_word) = Word::new(params.buffer, false)?.current(
+    if let Some(current_word) = Word::new(false)?.current(
         params.clone(),
         crate::components::editor::IfCurrentNotFound::LookForward,
     )? {

--- a/src/selection_mode/character.rs
+++ b/src/selection_mode/character.rs
@@ -175,9 +175,9 @@ gam
             let start = buffer.line_to_char(selected_line).unwrap();
             let selection_mode = Character::new(4);
             let method = if move_up {
-                Character::up_impl
+                Character::up
             } else {
-                Character::down_impl
+                Character::down
             };
             let result = method(
                 &selection_mode,

--- a/src/selection_mode/character.rs
+++ b/src/selection_mode/character.rs
@@ -44,6 +44,14 @@ impl PositionBasedSelectionMode for Character {
         let cursor_byte = buffer.char_to_byte(cursor_char_index)?;
         Ok(Some(ByteRange::new(cursor_byte..cursor_byte + 1)))
     }
+
+    fn vertical_movement(
+        &self,
+        params: &SelectionModeParams,
+        is_up: bool,
+    ) -> anyhow::Result<Option<Selection>> {
+        self.move_vertically(params, is_up)
+    }
 }
 
 impl Character {
@@ -78,13 +86,13 @@ fn line_len_without_new_line(current_line: &ropey::Rope) -> usize {
 impl Character {
     fn move_vertically(
         &self,
-        go_up: bool,
         super::SelectionModeParams {
             buffer,
             current_selection,
             cursor_direction,
             ..
-        }: super::SelectionModeParams,
+        }: &super::SelectionModeParams,
+        go_up: bool,
     ) -> anyhow::Result<Option<Selection>> {
         let current_char_index = current_selection.to_char_index(cursor_direction);
         let current_line = buffer.char_to_line(current_char_index)?;
@@ -142,7 +150,16 @@ mod test_character {
             &PositionBased(Character::new(0)),
             &buffer,
             selection,
-            &[(0..1, "f"), (1..2, "o"), (2..3, "o")],
+            &[
+                (0..1, "f"),
+                (1..2, "o"),
+                (2..3, "o"),
+                (3..4, "\n"),
+                (4..5, "s"),
+                (5..6, "p"),
+                (6..7, "a"),
+                (7..8, "m"),
+            ],
         );
 
         // Second line
@@ -152,7 +169,16 @@ mod test_character {
             &PositionBased(Character::new(0)),
             &buffer,
             selection,
-            &[(4..5, "s"), (5..6, "p"), (6..7, "a"), (7..8, "m")],
+            &[
+                (0..1, "f"),
+                (1..2, "o"),
+                (2..3, "o"),
+                (3..4, "\n"),
+                (4..5, "s"),
+                (5..6, "p"),
+                (6..7, "a"),
+                (7..8, "m"),
+            ],
         );
         Ok(())
     }

--- a/src/selection_mode/character.rs
+++ b/src/selection_mode/character.rs
@@ -1,9 +1,6 @@
 use ropey::Rope;
 
-use crate::{
-    components::editor::IfCurrentNotFound,
-    selection::{CharIndex, Selection},
-};
+use crate::{components::editor::IfCurrentNotFound, selection::Selection};
 
 use super::{
     word::SelectionPosition, ByteRange, PositionBased, PositionBasedSelectionMode, SelectionMode,
@@ -51,20 +48,6 @@ impl PositionBasedSelectionMode for Character {
         is_up: bool,
     ) -> anyhow::Result<Option<Selection>> {
         self.move_vertically(params, is_up)
-    }
-}
-
-impl Character {
-    fn make_selection(params: super::SelectionModeParams, char_index: CharIndex) -> Selection {
-        let start = char_index.clamp(
-            CharIndex(0),
-            CharIndex(params.buffer.len_chars().saturating_sub(1)),
-        );
-        let end = start + 1;
-        params
-            .current_selection
-            .clone()
-            .set_range((start..end).into())
     }
 }
 
@@ -117,7 +100,7 @@ fn get_char(
     position: SelectionPosition,
 ) -> anyhow::Result<Option<crate::selection::Selection>> {
     if let Some(current_word) = PositionBased(Word::new(false)).current(
-        params.clone(),
+        params,
         crate::components::editor::IfCurrentNotFound::LookForward,
     )? {
         let start = match position {

--- a/src/selection_mode/custom.rs
+++ b/src/selection_mode/custom.rs
@@ -1,6 +1,6 @@
 use crate::selection::Selection;
 
-use super::{IterBasedSelectionMode, SelectionMode};
+use super::IterBasedSelectionMode;
 
 pub(crate) struct Custom {
     current_selection: Selection,

--- a/src/selection_mode/custom.rs
+++ b/src/selection_mode/custom.rs
@@ -17,6 +17,7 @@ impl SelectionMode for Custom {
         &self,
         buffer: &crate::buffer::Buffer,
         _: crate::selection::CharIndex,
+        _: crate::components::editor::IfCurrentNotFound,
     ) -> anyhow::Result<Option<ByteRange>> {
         let range = self.current_selection.extended_range();
         let byte_range = buffer.char_index_range_to_byte_range(range)?;

--- a/src/selection_mode/custom.rs
+++ b/src/selection_mode/custom.rs
@@ -1,6 +1,6 @@
 use crate::selection::Selection;
 
-use super::{ByteRange, SelectionMode};
+use super::{ByteRange, PositionBased, PositionBasedSelectionMode};
 
 pub(crate) struct Custom {
     current_selection: Selection,
@@ -12,7 +12,7 @@ impl Custom {
     }
 }
 
-impl SelectionMode for Custom {
+impl PositionBasedSelectionMode for Custom {
     fn get_current_selection_by_cursor(
         &self,
         buffer: &crate::buffer::Buffer,

--- a/src/selection_mode/custom.rs
+++ b/src/selection_mode/custom.rs
@@ -1,6 +1,6 @@
 use crate::selection::Selection;
 
-use super::SelectionMode;
+use super::{ByteRange, SelectionMode};
 
 pub(crate) struct Custom {
     current_selection: Selection,
@@ -13,14 +13,15 @@ impl Custom {
 }
 
 impl SelectionMode for Custom {
-    fn iter<'a>(
-        &'a self,
-        params: super::SelectionModeParams<'a>,
-    ) -> anyhow::Result<Box<dyn Iterator<Item = super::ByteRange> + 'a>> {
-        let buffer = params.buffer;
+    fn get_current_selection_by_cursor(
+        &self,
+        buffer: &crate::buffer::Buffer,
+        _: crate::selection::CharIndex,
+    ) -> anyhow::Result<Option<ByteRange>> {
         let range = self.current_selection.extended_range();
-        Ok(Box::new(std::iter::once(super::ByteRange::new(
-            buffer.char_to_byte(range.start)?..buffer.char_to_byte(range.end)?,
-        ))))
+        let byte_range = buffer.char_index_range_to_byte_range(range)?;
+        Ok(Some(
+            ByteRange::new(byte_range).set_info(self.current_selection.info()),
+        ))
     }
 }

--- a/src/selection_mode/diagnostic.rs
+++ b/src/selection_mode/diagnostic.rs
@@ -4,9 +4,8 @@ use itertools::Itertools;
 
 use crate::{components::suggestive_editor::Info, quickfix_list::DiagnosticSeverityRange};
 
-use super::{get_current_selection_by_cursor_via_iter, SelectionMode};
+use super::{VectorBased, VectorBasedSelectionMode};
 
-// TODO: change this to custom selections, so it can also hold references, definitions etc
 pub(crate) struct Diagnostic {
     severity_range: DiagnosticSeverityRange,
     diagnostics: Vec<crate::lsp::diagnostic::Diagnostic>,
@@ -24,29 +23,22 @@ impl Diagnostic {
     }
 }
 
-impl SelectionMode for Diagnostic {
-    fn get_current_selection_by_cursor(
+impl VectorBasedSelectionMode for Diagnostic {
+    fn get_byte_ranges(
         &self,
         buffer: &crate::buffer::Buffer,
-        cursor_char_index: crate::selection::CharIndex,
-        if_current_not_found: crate::components::editor::IfCurrentNotFound,
-    ) -> anyhow::Result<Option<super::ByteRange>> {
-        get_current_selection_by_cursor_via_iter(
-            buffer,
-            cursor_char_index,
-            if_current_not_found,
-            Rc::new(
-                self.diagnostics
-                    .iter()
-                    .filter(|diagnostic| self.severity_range.contains(diagnostic.severity))
-                    .map(|diagnostic| -> anyhow::Result<_> {
-                        Ok(super::ByteRange::with_info(
-                            buffer.char_index_range_to_byte_range(diagnostic.range)?,
-                            Info::new("Diagnostics".to_string(), diagnostic.message.clone()),
-                        ))
-                    })
-                    .try_collect()?,
-            ),
-        )
+    ) -> Result<Rc<Vec<super::ByteRange>>, anyhow::Error> {
+        Ok(Rc::new(
+            self.diagnostics
+                .iter()
+                .filter(|diagnostic| self.severity_range.contains(diagnostic.severity))
+                .map(|diagnostic| -> anyhow::Result<_> {
+                    Ok(super::ByteRange::with_info(
+                        buffer.char_index_range_to_byte_range(diagnostic.range)?,
+                        Info::new("Diagnostics".to_string(), diagnostic.message.clone()),
+                    ))
+                })
+                .try_collect()?,
+        ))
     }
 }

--- a/src/selection_mode/diagnostic.rs
+++ b/src/selection_mode/diagnostic.rs
@@ -1,6 +1,6 @@
 use crate::{components::suggestive_editor::Info, quickfix_list::DiagnosticSeverityRange};
 
-use super::{IterBasedSelectionMode, SelectionMode};
+use super::IterBasedSelectionMode;
 
 // TODO: change this to custom selections, so it can also hold references, definitions etc
 pub(crate) struct Diagnostic {

--- a/src/selection_mode/git_hunk.rs
+++ b/src/selection_mode/git_hunk.rs
@@ -37,10 +37,16 @@ impl GitHunk {
 }
 
 impl SelectionMode for GitHunk {
-    fn iter<'a>(
-        &'a self,
-        _: super::SelectionModeParams<'a>,
-    ) -> anyhow::Result<Box<dyn Iterator<Item = super::ByteRange> + 'a>> {
-        Ok(Box::new(self.ranges.clone().into_iter()))
+    fn get_current_selection_by_cursor(
+        &self,
+        buffer: &crate::buffer::Buffer,
+        cursor_char_index: crate::selection::CharIndex,
+    ) -> anyhow::Result<Option<super::ByteRange>> {
+        let cursor_byte = buffer.char_to_byte(cursor_char_index)?;
+        Ok(self
+            .ranges
+            .iter()
+            .find(|range| range.range.contains(&cursor_byte))
+            .cloned())
     }
 }

--- a/src/selection_mode/git_hunk.rs
+++ b/src/selection_mode/git_hunk.rs
@@ -1,7 +1,7 @@
 use crate::{buffer::Buffer, context::Context, git::GitOperation};
 use itertools::Itertools;
 
-use super::{ByteRange, IterBasedSelectionMode, SelectionMode};
+use super::{ByteRange, IterBasedSelectionMode};
 
 pub(crate) struct GitHunk {
     ranges: Vec<super::ByteRange>,

--- a/src/selection_mode/git_hunk.rs
+++ b/src/selection_mode/git_hunk.rs
@@ -3,7 +3,10 @@ use std::rc::Rc;
 use crate::{buffer::Buffer, context::Context, git::GitOperation};
 use itertools::Itertools;
 
-use super::{get_current_selection_by_cursor_via_iter, ByteRange, SelectionMode};
+use super::{
+    get_current_selection_by_cursor_via_iter, ByteRange, PositionBasedSelectionMode, VectorBased,
+    VectorBasedSelectionMode,
+};
 
 pub(crate) struct GitHunk {
     ranges: Rc<Vec<super::ByteRange>>,
@@ -42,18 +45,8 @@ impl GitHunk {
     }
 }
 
-impl SelectionMode for GitHunk {
-    fn get_current_selection_by_cursor(
-        &self,
-        buffer: &crate::buffer::Buffer,
-        cursor_char_index: crate::selection::CharIndex,
-        if_current_not_found: crate::components::editor::IfCurrentNotFound,
-    ) -> anyhow::Result<Option<super::ByteRange>> {
-        get_current_selection_by_cursor_via_iter(
-            buffer,
-            cursor_char_index,
-            if_current_not_found,
-            self.ranges.clone(),
-        )
+impl VectorBasedSelectionMode for GitHunk {
+    fn get_byte_ranges(&self, buffer: &Buffer) -> anyhow::Result<Rc<Vec<ByteRange>>> {
+        Ok(self.ranges.clone())
     }
 }

--- a/src/selection_mode/line_full.rs
+++ b/src/selection_mode/line_full.rs
@@ -112,14 +112,14 @@ impl PositionBasedSelectionMode for LineFull {
         &self,
         params: &super::SelectionModeParams,
     ) -> anyhow::Result<Option<crate::selection::Selection>> {
-        self.down_impl(params)
+        self.down(params)
     }
 
     fn delete_backward(
         &self,
         params: &super::SelectionModeParams,
     ) -> anyhow::Result<Option<crate::selection::Selection>> {
-        self.up_impl(params)
+        self.up(params)
     }
 
     fn get_current_selection_by_cursor(

--- a/src/selection_mode/line_full.rs
+++ b/src/selection_mode/line_full.rs
@@ -67,6 +67,7 @@ impl SelectionMode for LineFull {
         &self,
         buffer: &crate::buffer::Buffer,
         cursor_char_index: crate::selection::CharIndex,
+        _: crate::components::editor::IfCurrentNotFound,
     ) -> anyhow::Result<Option<super::ByteRange>> {
         let line_index = buffer.char_to_line(cursor_char_index)?;
         let line_start_char_index = buffer.line_to_char(line_index)?;
@@ -89,7 +90,7 @@ fn is_blank(buffer: &crate::buffer::Buffer, byte_range: &super::ByteRange) -> Op
 }
 
 #[cfg(test)]
-mod test_line {
+mod test_line_full {
     use crate::{buffer::Buffer, selection::Selection};
 
     use super::*;

--- a/src/selection_mode/line_full.rs
+++ b/src/selection_mode/line_full.rs
@@ -1,60 +1,29 @@
 use itertools::Itertools;
 
-use super::SelectionMode;
+use super::{ByteRange, SelectionMode};
 
 pub(crate) struct LineFull;
 
 impl SelectionMode for LineFull {
-    fn iter<'a>(
-        &'a self,
-        params: super::SelectionModeParams<'a>,
-    ) -> anyhow::Result<Box<dyn Iterator<Item = super::ByteRange> + 'a>> {
-        let buffer = params.buffer;
-        let len_lines = buffer.len_lines();
-
-        Ok(Box::new(
-            (0..len_lines)
-                .take(
-                    // This is a weird hack, because `rope.len_lines`
-                    // returns an extra line which is empty if the rope ends with the newline character
-                    if buffer.rope().to_string().ends_with('\n') {
-                        len_lines.saturating_sub(1)
-                    } else {
-                        len_lines
-                    },
-                )
-                .filter_map(move |line_index| {
-                    let line = buffer.get_line_by_line_index(line_index)?;
-                    let start = buffer.line_to_byte(line_index).ok()?;
-                    let len_bytes = line.len_bytes();
-                    let end = start + len_bytes;
-
-                    Some(super::ByteRange::new(start..end))
-                }),
-        ))
-    }
     fn right(
         &self,
         params: super::SelectionModeParams,
     ) -> anyhow::Result<Option<crate::selection::Selection>> {
         let buffer = params.buffer;
-        let current_selection = params.current_selection;
-        let current_selection_range =
-            buffer.char_index_range_to_byte_range(current_selection.range())?;
-        Ok(self
-            .iter_filtered(params)?
-            .skip_while(|byte_range| byte_range.range != current_selection_range)
-            .skip_while(|byte_range| is_blank(buffer, byte_range).unwrap_or(false))
-            .find_map(|byte_range| {
-                if is_blank(buffer, &byte_range)? {
-                    buffer
-                        .byte_range_to_char_index_range(&byte_range.range)
-                        .ok()
+        let mut line_index = buffer.char_to_line(params.cursor_char_index())?;
+        while line_index < buffer.len_lines() {
+            if let Some(slice) = buffer.get_line_by_line_index(line_index) {
+                if slice.chars().all(|char| char.is_whitespace()) {
+                    let range = buffer.line_to_char_range(line_index)?;
+                    return Ok(Some(params.current_selection.clone().set_range(range)));
                 } else {
-                    None
+                    line_index += 1
                 }
-            })
-            .map(|range| current_selection.clone().set_range(range)))
+            } else {
+                break;
+            }
+        }
+        Ok(None)
     }
 
     fn left(
@@ -62,26 +31,22 @@ impl SelectionMode for LineFull {
         params: super::SelectionModeParams,
     ) -> anyhow::Result<Option<crate::selection::Selection>> {
         let buffer = params.buffer;
-        let current_selection = params.current_selection;
-        let current_selection_range =
-            buffer.char_index_range_to_byte_range(current_selection.range())?;
-        Ok(self
-            .iter_filtered(params)?
-            .take_while(|byte_range| byte_range.range != current_selection_range)
-            .collect_vec()
-            .into_iter()
-            .rev()
-            .skip_while(|byte_range| is_blank(buffer, byte_range).unwrap_or(false))
-            .find_map(|byte_range| {
-                if is_blank(buffer, &byte_range)? {
-                    buffer
-                        .byte_range_to_char_index_range(&byte_range.range)
-                        .ok()
+        let mut line_index = buffer.char_to_line(params.cursor_char_index())?;
+        loop {
+            if let Some(slice) = buffer.get_line_by_line_index(line_index) {
+                if slice.chars().all(|char| char.is_whitespace()) {
+                    let range = buffer.line_to_char_range(line_index)?;
+                    return Ok(Some(params.current_selection.clone().set_range(range)));
+                } else if line_index == 0 {
+                    break;
                 } else {
-                    None
+                    line_index -= 1
                 }
-            })
-            .map(|range| current_selection.clone().set_range(range)))
+            } else {
+                break;
+            }
+        }
+        Ok(None)
     }
 
     fn delete_forward(
@@ -96,6 +61,22 @@ impl SelectionMode for LineFull {
         params: super::SelectionModeParams,
     ) -> anyhow::Result<Option<crate::selection::Selection>> {
         self.up(params)
+    }
+
+    fn get_current_selection_by_cursor(
+        &self,
+        buffer: &crate::buffer::Buffer,
+        cursor_char_index: crate::selection::CharIndex,
+    ) -> anyhow::Result<Option<super::ByteRange>> {
+        let line_index = buffer.char_to_line(cursor_char_index)?;
+        let line_start_char_index = buffer.line_to_char(line_index)?;
+        let Some(line) = buffer.get_line_by_line_index(line_index) else {
+            return Ok(None);
+        };
+        let range = buffer.char_index_range_to_byte_range(
+            (line_start_char_index..line_start_char_index + line.len_chars()).into(),
+        )?;
+        Ok(Some(ByteRange::new(range)))
     }
 }
 

--- a/src/selection_mode/line_full.rs
+++ b/src/selection_mode/line_full.rs
@@ -1,8 +1,6 @@
-use itertools::Itertools;
-
 use crate::selection::CharIndex;
 
-use super::{ByteRange, PositionBased, PositionBasedSelectionMode};
+use super::{ByteRange, PositionBasedSelectionMode};
 
 pub(crate) struct LineFull;
 
@@ -91,18 +89,14 @@ impl PositionBasedSelectionMode for LineFull {
             }
         };
         let mut line_index = buffer.char_to_line(start_char_index)?;
-        loop {
-            if let Some(slice) = buffer.get_line_by_line_index(line_index) {
-                if slice.chars().all(|char| char.is_whitespace()) {
-                    let range = buffer.line_to_char_range(line_index)?;
-                    return Ok(Some(params.current_selection.clone().set_range(range)));
-                } else if line_index == 0 {
-                    break;
-                } else {
-                    line_index -= 1
-                }
-            } else {
+        while let Some(slice) = buffer.get_line_by_line_index(line_index) {
+            if slice.chars().all(|char| char.is_whitespace()) {
+                let range = buffer.line_to_char_range(line_index)?;
+                return Ok(Some(params.current_selection.clone().set_range(range)));
+            } else if line_index == 0 {
                 break;
+            } else {
+                line_index -= 1
             }
         }
         Ok(None)
@@ -140,17 +134,13 @@ impl PositionBasedSelectionMode for LineFull {
     }
 }
 
-fn is_blank(buffer: &crate::buffer::Buffer, byte_range: &super::ByteRange) -> Option<bool> {
-    let range = buffer
-        .byte_range_to_char_index_range(&byte_range.range)
-        .ok()?;
-    let content = buffer.slice(&range).ok()?;
-    Some(content.chars().all(|c| c.is_whitespace()))
-}
-
 #[cfg(test)]
 mod test_line_full {
-    use crate::{buffer::Buffer, selection::Selection, selection_mode::SelectionMode as _};
+    use crate::{
+        buffer::Buffer,
+        selection::Selection,
+        selection_mode::{PositionBased, SelectionMode as _},
+    };
 
     use super::*;
 

--- a/src/selection_mode/line_full.rs
+++ b/src/selection_mode/line_full.rs
@@ -2,14 +2,20 @@ use itertools::Itertools;
 
 use crate::selection::CharIndex;
 
-use super::{ByteRange, SelectionMode};
+use super::{ByteRange, PositionBased, PositionBasedSelectionMode};
 
 pub(crate) struct LineFull;
 
-impl SelectionMode for LineFull {
+impl LineFull {
+    pub(crate) fn new() -> Self {
+        Self
+    }
+}
+
+impl PositionBasedSelectionMode for LineFull {
     fn right(
         &self,
-        params: super::SelectionModeParams,
+        params: &super::SelectionModeParams,
     ) -> anyhow::Result<Option<crate::selection::Selection>> {
         let buffer = params.buffer;
         let start_char_index = {
@@ -55,7 +61,7 @@ impl SelectionMode for LineFull {
 
     fn left(
         &self,
-        params: super::SelectionModeParams,
+        params: &super::SelectionModeParams,
     ) -> anyhow::Result<Option<crate::selection::Selection>> {
         let buffer = params.buffer;
         let start_char_index = {
@@ -104,16 +110,16 @@ impl SelectionMode for LineFull {
 
     fn delete_forward(
         &self,
-        params: super::SelectionModeParams,
+        params: &super::SelectionModeParams,
     ) -> anyhow::Result<Option<crate::selection::Selection>> {
-        self.down(params)
+        self.down_impl(params)
     }
 
     fn delete_backward(
         &self,
-        params: super::SelectionModeParams,
+        params: &super::SelectionModeParams,
     ) -> anyhow::Result<Option<crate::selection::Selection>> {
-        self.up(params)
+        self.up_impl(params)
     }
 
     fn get_current_selection_by_cursor(
@@ -144,14 +150,14 @@ fn is_blank(buffer: &crate::buffer::Buffer, byte_range: &super::ByteRange) -> Op
 
 #[cfg(test)]
 mod test_line_full {
-    use crate::{buffer::Buffer, selection::Selection};
+    use crate::{buffer::Buffer, selection::Selection, selection_mode::SelectionMode as _};
 
     use super::*;
 
     #[test]
     fn case_1() {
         let buffer = Buffer::new(None, "a\n\n\nb\nc\n  hello");
-        LineFull.assert_all_selections(
+        PositionBased(LineFull).assert_all_selections(
             &buffer,
             Selection::default(),
             &[
@@ -170,6 +176,10 @@ mod test_line_full {
     #[test]
     fn single_line_without_trailing_newline_character() {
         let buffer = Buffer::new(None, "a");
-        LineFull.assert_all_selections(&buffer, Selection::default(), &[(0..1, "a")]);
+        PositionBased(LineFull).assert_all_selections(
+            &buffer,
+            Selection::default(),
+            &[(0..1, "a")],
+        );
     }
 }

--- a/src/selection_mode/local_quickfix.rs
+++ b/src/selection_mode/local_quickfix.rs
@@ -1,8 +1,7 @@
 use std::rc::Rc;
 
-use super::{get_current_selection_by_cursor_via_iter, ByteRange, SelectionMode};
+use super::{ByteRange, VectorBased, VectorBasedSelectionMode};
 
-// TODO: change this to custom selections, so it can also hold references, definitions etc
 pub(crate) struct LocalQuickfix {
     ranges: Rc<Vec<ByteRange>>,
 }
@@ -30,18 +29,8 @@ impl LocalQuickfix {
     }
 }
 
-impl SelectionMode for LocalQuickfix {
-    fn get_current_selection_by_cursor(
-        &self,
-        buffer: &crate::buffer::Buffer,
-        cursor_char_index: crate::selection::CharIndex,
-        if_current_not_found: crate::components::editor::IfCurrentNotFound,
-    ) -> anyhow::Result<Option<super::ByteRange>> {
-        get_current_selection_by_cursor_via_iter(
-            buffer,
-            cursor_char_index,
-            if_current_not_found,
-            self.ranges.clone(),
-        )
+impl VectorBasedSelectionMode for LocalQuickfix {
+    fn get_byte_ranges(&self, _: &crate::buffer::Buffer) -> anyhow::Result<Rc<Vec<ByteRange>>> {
+        Ok(self.ranges.clone())
     }
 }

--- a/src/selection_mode/local_quickfix.rs
+++ b/src/selection_mode/local_quickfix.rs
@@ -1,27 +1,31 @@
-use super::{ByteRange, SelectionMode};
+use std::rc::Rc;
+
+use super::{get_current_selection_by_cursor_via_iter, ByteRange, SelectionMode};
 
 // TODO: change this to custom selections, so it can also hold references, definitions etc
 pub(crate) struct LocalQuickfix {
-    ranges: Vec<ByteRange>,
+    ranges: Rc<Vec<ByteRange>>,
 }
 
 impl LocalQuickfix {
     pub(crate) fn new(params: super::SelectionModeParams<'_>) -> Self {
         let buffer = params.buffer;
-        let ranges = buffer
-            .quickfix_list_items()
-            .into_iter()
-            .filter_map(|item| {
-                Some(
-                    super::ByteRange::new(
-                        buffer
-                            .position_range_to_byte_range(&item.location().range)
-                            .ok()?,
+        let ranges = Rc::new(
+            buffer
+                .quickfix_list_items()
+                .into_iter()
+                .filter_map(|item| {
+                    Some(
+                        super::ByteRange::new(
+                            buffer
+                                .position_range_to_byte_range(&item.location().range)
+                                .ok()?,
+                        )
+                        .set_info(item.info().clone()),
                     )
-                    .set_info(item.info().clone()),
-                )
-            })
-            .collect();
+                })
+                .collect(),
+        );
         Self { ranges }
     }
 }
@@ -31,12 +35,13 @@ impl SelectionMode for LocalQuickfix {
         &self,
         buffer: &crate::buffer::Buffer,
         cursor_char_index: crate::selection::CharIndex,
+        if_current_not_found: crate::components::editor::IfCurrentNotFound,
     ) -> anyhow::Result<Option<super::ByteRange>> {
-        let cursor_byte = buffer.char_to_byte(cursor_char_index)?;
-        Ok(self
-            .ranges
-            .iter()
-            .find(|range| range.range.contains(&cursor_byte))
-            .cloned())
+        get_current_selection_by_cursor_via_iter(
+            buffer,
+            cursor_char_index,
+            if_current_not_found,
+            self.ranges.clone(),
+        )
     }
 }

--- a/src/selection_mode/local_quickfix.rs
+++ b/src/selection_mode/local_quickfix.rs
@@ -1,4 +1,4 @@
-use super::{ByteRange, IterBasedSelectionMode, SelectionMode};
+use super::{ByteRange, IterBasedSelectionMode};
 
 // TODO: change this to custom selections, so it can also hold references, definitions etc
 pub(crate) struct LocalQuickfix {

--- a/src/selection_mode/local_quickfix.rs
+++ b/src/selection_mode/local_quickfix.rs
@@ -1,36 +1,36 @@
-use std::rc::Rc;
+use super::{ByteRange, IterBasedSelectionMode, SelectionMode};
 
-use super::{ByteRange, VectorBased, VectorBasedSelectionMode};
-
+// TODO: change this to custom selections, so it can also hold references, definitions etc
 pub(crate) struct LocalQuickfix {
-    ranges: Rc<Vec<ByteRange>>,
+    ranges: Vec<ByteRange>,
 }
 
 impl LocalQuickfix {
     pub(crate) fn new(params: super::SelectionModeParams<'_>) -> Self {
         let buffer = params.buffer;
-        let ranges = Rc::new(
-            buffer
-                .quickfix_list_items()
-                .into_iter()
-                .filter_map(|item| {
-                    Some(
-                        super::ByteRange::new(
-                            buffer
-                                .position_range_to_byte_range(&item.location().range)
-                                .ok()?,
-                        )
-                        .set_info(item.info().clone()),
+        let ranges = buffer
+            .quickfix_list_items()
+            .into_iter()
+            .filter_map(|item| {
+                Some(
+                    super::ByteRange::new(
+                        buffer
+                            .position_range_to_byte_range(&item.location().range)
+                            .ok()?,
                     )
-                })
-                .collect(),
-        );
+                    .set_info(item.info().clone()),
+                )
+            })
+            .collect();
         Self { ranges }
     }
 }
 
-impl VectorBasedSelectionMode for LocalQuickfix {
-    fn get_byte_ranges(&self, _: &crate::buffer::Buffer) -> anyhow::Result<Rc<Vec<ByteRange>>> {
-        Ok(self.ranges.clone())
+impl IterBasedSelectionMode for LocalQuickfix {
+    fn iter<'a>(
+        &'a self,
+        _: &super::SelectionModeParams<'a>,
+    ) -> anyhow::Result<Box<dyn Iterator<Item = super::ByteRange> + 'a>> {
+        Ok(Box::new(self.ranges.clone().into_iter()))
     }
 }

--- a/src/selection_mode/local_quickfix.rs
+++ b/src/selection_mode/local_quickfix.rs
@@ -27,10 +27,16 @@ impl LocalQuickfix {
 }
 
 impl SelectionMode for LocalQuickfix {
-    fn iter<'a>(
-        &'a self,
-        _: super::SelectionModeParams<'a>,
-    ) -> anyhow::Result<Box<dyn Iterator<Item = super::ByteRange> + 'a>> {
-        Ok(Box::new(self.ranges.clone().into_iter()))
+    fn get_current_selection_by_cursor(
+        &self,
+        buffer: &crate::buffer::Buffer,
+        cursor_char_index: crate::selection::CharIndex,
+    ) -> anyhow::Result<Option<super::ByteRange>> {
+        let cursor_byte = buffer.char_to_byte(cursor_char_index)?;
+        Ok(self
+            .ranges
+            .iter()
+            .find(|range| range.range.contains(&cursor_byte))
+            .cloned())
     }
 }

--- a/src/selection_mode/mark.rs
+++ b/src/selection_mode/mark.rs
@@ -1,23 +1,22 @@
-use crate::char_index_range::CharIndexRange;
+use super::{get_current_selection_by_cursor_via_iter, ByteRange, SelectionMode};
+use std::rc::Rc;
 
-use super::SelectionMode;
-
-pub(crate) struct Mark;
+pub(crate) struct Mark {
+    pub(crate) ranges: Rc<Vec<ByteRange>>,
+}
 
 impl SelectionMode for Mark {
     fn get_current_selection_by_cursor(
         &self,
         buffer: &crate::buffer::Buffer,
         cursor_char_index: crate::selection::CharIndex,
+        if_current_not_found: crate::components::editor::IfCurrentNotFound,
     ) -> anyhow::Result<Option<super::ByteRange>> {
-        Ok(buffer.marks().iter().find_map(|range| {
-            if range.contains(&cursor_char_index) {
-                Some(super::ByteRange::new(
-                    buffer.char_index_range_to_byte_range(*range).ok()?,
-                ))
-            } else {
-                None
-            }
-        }))
+        get_current_selection_by_cursor_via_iter(
+            buffer,
+            cursor_char_index,
+            if_current_not_found,
+            self.ranges.clone(),
+        )
     }
 }

--- a/src/selection_mode/mark.rs
+++ b/src/selection_mode/mark.rs
@@ -1,4 +1,4 @@
-use super::{IterBasedSelectionMode, SelectionMode};
+use super::IterBasedSelectionMode;
 
 pub(crate) struct Mark;
 

--- a/src/selection_mode/mark.rs
+++ b/src/selection_mode/mark.rs
@@ -1,17 +1,23 @@
+use crate::char_index_range::CharIndexRange;
+
 use super::SelectionMode;
 
 pub(crate) struct Mark;
 
 impl SelectionMode for Mark {
-    fn iter<'a>(
-        &'a self,
-        params: super::SelectionModeParams<'a>,
-    ) -> anyhow::Result<Box<dyn Iterator<Item = super::ByteRange> + 'a>> {
-        let buffer = params.buffer;
-        Ok(Box::new(buffer.marks().into_iter().filter_map(|range| {
-            let start = buffer.char_to_byte(range.start).ok()?;
-            let end = buffer.char_to_byte(range.end).ok()?;
-            Some(super::ByteRange::new(start..end))
-        })))
+    fn get_current_selection_by_cursor(
+        &self,
+        buffer: &crate::buffer::Buffer,
+        cursor_char_index: crate::selection::CharIndex,
+    ) -> anyhow::Result<Option<super::ByteRange>> {
+        Ok(buffer.marks().iter().find_map(|range| {
+            if range.contains(&cursor_char_index) {
+                Some(super::ByteRange::new(
+                    buffer.char_index_range_to_byte_range(*range).ok()?,
+                ))
+            } else {
+                None
+            }
+        }))
     }
 }

--- a/src/selection_mode/mark.rs
+++ b/src/selection_mode/mark.rs
@@ -1,35 +1,17 @@
-use crate::buffer::Buffer;
+use super::{IterBasedSelectionMode, SelectionMode};
 
-use super::{
-    get_current_selection_by_cursor_via_iter, ByteRange, PositionBasedSelectionMode, VectorBased,
-    VectorBasedSelectionMode,
-};
-use std::rc::Rc;
+pub(crate) struct Mark;
 
-pub(crate) struct Mark {
-    ranges: Rc<Vec<ByteRange>>,
-}
-
-impl Mark {
-    pub(crate) fn new(buffer: &Buffer) -> anyhow::Result<Self> {
-        Ok(Mark {
-            ranges: Rc::new(
-                buffer
-                    .marks()
-                    .into_iter()
-                    .filter_map(|range| {
-                        Some(ByteRange::new(
-                            buffer.char_index_range_to_byte_range(range).ok()?,
-                        ))
-                    })
-                    .collect(),
-            ),
-        })
-    }
-}
-
-impl VectorBasedSelectionMode for Mark {
-    fn get_byte_ranges(&self, buffer: &Buffer) -> anyhow::Result<Rc<Vec<ByteRange>>> {
-        Ok(self.ranges.clone())
+impl IterBasedSelectionMode for Mark {
+    fn iter<'a>(
+        &'a self,
+        params: &super::SelectionModeParams<'a>,
+    ) -> anyhow::Result<Box<dyn Iterator<Item = super::ByteRange> + 'a>> {
+        let buffer = params.buffer;
+        Ok(Box::new(buffer.marks().into_iter().filter_map(|range| {
+            let start = buffer.char_to_byte(range.start).ok()?;
+            let end = buffer.char_to_byte(range.end).ok()?;
+            Some(super::ByteRange::new(start..end))
+        })))
     }
 }

--- a/src/selection_mode/mod.rs
+++ b/src/selection_mode/mod.rs
@@ -108,6 +108,11 @@ pub(crate) struct SelectionModeParams<'a> {
     pub(crate) current_selection: &'a Selection,
     pub(crate) cursor_direction: &'a Direction,
 }
+impl SelectionModeParams<'_> {
+    fn cursor_char_index(&self) -> CharIndex {
+        self.current_selection.to_char_index(self.cursor_direction)
+    }
+}
 #[derive(Debug, Clone)]
 pub(crate) struct ApplyMovementResult {
     pub(crate) selection: Selection,

--- a/src/selection_mode/mod.rs
+++ b/src/selection_mode/mod.rs
@@ -653,7 +653,6 @@ pub trait PositionBasedSelectionMode {
             .into_iter()
             .flatten()
             .collect_vec();
-
         // Ensure no duplicated ranges
         debug_assert!(result.iter().unique_by(|range| range.range()).count() == result.len());
         Ok(result)
@@ -695,11 +694,18 @@ pub trait PositionBasedSelectionMode {
                     ) {
                         break result;
                     } else {
-                        cursor_char_index = buffer.byte_to_char(range.range().end)?;
-                        result.push(range);
+                        let new_cursor_char_index = buffer.byte_to_char(range.range().end)?;
+                        if new_cursor_char_index == cursor_char_index {
+                            break result;
+                        } else {
+                            cursor_char_index = buffer.byte_to_char(range.range().end)?;
+                            result.push(range);
+                        }
                     }
                 }
-                _ => break result,
+                _ => {
+                    break result;
+                }
             }
         };
         Ok(result)

--- a/src/selection_mode/mod.rs
+++ b/src/selection_mode/mod.rs
@@ -39,7 +39,7 @@ pub(crate) use word::Word;
 
 use crate::{
     buffer::Buffer,
-    char_index_range::CharIndexRange,
+    char_index_range::{range_intersects, CharIndexRange},
     components::{
         editor::{Direction, IfCurrentNotFound, Jump, Movement, SurroundKind},
         suggestive_editor::Info,
@@ -111,7 +111,6 @@ impl Ord for ByteRange {
     }
 }
 
-#[derive(Clone)]
 pub(crate) struct SelectionModeParams<'a> {
     pub(crate) buffer: &'a Buffer,
     pub(crate) current_selection: &'a Selection,
@@ -125,139 +124,13 @@ impl SelectionModeParams<'_> {
     fn cursor_byte(&self) -> anyhow::Result<usize> {
         self.buffer.char_to_byte(self.cursor_char_index())
     }
-}
-#[derive(Debug, Clone)]
-pub(crate) struct ApplyMovementResult {
-    pub(crate) selection: Selection,
-    pub(crate) mode: Option<crate::selection::SelectionMode>,
-}
 
-impl ApplyMovementResult {
-    pub(crate) fn from_selection(selection: Selection) -> Self {
-        Self {
-            selection,
-            mode: None,
-        }
-    }
-}
-
-pub(crate) fn get_current_selection_by_cursor_via_iter(
-    buffer: &crate::buffer::Buffer,
-    cursor_char_index: crate::selection::CharIndex,
-    if_current_not_found: IfCurrentNotFound,
-    iter: Rc<Vec<ByteRange>>,
-) -> anyhow::Result<Option<ByteRange>> {
-    let cursor_byte = buffer.char_to_byte(cursor_char_index)?;
-    let mut previous_range: Option<&ByteRange> = None;
-    for range in iter.iter() {
-        if range.range().contains(&cursor_byte) {
-            return Ok(Some(range.clone()));
-        } else if range.range.start > cursor_byte {
-            match if_current_not_found {
-                IfCurrentNotFound::LookForward => return Ok(Some(range.clone())),
-                IfCurrentNotFound::LookBackward => return Ok(previous_range.cloned()),
-            }
-        } else {
-            previous_range = Some(range)
-        }
-    }
-    Ok(previous_range.cloned())
-}
-
-pub trait SelectionMode {
-    fn all_selections<'a>(
-        &'a self,
-        params: SelectionModeParams<'a>,
-    ) -> anyhow::Result<Vec<ByteRange>> {
-        let mut cursor_char_index = CharIndex(0);
-        let mut result = Vec::new();
-        while cursor_char_index < CharIndex(params.buffer.len_chars()) {
-            if let Some(range) = self.get_current_selection_by_cursor(
-                &params.buffer,
-                cursor_char_index,
-                IfCurrentNotFound::LookForward,
-            )? {
-                cursor_char_index = params.buffer.byte_to_char(range.range.end)?;
-
-                if Some(&range) == result.last() {
-                    result.push(range);
-                    break;
-                } else {
-                    result.push(range);
-                }
-            } else {
-                break;
-            }
-        }
-        return Ok(result);
-    }
-
-    #[cfg(test)]
-    fn all_selections_gathered_inversely<'a>(
-        &'a self,
-        params: SelectionModeParams<'a>,
-    ) -> anyhow::Result<Vec<ByteRange>> {
-        let mut cursor_char_index = CharIndex(params.buffer.len_chars() - 1);
-        println!("all_selections_gathered_inversely: cursor char index = {cursor_char_index:?}");
-        let mut result = Vec::new();
-        loop {
-            if let Some(range) = self.get_current_selection_by_cursor(
-                &params.buffer,
-                cursor_char_index,
-                IfCurrentNotFound::LookBackward,
-            )? {
-                if range.range.start == 0 || Some(&range) == result.first() {
-                    result.insert(0, range);
-                    break;
-                } else {
-                    println!("cursor_char_index = {cursor_char_index:?}");
-                    cursor_char_index = params.buffer.byte_to_char(range.range.start - 1)?;
-                    result.insert(0, range);
-                }
-            } else {
-                break;
-            }
-        }
-        return Ok(result);
-    }
-
-    fn apply_movement(
-        &self,
-        params: SelectionModeParams,
-        movement: Movement,
-    ) -> anyhow::Result<Option<ApplyMovementResult>> {
-        fn convert(
-            result: anyhow::Result<Option<Selection>>,
-        ) -> anyhow::Result<Option<ApplyMovementResult>> {
-            Ok(result?.map(|result| result.into()))
-        }
-        match movement {
-            Movement::Right => convert(self.right(params)),
-
-            Movement::Left => convert(self.left(params)),
-            Movement::Last => convert(self.last(&params)),
-            Movement::Current(if_current_not_found) => {
-                convert(self.current(params, if_current_not_found))
-            }
-            Movement::First => convert(self.first(&params)),
-            Movement::Index(index) => convert(self.to_index(params, index)),
-            Movement::Jump(range) => Ok(Some(ApplyMovementResult::from_selection(
-                params.current_selection.clone().set_range(range),
-            ))),
-            Movement::Up => convert(self.up(params)),
-            Movement::Down => convert(self.down(params)),
-            Movement::Expand => self.expand(params),
-            Movement::DeleteBackward => convert(self.delete_backward(params)),
-            Movement::DeleteForward => convert(self.delete_forward(params)),
-        }
-    }
-
-    fn expand(&self, params: SelectionModeParams) -> anyhow::Result<Option<ApplyMovementResult>> {
-        let buffer = params.buffer;
-        let selection = params.current_selection;
-        let range = params.current_selection.extended_range();
-        let range_start = params.current_selection.extended_range().start;
-        let range_end = params.current_selection.extended_range().end;
+    fn expand(&self) -> Result<Option<ApplyMovementResult>, anyhow::Error> {
+        let buffer = self.buffer;
+        let selection = self.current_selection;
+        let range = self.current_selection.extended_range();
+        let range_start = self.current_selection.extended_range().start;
+        let range_end = self.current_selection.extended_range().end;
         use position_pair::Position::*;
         use EnclosureKind::*;
         use SurroundKind::*;
@@ -397,96 +270,434 @@ pub trait SelectionMode {
             selection.clone().set_range(range),
         )))
     }
+}
+#[derive(Debug, Clone)]
+pub(crate) struct ApplyMovementResult {
+    pub(crate) selection: Selection,
+    pub(crate) mode: Option<crate::selection::SelectionMode>,
+}
 
-    fn up(&self, params: SelectionModeParams) -> anyhow::Result<Option<Selection>> {
-        self.vertical_movement(params, true)
-    }
-
-    fn down(&self, params: SelectionModeParams) -> anyhow::Result<Option<Selection>> {
-        self.vertical_movement(params, false)
-    }
-
-    fn vertical_movement(
-        &self,
-        params: SelectionModeParams,
-        is_up: bool,
-    ) -> anyhow::Result<Option<Selection>> {
-        let cursor_char_index = params.cursor_char_index();
-        let SelectionModeParams {
-            buffer,
-            current_selection,
-            ..
-        } = params;
-        let current_position = buffer.char_to_position(cursor_char_index)?;
-
-        // Early return check
-        if (is_up && current_position.line == 0)
-            || (!is_up && current_position.line == buffer.len_lines().saturating_sub(1))
-        {
-            return Ok(None);
+impl ApplyMovementResult {
+    pub(crate) fn from_selection(selection: Selection) -> Self {
+        Self {
+            selection,
+            mode: None,
         }
+    }
+}
 
-        // Calculate the new line
-        let new_line = if is_up {
-            current_position.line - 1
-        } else {
-            current_position.line + 1
-        };
-
-        let mut new_position = current_position.set_line(new_line);
-        let mut new_cursor_char_index = buffer.position_to_char(new_position)?;
-
-        // Define which look direction to try first and second based on movement direction
-        let (first_look, second_look) = if is_up {
-            (
-                IfCurrentNotFound::LookBackward,
-                IfCurrentNotFound::LookForward,
-            )
-        } else {
-            (
-                IfCurrentNotFound::LookForward,
-                IfCurrentNotFound::LookBackward,
-            )
-        };
-
-        while let Some(result) =
-            self.get_current_selection_by_cursor(&params.buffer, new_cursor_char_index, first_look)?
-        {
-            if buffer.byte_to_line(result.range.start)? == new_position.line {
-                return Ok(Some(
-                    current_selection
-                        .clone()
-                        .set_range(buffer.byte_range_to_char_index_range(&result.range)?)
-                        .set_info(result.info),
-                ));
-            } else if let Some(result) = self.get_current_selection_by_cursor(
-                &params.buffer,
-                new_cursor_char_index,
-                second_look,
-            )? {
-                if buffer.byte_to_line(result.range.start)? == new_position.line {
-                    return Ok(Some(
-                        current_selection
-                            .clone()
-                            .set_range(buffer.byte_range_to_char_index_range(&result.range)?)
-                            .set_info(result.info),
-                    ));
-                }
-            }
-
-            // Move to next line
-            new_position.line = if is_up {
-                new_position.line.saturating_sub(1)
+pub(crate) fn get_current_selection_by_cursor_via_iter(
+    buffer: &crate::buffer::Buffer,
+    cursor_char_index: crate::selection::CharIndex,
+    if_current_not_found: IfCurrentNotFound,
+    vec: Rc<Vec<ByteRange>>,
+) -> anyhow::Result<Option<ByteRange>> {
+    debug_assert!(vec.iter().is_sorted());
+    let cursor_byte = buffer.char_to_byte(cursor_char_index)?;
+    let mut previous_range: Option<&ByteRange> = None;
+    let partition_point = vec.partition_point(|byte_range| byte_range.range().start < cursor_byte);
+    let calibrated_partition_point = match if_current_not_found {
+        IfCurrentNotFound::LookForward => partition_point,
+        IfCurrentNotFound::LookBackward => {
+            if partition_point == 0 {
+                return Ok(None);
             } else {
-                new_position.line + 1
-            };
-            new_cursor_char_index = buffer.position_to_char(new_position)?;
+                partition_point - 1
+            }
         }
+    };
+    return Ok(vec.iter().nth(calibrated_partition_point).cloned());
 
-        Ok(None)
+    for range in vec.iter() {
+        if range.range().contains(&cursor_byte) {
+            return Ok(Some(range.clone()));
+        } else if range.range.start > cursor_byte {
+            match if_current_not_found {
+                IfCurrentNotFound::LookForward => return Ok(Some(range.clone())),
+                IfCurrentNotFound::LookBackward => return Ok(previous_range.cloned()),
+            }
+        } else {
+            previous_range = Some(range)
+        }
+    }
+    Ok(None)
+}
+
+/// This is so that any struct that implements PositionBasedSelectionMode
+/// gets a free implementation of SelectionMode.
+///
+/// See https://stackoverflow.com/a/40945952/6587634
+impl<T: PositionBasedSelectionMode> SelectionMode for PositionBased<T> {
+    fn revealed_selections<'a>(
+        &'a self,
+        params: SelectionModeParams<'a>,
+    ) -> anyhow::Result<Vec<ByteRange>> {
+        self.all_selections(params)
+    }
+    fn get_current_selection_by_cursor(
+        &self,
+        buffer: &Buffer,
+        cursor_char_index: CharIndex,
+        if_current_not_found: IfCurrentNotFound,
+    ) -> anyhow::Result<Option<ByteRange>> {
+        self.0
+            .get_current_selection_by_cursor(buffer, cursor_char_index, if_current_not_found)
+    }
+
+    #[cfg(test)]
+    fn all_selections_gathered_inversely<'a>(
+        &'a self,
+        params: SelectionModeParams<'a>,
+    ) -> anyhow::Result<Vec<ByteRange>> {
+        let mut cursor_char_index = CharIndex(params.buffer.len_chars() - 1);
+        let mut result = Vec::new();
+        loop {
+            if let Some(range) = self.get_current_selection_by_cursor(
+                &params.buffer,
+                cursor_char_index,
+                IfCurrentNotFound::LookBackward,
+            )? {
+                if range.range.start == 0 || Some(&range) == result.first() {
+                    result.insert(0, range);
+                    break;
+                } else {
+                    cursor_char_index = params.buffer.byte_to_char(range.range.start - 1)?;
+                    result.insert(0, range);
+                }
+            } else {
+                break;
+            }
+        }
+        return Ok(result);
+    }
+
+    fn to_index(
+        &self,
+        params: &SelectionModeParams,
+        index: usize,
+    ) -> anyhow::Result<Option<Selection>> {
+        let current_selection = params.current_selection;
+        let buffer = params.buffer;
+        let mut cursor_char_index = CharIndex(0);
+        let limit = CharIndex(params.buffer.len_chars());
+        let mut current_index: usize = 0;
+        while cursor_char_index < limit {
+            if let Some(range) = self.get_current_selection_by_cursor(
+                &params.buffer,
+                cursor_char_index,
+                IfCurrentNotFound::LookForward,
+            )? {
+                if current_index == index {
+                    return Ok(Some(range.to_selection(buffer, current_selection)?));
+                } else {
+                    current_index += 1;
+                    cursor_char_index = buffer.byte_to_char(range.range.end)?
+                }
+            } else {
+                return Ok(None);
+            }
+        }
+        return Ok(None);
+    }
+
+    fn first(&self, params: &SelectionModeParams) -> anyhow::Result<Option<Selection>> {
+        self.0.first(params)
+    }
+
+    fn last(&self, params: &SelectionModeParams) -> anyhow::Result<Option<Selection>> {
+        self.0.last(params)
+    }
+
+    fn right(
+        &self,
+        params: &SelectionModeParams,
+    ) -> anyhow::Result<Option<crate::selection::Selection>> {
+        self.0.right(params)
+    }
+
+    fn left(
+        &self,
+        params: &SelectionModeParams,
+    ) -> anyhow::Result<Option<crate::selection::Selection>> {
+        self.0.left(params)
+    }
+
+    fn all_selections<'a>(
+        &'a self,
+        params: SelectionModeParams<'a>,
+    ) -> anyhow::Result<Vec<ByteRange>> {
+        self.0.all_selections(params)
+    }
+
+    fn up(&self, params: &SelectionModeParams) -> anyhow::Result<Option<Selection>> {
+        self.0.up_impl(params)
+    }
+
+    fn down(&self, params: &SelectionModeParams) -> anyhow::Result<Option<Selection>> {
+        self.0.down_impl(params)
+    }
+
+    fn expand(&self, params: &SelectionModeParams) -> anyhow::Result<Option<ApplyMovementResult>> {
+        self.0.expand_impl(params)
+    }
+
+    fn jumps(
+        &self,
+        params: &SelectionModeParams,
+        chars: Vec<char>,
+        line_number_ranges: Vec<Range<usize>>,
+    ) -> anyhow::Result<Vec<Jump>> {
+        self.0.jumps_impl(params, chars, line_number_ranges)
     }
 
     fn selections_in_line_number_range(
+        &self,
+        params: &SelectionModeParams,
+        line_number_ranges: Vec<Range<usize>>,
+    ) -> anyhow::Result<Vec<ByteRange>> {
+        self.0
+            .selections_in_line_number_range_impl(params, line_number_ranges)
+    }
+}
+
+pub trait SelectionMode {
+    fn all_selections<'a>(
+        &'a self,
+        params: SelectionModeParams<'a>,
+    ) -> anyhow::Result<Vec<ByteRange>>;
+
+    #[cfg(test)]
+    fn all_selections_gathered_inversely<'a>(
+        &'a self,
+        params: SelectionModeParams<'a>,
+    ) -> anyhow::Result<Vec<ByteRange>>;
+
+    fn apply_movement(
+        &self,
+        params: &SelectionModeParams,
+        movement: Movement,
+    ) -> anyhow::Result<Option<ApplyMovementResult>> {
+        fn convert(
+            result: anyhow::Result<Option<Selection>>,
+        ) -> anyhow::Result<Option<ApplyMovementResult>> {
+            Ok(result?.map(|result| result.into()))
+        }
+        match movement {
+            Movement::Right => convert(self.right(params)),
+
+            Movement::Left => convert(self.left(params)),
+            Movement::Last => convert(self.last(&params)),
+            Movement::Current(if_current_not_found) => {
+                convert(self.current(params, if_current_not_found))
+            }
+            Movement::First => convert(self.first(&params)),
+            Movement::Index(index) => convert(self.to_index(params, index)),
+            Movement::Jump(range) => Ok(Some(ApplyMovementResult::from_selection(
+                params.current_selection.clone().set_range(range),
+            ))),
+            Movement::Up => convert(self.up(params)),
+            Movement::Down => convert(self.down(params)),
+            Movement::Expand => self.expand(params),
+            Movement::DeleteBackward => convert(self.delete_backward(params)),
+            Movement::DeleteForward => convert(self.delete_forward(params)),
+        }
+    }
+
+    fn expand(&self, params: &SelectionModeParams) -> anyhow::Result<Option<ApplyMovementResult>>;
+
+    fn up(&self, params: &SelectionModeParams) -> anyhow::Result<Option<Selection>>;
+
+    fn down(&self, params: &SelectionModeParams) -> anyhow::Result<Option<Selection>>;
+
+    fn selections_in_line_number_range(
+        &self,
+        params: &SelectionModeParams,
+        line_number_ranges: Vec<Range<usize>>,
+    ) -> anyhow::Result<Vec<ByteRange>>;
+
+    fn revealed_selections<'a>(
+        &'a self,
+        params: SelectionModeParams<'a>,
+    ) -> anyhow::Result<Vec<ByteRange>> {
+        self.all_selections(params)
+    }
+
+    fn jumps(
+        &self,
+        params: &SelectionModeParams,
+        chars: Vec<char>,
+        line_number_ranges: Vec<Range<usize>>,
+    ) -> anyhow::Result<Vec<Jump>>;
+
+    fn to_index(
+        &self,
+        params: &SelectionModeParams,
+        index: usize,
+    ) -> anyhow::Result<Option<Selection>>;
+
+    fn delete_forward(&self, params: &SelectionModeParams) -> anyhow::Result<Option<Selection>> {
+        self.right(params)
+    }
+
+    fn delete_backward(&self, params: &SelectionModeParams) -> anyhow::Result<Option<Selection>> {
+        self.left(params)
+    }
+
+    fn first(&self, params: &SelectionModeParams) -> anyhow::Result<Option<Selection>>;
+
+    fn last(&self, params: &SelectionModeParams) -> anyhow::Result<Option<Selection>>;
+
+    fn get_current_selection_by_cursor(
+        &self,
+        buffer: &Buffer,
+        cursor_char_index: CharIndex,
+        if_current_not_found: IfCurrentNotFound,
+    ) -> anyhow::Result<Option<ByteRange>>;
+
+    fn current(
+        &self,
+        params: &SelectionModeParams,
+        if_current_not_found: IfCurrentNotFound,
+    ) -> anyhow::Result<Option<crate::selection::Selection>> {
+        let range = self.get_current_selection_by_cursor(
+            &params.buffer,
+            params.cursor_char_index(),
+            if_current_not_found,
+        )?;
+        let range = if range.is_none() {
+            self.get_current_selection_by_cursor(
+                &params.buffer,
+                params.cursor_char_index(),
+                if_current_not_found.inverse(),
+            )?
+        } else {
+            range
+        };
+        range
+            .map(|range| {
+                params
+                    .current_selection
+                    .clone()
+                    .update_with_byte_range(params.buffer, range)
+            })
+            .transpose()
+    }
+
+    fn right(
+        &self,
+        params: &SelectionModeParams,
+    ) -> anyhow::Result<Option<crate::selection::Selection>>;
+
+    fn left(
+        &self,
+        params: &SelectionModeParams,
+    ) -> anyhow::Result<Option<crate::selection::Selection>>;
+
+    #[cfg(test)]
+    fn assert_all_selections(
+        &self,
+        buffer: &Buffer,
+        current_selection: Selection,
+        selections: &[(Range<usize>, &'static str)],
+    ) {
+        let expected = selections
+            .iter()
+            .map(|(range, info)| (range.to_owned(), info.to_string()))
+            .collect_vec();
+
+        let actual_forward = self
+            .all_selections(SelectionModeParams {
+                buffer,
+                current_selection: &current_selection,
+                cursor_direction: &Direction::default(),
+            })
+            .unwrap()
+            .into_iter()
+            .flat_map(|range| -> anyhow::Result<_> {
+                Ok((
+                    range.range.start..range.range.end,
+                    buffer
+                        .slice(&range.to_char_index_range(buffer)?)?
+                        .to_string(),
+                ))
+            })
+            .collect_vec();
+
+        assert_eq!(expected, actual_forward);
+
+        let actual_backward = self
+            .all_selections_gathered_inversely(SelectionModeParams {
+                buffer,
+                current_selection: &current_selection,
+                cursor_direction: &Direction::default(),
+            })
+            .unwrap()
+            .into_iter()
+            .flat_map(|range| -> anyhow::Result<_> {
+                Ok((
+                    range.range.start..range.range.end,
+                    buffer
+                        .slice(&range.to_char_index_range(buffer)?)?
+                        .to_string(),
+                ))
+            })
+            .collect_vec();
+
+        assert_eq!(expected, actual_backward, "backward assertion");
+    }
+}
+
+pub trait PositionBasedSelectionMode {
+    fn jumps_impl(
+        &self,
+        params: &SelectionModeParams,
+        chars: Vec<char>,
+        line_number_ranges: Vec<Range<usize>>,
+    ) -> anyhow::Result<Vec<Jump>> {
+        let ranges = self.selections_in_line_number_range_impl(&params, line_number_ranges)?;
+        let jumps = ranges
+            .into_iter()
+            .filter_map(|range| {
+                let selection = range
+                    .to_selection(params.buffer, params.current_selection)
+                    .ok()?;
+                let character = params
+                    .buffer
+                    .slice(&selection.range()) // Cannot use extend_range here, must use range only
+                    .ok()?
+                    .chars()
+                    .next()?
+                    .to_ascii_lowercase();
+                Some(Jump {
+                    character,
+                    selection,
+                })
+            })
+            .collect_vec();
+        let jumps = if jumps
+            .iter()
+            .chunk_by(|jump| jump.character)
+            .into_iter()
+            .count()
+            > 1
+        {
+            jumps
+        } else {
+            // All jumps has the same chars, assign their char using the given chars set
+            chars
+                .into_iter()
+                .cycle()
+                .zip(jumps)
+                .map(|(char, jump)| Jump {
+                    character: char,
+                    selection: jump.selection,
+                })
+                .collect_vec()
+        };
+        Ok(jumps)
+    }
+
+    fn selections_in_line_number_range_impl(
         &self,
         params: &SelectionModeParams,
         line_number_ranges: Vec<Range<usize>>,
@@ -569,99 +780,12 @@ pub trait SelectionMode {
 
         Ok(result)
     }
-
-    fn revealed_selections<'a>(
-        &'a self,
-        params: SelectionModeParams<'a>,
-    ) -> anyhow::Result<Vec<ByteRange>> {
-        self.all_selections(params)
-    }
-
-    fn jumps(
+    fn get_current_selection_by_cursor(
         &self,
-        params: SelectionModeParams,
-        chars: Vec<char>,
-        line_number_ranges: Vec<Range<usize>>,
-    ) -> anyhow::Result<Vec<Jump>> {
-        let ranges = self.selections_in_line_number_range(&params, line_number_ranges)?;
-        let jumps = ranges
-            .into_iter()
-            .filter_map(|range| {
-                let selection = range
-                    .to_selection(params.buffer, params.current_selection)
-                    .ok()?;
-                let character = params
-                    .buffer
-                    .slice(&selection.range()) // Cannot use extend_range here, must use range only
-                    .ok()?
-                    .chars()
-                    .next()?
-                    .to_ascii_lowercase();
-                Some(Jump {
-                    character,
-                    selection,
-                })
-            })
-            .collect_vec();
-        let jumps = if jumps
-            .iter()
-            .chunk_by(|jump| jump.character)
-            .into_iter()
-            .count()
-            > 1
-        {
-            jumps
-        } else {
-            // All jumps has the same chars, assign their char using the given chars set
-            chars
-                .into_iter()
-                .cycle()
-                .zip(jumps)
-                .map(|(char, jump)| Jump {
-                    character: char,
-                    selection: jump.selection,
-                })
-                .collect_vec()
-        };
-        Ok(jumps)
-    }
-
-    fn to_index(
-        &self,
-        params: SelectionModeParams,
-        index: usize,
-    ) -> anyhow::Result<Option<Selection>> {
-        let current_selection = params.current_selection;
-        let buffer = params.buffer;
-        let mut cursor_char_index = CharIndex(0);
-        let limit = CharIndex(params.buffer.len_chars());
-        let mut current_index: usize = 0;
-        while cursor_char_index < limit {
-            if let Some(range) = self.get_current_selection_by_cursor(
-                &params.buffer,
-                cursor_char_index,
-                IfCurrentNotFound::LookForward,
-            )? {
-                if current_index == index {
-                    return Ok(Some(range.to_selection(buffer, current_selection)?));
-                } else {
-                    current_index += 1;
-                    cursor_char_index = buffer.byte_to_char(range.range.end)?
-                }
-            } else {
-                return Ok(None);
-            }
-        }
-        return Ok(None);
-    }
-
-    fn delete_forward(&self, params: SelectionModeParams) -> anyhow::Result<Option<Selection>> {
-        self.right(params)
-    }
-
-    fn delete_backward(&self, params: SelectionModeParams) -> anyhow::Result<Option<Selection>> {
-        self.left(params)
-    }
+        buffer: &Buffer,
+        cursor_char_index: CharIndex,
+        if_current_not_found: IfCurrentNotFound,
+    ) -> anyhow::Result<Option<ByteRange>>;
 
     fn first(&self, params: &SelectionModeParams) -> anyhow::Result<Option<Selection>> {
         self.get_current_selection_by_cursor(
@@ -683,45 +807,9 @@ pub trait SelectionMode {
         .transpose()
     }
 
-    fn get_current_selection_by_cursor(
-        &self,
-        buffer: &Buffer,
-        cursor_char_index: CharIndex,
-        if_current_not_found: IfCurrentNotFound,
-    ) -> anyhow::Result<Option<ByteRange>>;
-
-    fn current(
-        &self,
-        params: SelectionModeParams,
-        if_current_not_found: IfCurrentNotFound,
-    ) -> anyhow::Result<Option<crate::selection::Selection>> {
-        let range = self.get_current_selection_by_cursor(
-            &params.buffer,
-            params.cursor_char_index(),
-            if_current_not_found,
-        )?;
-        let range = if range.is_none() {
-            self.get_current_selection_by_cursor(
-                &params.buffer,
-                params.cursor_char_index(),
-                if_current_not_found.inverse(),
-            )?
-        } else {
-            range
-        };
-        range
-            .map(|range| {
-                params
-                    .current_selection
-                    .clone()
-                    .update_with_byte_range(params.buffer, range)
-            })
-            .transpose()
-    }
-
     fn right(
         &self,
-        params: SelectionModeParams,
+        params: &SelectionModeParams,
     ) -> anyhow::Result<Option<crate::selection::Selection>> {
         self.get_current_selection_by_cursor(
             params.buffer,
@@ -739,7 +827,7 @@ pub trait SelectionMode {
 
     fn left(
         &self,
-        params: SelectionModeParams,
+        params: &SelectionModeParams,
     ) -> anyhow::Result<Option<crate::selection::Selection>> {
         self.get_current_selection_by_cursor(
             &params.buffer,
@@ -755,57 +843,427 @@ pub trait SelectionMode {
         .transpose()
     }
 
+    fn delete_forward(&self, params: &SelectionModeParams) -> anyhow::Result<Option<Selection>> {
+        self.right(params)
+    }
+
+    fn delete_backward(&self, params: &SelectionModeParams) -> anyhow::Result<Option<Selection>> {
+        self.left(params)
+    }
+
+    fn revealed_selections<'a>(
+        &'a self,
+        params: SelectionModeParams<'a>,
+    ) -> anyhow::Result<Vec<ByteRange>> {
+        self.all_selections(params)
+    }
+
+    fn all_selections<'a>(
+        &'a self,
+        params: SelectionModeParams<'a>,
+    ) -> anyhow::Result<Vec<ByteRange>> {
+        let mut cursor_char_index = CharIndex(0);
+        let mut result = Vec::new();
+        while cursor_char_index < CharIndex(params.buffer.len_chars()) {
+            if let Some(range) = self.get_current_selection_by_cursor(
+                &params.buffer,
+                cursor_char_index,
+                IfCurrentNotFound::LookForward,
+            )? {
+                cursor_char_index = params.buffer.byte_to_char(range.range.end)?;
+
+                if Some(&range) == result.last() {
+                    result.push(range);
+                    break;
+                } else {
+                    result.push(range);
+                }
+            } else {
+                break;
+            }
+        }
+        return Ok(result);
+    }
+
+    fn expand_impl(
+        &self,
+        params: &SelectionModeParams,
+    ) -> anyhow::Result<Option<ApplyMovementResult>> {
+        params.expand()
+    }
+
+    fn up_impl(&self, params: &SelectionModeParams) -> anyhow::Result<Option<Selection>> {
+        self.vertical_movement(params, true)
+    }
+
+    fn down_impl(&self, params: &SelectionModeParams) -> anyhow::Result<Option<Selection>> {
+        self.vertical_movement(params, false)
+    }
+
+    fn vertical_movement(
+        &self,
+        params: &SelectionModeParams,
+        is_up: bool,
+    ) -> anyhow::Result<Option<Selection>> {
+        let cursor_char_index = params.cursor_char_index();
+        let SelectionModeParams {
+            buffer,
+            current_selection,
+            ..
+        } = params;
+        let current_position = buffer.char_to_position(cursor_char_index)?;
+
+        // Early return check
+        if (is_up && current_position.line == 0)
+            || (!is_up && current_position.line == buffer.len_lines().saturating_sub(1))
+        {
+            return Ok(None);
+        }
+
+        // Calculate the new line
+        let new_line = if is_up {
+            current_position.line - 1
+        } else {
+            current_position.line + 1
+        };
+
+        let mut new_position = current_position.set_line(new_line);
+        let mut new_cursor_char_index = buffer.position_to_char(new_position)?;
+
+        // Define which look direction to try first and second based on movement direction
+        let (first_look, second_look) = if is_up {
+            (
+                IfCurrentNotFound::LookBackward,
+                IfCurrentNotFound::LookForward,
+            )
+        } else {
+            (
+                IfCurrentNotFound::LookForward,
+                IfCurrentNotFound::LookBackward,
+            )
+        };
+
+        while let Some(result) =
+            self.get_current_selection_by_cursor(&params.buffer, new_cursor_char_index, first_look)?
+        {
+            if buffer.byte_to_line(result.range.start)? == new_position.line {
+                return Ok(Some(
+                    (*current_selection)
+                        .clone()
+                        .set_range(buffer.byte_range_to_char_index_range(&result.range)?)
+                        .set_info(result.info),
+                ));
+            } else if let Some(result) = self.get_current_selection_by_cursor(
+                &params.buffer,
+                new_cursor_char_index,
+                second_look,
+            )? {
+                if buffer.byte_to_line(result.range.start)? == new_position.line {
+                    return Ok(Some(
+                        (*current_selection)
+                            .clone()
+                            .set_range(buffer.byte_range_to_char_index_range(&result.range)?)
+                            .set_info(result.info),
+                    ));
+                }
+            }
+
+            // Move to next line
+            new_position.line = if is_up {
+                new_position.line.saturating_sub(1)
+            } else {
+                new_position.line + 1
+            };
+            new_cursor_char_index = buffer.position_to_char(new_position)?;
+        }
+
+        Ok(None)
+    }
+}
+pub(crate) struct PositionBased<T: PositionBasedSelectionMode>(pub(crate) T);
+pub(crate) struct VectorBased<T: VectorBasedSelectionMode>(pub(crate) T);
+
+impl<T: VectorBasedSelectionMode> SelectionMode for VectorBased<T> {
+    fn all_selections<'a>(
+        &'a self,
+        params: SelectionModeParams<'a>,
+    ) -> anyhow::Result<Vec<ByteRange>> {
+        Ok(self
+            .0
+            .get_byte_ranges(params.buffer)?
+            .iter()
+            .cloned()
+            .collect_vec())
+    }
+
     #[cfg(test)]
-    fn assert_all_selections(
+    fn all_selections_gathered_inversely<'a>(
+        &'a self,
+        params: SelectionModeParams<'a>,
+    ) -> anyhow::Result<Vec<ByteRange>> {
+        self.all_selections(params)
+    }
+
+    fn selections_in_line_number_range(
+        &self,
+        params: &SelectionModeParams,
+        line_number_ranges: Vec<Range<usize>>,
+    ) -> anyhow::Result<Vec<ByteRange>> {
+        let line_byte_ranges = line_number_ranges
+            .into_iter()
+            .flat_map(|lines| lines.flat_map(|line| params.buffer.line_to_byte_range(line).ok()))
+            .collect_vec();
+        Ok(self
+            .0
+            .get_byte_ranges(params.buffer)?
+            .iter()
+            .filter(|range| {
+                line_byte_ranges
+                    .iter()
+                    .any(|line_byte_range| range_intersects(line_byte_range.range(), range.range()))
+            })
+            .cloned()
+            .collect_vec())
+    }
+
+    fn to_index(
+        &self,
+        params: &SelectionModeParams,
+        index: usize,
+    ) -> anyhow::Result<Option<Selection>> {
+        self.0
+            .get_byte_ranges(params.buffer)?
+            .get(index)
+            .map(|range| {
+                Ok(params.current_selection.clone().set_range(
+                    params
+                        .buffer
+                        .byte_range_to_char_index_range(range.range())?,
+                ))
+            })
+            .transpose()
+    }
+
+    fn first(&self, params: &SelectionModeParams) -> anyhow::Result<Option<Selection>> {
+        self.to_index(params, 0)
+    }
+
+    fn last(&self, params: &SelectionModeParams) -> anyhow::Result<Option<Selection>> {
+        self.to_index(
+            params,
+            self.0
+                .get_byte_ranges(params.buffer)?
+                .len()
+                .saturating_sub(1),
+        )
+    }
+
+    fn right(
+        &self,
+        params: &SelectionModeParams,
+    ) -> anyhow::Result<Option<crate::selection::Selection>> {
+        let byte_range = params
+            .buffer
+            .char_index_range_to_byte_range(params.current_selection.range())?;
+        let ranges = self.0.get_byte_ranges(params.buffer)?;
+        match ranges.binary_search_by(|range| range.range().clone().cmp(byte_range.clone())) {
+            Ok(index) if index < ranges.len().saturating_sub(1) => ranges
+                .get(index + 1)
+                .map(|byte_range| {
+                    Ok(params.current_selection.clone().set_range(
+                        params
+                            .buffer
+                            .byte_range_to_char_index_range(byte_range.range())?,
+                    ))
+                })
+                .transpose(),
+            _ => self.current(&params, IfCurrentNotFound::LookForward),
+        }
+    }
+
+    fn left(
+        &self,
+        params: &SelectionModeParams,
+    ) -> anyhow::Result<Option<crate::selection::Selection>> {
+        let byte_ranges = self.0.get_byte_ranges(params.buffer)?;
+        let byte_range = params
+            .buffer
+            .char_index_range_to_byte_range(params.current_selection.range())?;
+        match byte_ranges.binary_search_by(|range| range.range().clone().cmp(byte_range.clone())) {
+            Ok(index) if index > 0 => byte_ranges
+                .get(index - 1)
+                .map(|byte_range| {
+                    Ok(params.current_selection.clone().set_range(
+                        params
+                            .buffer
+                            .byte_range_to_char_index_range(byte_range.range())?,
+                    ))
+                })
+                .transpose(),
+            _ => self.current(&params, IfCurrentNotFound::LookBackward),
+        }
+    }
+
+    fn up(&self, params: &SelectionModeParams) -> anyhow::Result<Option<Selection>> {
+        self.0.up_impl(params)
+    }
+
+    fn down(&self, params: &SelectionModeParams) -> anyhow::Result<Option<Selection>> {
+        self.0.down_impl(params)
+    }
+
+    fn expand(&self, params: &SelectionModeParams) -> anyhow::Result<Option<ApplyMovementResult>> {
+        params.expand()
+    }
+
+    fn jumps(
+        &self,
+        params: &SelectionModeParams,
+        chars: Vec<char>,
+        line_number_ranges: Vec<Range<usize>>,
+    ) -> anyhow::Result<Vec<Jump>> {
+        todo!()
+    }
+
+    fn get_current_selection_by_cursor(
         &self,
         buffer: &Buffer,
-        current_selection: Selection,
-        selections: &[(Range<usize>, &'static str)],
-    ) {
-        let expected = selections
-            .iter()
-            .map(|(range, info)| (range.to_owned(), info.to_string()))
-            .collect_vec();
+        cursor_char_index: CharIndex,
+        if_current_not_found: IfCurrentNotFound,
+    ) -> anyhow::Result<Option<ByteRange>> {
+        self.0
+            .get_current_selection_by_cursor(buffer, cursor_char_index, if_current_not_found)
+    }
+}
 
-        let actual_forward = self
-            .all_selections(SelectionModeParams {
-                buffer,
-                current_selection: &current_selection,
-                cursor_direction: &Direction::default(),
-            })
-            .unwrap()
-            .into_iter()
-            .flat_map(|range| -> anyhow::Result<_> {
-                Ok((
-                    range.range.start..range.range.end,
-                    buffer
-                        .slice(&range.to_char_index_range(buffer)?)?
-                        .to_string(),
-                ))
-            })
-            .collect_vec();
+pub trait VectorBasedSelectionMode {
+    fn get_byte_ranges(&self, buffer: &Buffer) -> anyhow::Result<Rc<Vec<ByteRange>>>;
 
-        assert_eq!(expected, actual_forward);
+    fn up_impl(&self, params: &SelectionModeParams) -> anyhow::Result<Option<Selection>> {
+        self.vertical_movement(params, true)
+    }
 
-        let actual_backward = self
-            .all_selections_gathered_inversely(SelectionModeParams {
-                buffer,
-                current_selection: &current_selection,
-                cursor_direction: &Direction::default(),
-            })
-            .unwrap()
-            .into_iter()
-            .flat_map(|range| -> anyhow::Result<_> {
-                Ok((
-                    range.range.start..range.range.end,
-                    buffer
-                        .slice(&range.to_char_index_range(buffer)?)?
-                        .to_string(),
-                ))
-            })
-            .collect_vec();
+    fn down_impl(&self, params: &SelectionModeParams) -> anyhow::Result<Option<Selection>> {
+        self.vertical_movement(params, false)
+    }
 
-        assert_eq!(expected, actual_backward, "backward assertion");
+    fn get_current_selection_by_cursor(
+        &self,
+        buffer: &Buffer,
+        cursor_char_index: CharIndex,
+        if_current_not_found: IfCurrentNotFound,
+    ) -> anyhow::Result<Option<ByteRange>> {
+        let vec = self.get_byte_ranges(buffer)?;
+        debug_assert!(vec.iter().is_sorted());
+        let cursor_byte = buffer.char_to_byte(cursor_char_index)?;
+        let mut previous_range: Option<&ByteRange> = None;
+        let partition_point =
+            vec.partition_point(|byte_range| byte_range.range().start < cursor_byte);
+        let calibrated_partition_point = match if_current_not_found {
+            IfCurrentNotFound::LookForward => partition_point,
+            IfCurrentNotFound::LookBackward => {
+                if partition_point == 0 {
+                    return Ok(None);
+                } else {
+                    partition_point - 1
+                }
+            }
+        };
+        return Ok(vec.iter().nth(calibrated_partition_point).cloned());
+
+        for range in vec.iter() {
+            if range.range().contains(&cursor_byte) {
+                return Ok(Some(range.clone()));
+            } else if range.range.start > cursor_byte {
+                match if_current_not_found {
+                    IfCurrentNotFound::LookForward => return Ok(Some(range.clone())),
+                    IfCurrentNotFound::LookBackward => return Ok(previous_range.cloned()),
+                }
+            } else {
+                previous_range = Some(range)
+            }
+        }
+        Ok(None)
+    }
+
+    fn vertical_movement(
+        &self,
+        params: &SelectionModeParams,
+        is_up: bool,
+    ) -> anyhow::Result<Option<Selection>> {
+        let cursor_char_index = params.cursor_char_index();
+        let SelectionModeParams {
+            buffer,
+            current_selection,
+            ..
+        } = params;
+        let current_position = buffer.char_to_position(cursor_char_index)?;
+
+        // Early return check
+        if (is_up && current_position.line == 0)
+            || (!is_up && current_position.line == buffer.len_lines().saturating_sub(1))
+        {
+            return Ok(None);
+        }
+
+        // Calculate the new line
+        let new_line = if is_up {
+            current_position.line - 1
+        } else {
+            current_position.line + 1
+        };
+
+        let mut new_position = current_position.set_line(new_line);
+        let mut new_cursor_char_index = buffer.position_to_char(new_position)?;
+
+        // Define which look direction to try first and second based on movement direction
+        let (first_look, second_look) = if is_up {
+            (
+                IfCurrentNotFound::LookBackward,
+                IfCurrentNotFound::LookForward,
+            )
+        } else {
+            (
+                IfCurrentNotFound::LookForward,
+                IfCurrentNotFound::LookBackward,
+            )
+        };
+
+        while let Some(result) =
+            self.get_current_selection_by_cursor(&params.buffer, new_cursor_char_index, first_look)?
+        {
+            if buffer.byte_to_line(result.range.start)? == new_position.line {
+                return Ok(Some(
+                    (*current_selection)
+                        .clone()
+                        .set_range(buffer.byte_range_to_char_index_range(&result.range)?)
+                        .set_info(result.info),
+                ));
+            } else if let Some(result) = self.get_current_selection_by_cursor(
+                &params.buffer,
+                new_cursor_char_index,
+                second_look,
+            )? {
+                if buffer.byte_to_line(result.range.start)? == new_position.line {
+                    return Ok(Some(
+                        (*current_selection)
+                            .clone()
+                            .set_range(buffer.byte_range_to_char_index_range(&result.range)?)
+                            .set_info(result.info),
+                    ));
+                }
+            }
+
+            // Move to next line
+            new_position.line = if is_up {
+                new_position.line.saturating_sub(1)
+            } else {
+                new_position.line + 1
+            };
+            new_cursor_char_index = buffer.position_to_char(new_position)?;
+        }
+
+        Ok(None)
     }
 }
 
@@ -821,13 +1279,14 @@ mod test_selection_mode {
             suggestive_editor::Info,
         },
         selection::{CharIndex, Selection},
+        selection_mode::{PositionBased, SelectionMode},
     };
 
-    use super::{ByteRange, SelectionMode, SelectionModeParams};
+    use super::{ByteRange, PositionBasedSelectionMode, SelectionModeParams};
     use pretty_assertions::assert_eq;
 
     struct Dummy;
-    impl SelectionMode for Dummy {
+    impl PositionBasedSelectionMode for Dummy {
         fn get_current_selection_by_cursor(
             &self,
             buffer: &crate::buffer::Buffer,
@@ -851,8 +1310,8 @@ mod test_selection_mode {
             }),
             cursor_direction: &Direction::default(),
         };
-        let actual = Dummy
-            .apply_movement(params, movement)
+        let actual = PositionBased(Dummy)
+            .apply_movement(&params, movement)
             .unwrap()
             .unwrap()
             .selection
@@ -939,7 +1398,7 @@ mod test_selection_mode {
             cursor_direction: &Direction::default(),
         };
         struct Dummy;
-        impl SelectionMode for Dummy {
+        impl PositionBasedSelectionMode for Dummy {
             fn get_current_selection_by_cursor(
                 &self,
                 buffer: &crate::buffer::Buffer,
@@ -962,8 +1421,8 @@ mod test_selection_mode {
             }
         }
         let run_test = |movement: Movement, expected_info: &str| {
-            let actual = Dummy
-                .apply_movement(params.clone(), movement)
+            let actual = PositionBased(Dummy)
+                .apply_movement(&params, movement)
                 .unwrap()
                 .unwrap()
                 .selection;
@@ -993,8 +1452,8 @@ mod test_selection_mode {
                 })),
             cursor_direction: &Direction::default(),
         };
-        let actual = Dummy
-            .apply_movement(params, Movement::Right)
+        let actual = PositionBased(Dummy)
+            .apply_movement(&params, Movement::Right)
             .unwrap()
             .unwrap()
             .selection

--- a/src/selection_mode/naming_convention_agnostic.rs
+++ b/src/selection_mode/naming_convention_agnostic.rs
@@ -1,6 +1,6 @@
 use itertools::Itertools;
 
-use super::{ByteRange, IterBasedSelectionMode, SelectionMode};
+use super::{ByteRange, IterBasedSelectionMode};
 
 pub(crate) struct NamingConventionAgnostic {
     pattern: String,

--- a/src/selection_mode/naming_convention_agnostic.rs
+++ b/src/selection_mode/naming_convention_agnostic.rs
@@ -70,6 +70,7 @@ impl SelectionMode for NamingConventionAgnostic {
         &self,
         buffer: &crate::buffer::Buffer,
         cursor_char_index: crate::selection::CharIndex,
+        if_current_not_found: crate::components::editor::IfCurrentNotFound,
     ) -> anyhow::Result<Option<super::ByteRange>> {
         let cursor_byte = buffer.char_to_byte(cursor_char_index)?;
         Ok(self

--- a/src/selection_mode/naming_convention_agnostic.rs
+++ b/src/selection_mode/naming_convention_agnostic.rs
@@ -66,14 +66,17 @@ impl NamingConventionAgnostic {
 }
 
 impl SelectionMode for NamingConventionAgnostic {
-    fn iter<'a>(
-        &'a self,
-        params: super::SelectionModeParams<'a>,
-    ) -> anyhow::Result<Box<dyn Iterator<Item = super::ByteRange> + 'a>> {
-        let string = params.buffer.rope().to_string();
-        Ok(Box::new(
-            self.find_all(&string).into_iter().map(|(range, _)| range),
-        ))
+    fn get_current_selection_by_cursor(
+        &self,
+        buffer: &crate::buffer::Buffer,
+        cursor_char_index: crate::selection::CharIndex,
+    ) -> anyhow::Result<Option<super::ByteRange>> {
+        let cursor_byte = buffer.char_to_byte(cursor_char_index)?;
+        Ok(self
+            .find_all(&buffer.rope().to_string())
+            .into_iter()
+            .find(|(range, _)| range.range.contains(&cursor_byte))
+            .map(|(range, _)| range))
     }
 }
 

--- a/src/selection_mode/regex.rs
+++ b/src/selection_mode/regex.rs
@@ -1,6 +1,6 @@
 use crate::{buffer::Buffer, list::grep::RegexConfig};
 
-use super::{ByteRange, IterBasedSelectionMode, SelectionMode};
+use super::{ByteRange, IterBasedSelectionMode};
 
 pub(crate) struct Regex {
     regex: fancy_regex::Regex,

--- a/src/selection_mode/syntax_node.rs
+++ b/src/selection_mode/syntax_node.rs
@@ -155,6 +155,7 @@ impl SelectionMode for SyntaxNode {
         &self,
         buffer: &crate::buffer::Buffer,
         cursor_char_index: crate::selection::CharIndex,
+        if_current_not_found: crate::components::editor::IfCurrentNotFound,
     ) -> anyhow::Result<Option<super::ByteRange>> {
         // Implement this code
         let node = buffer

--- a/src/selection_mode/syntax_node.rs
+++ b/src/selection_mode/syntax_node.rs
@@ -2,7 +2,7 @@ use itertools::Itertools;
 
 use crate::selection_mode::ApplyMovementResult;
 
-use super::{ByteRange, IterBasedSelectionMode, SelectionMode, SyntaxToken, TopNode};
+use super::{ByteRange, IterBasedSelectionMode, SyntaxToken, TopNode};
 
 pub(crate) struct SyntaxNode {
     /// If this is true:
@@ -58,7 +58,7 @@ impl IterBasedSelectionMode for SyntaxNode {
         &self,
         params: &super::SelectionModeParams,
     ) -> anyhow::Result<Option<ApplyMovementResult>> {
-        self.select_vertical(params.clone(), true)
+        self.select_vertical(params, true)
     }
     fn down(
         &self,

--- a/src/selection_mode/syntax_token.rs
+++ b/src/selection_mode/syntax_token.rs
@@ -1,6 +1,6 @@
 pub(crate) struct SyntaxToken;
 
-use crate::{components::editor::IfCurrentNotFound, selection_mode::SelectionMode};
+use crate::components::editor::IfCurrentNotFound;
 
 use super::{ByteRange, IterBasedSelectionMode, TopNode};
 

--- a/src/selection_mode/syntax_token.rs
+++ b/src/selection_mode/syntax_token.rs
@@ -1,63 +1,48 @@
 pub(crate) struct SyntaxToken;
 
-use std::rc::Rc;
+use crate::{components::editor::IfCurrentNotFound, selection_mode::SelectionMode};
 
-use crate::{
-    buffer::Buffer, components::editor::IfCurrentNotFound,
-    selection_mode::PositionBasedSelectionMode,
-};
+use super::{ByteRange, IterBasedSelectionMode, TopNode};
 
-use super::{
-    get_current_selection_by_cursor_via_iter, ByteRange, PositionBased, SelectionMode, TopNode,
-};
+impl IterBasedSelectionMode for SyntaxToken {
+    fn iter<'a>(
+        &self,
+        params: &super::SelectionModeParams<'a>,
+    ) -> anyhow::Result<Box<dyn Iterator<Item = ByteRange> + 'a>> {
+        let buffer = params.buffer;
+        let tree = buffer
+            .tree()
+            .ok_or(anyhow::anyhow!("Unable to find Treesitter language"))?;
+        Ok(Box::new(
+            tree_sitter_traversal2::traverse(tree.walk(), tree_sitter_traversal2::Order::Post)
+                .filter(|node| node.child_count() == 0)
+                .map(|node| ByteRange::new(node.byte_range())),
+        ))
+    }
 
-impl PositionBasedSelectionMode for SyntaxToken {
-    fn expand_impl(
+    fn expand(
         &self,
         params: &super::SelectionModeParams,
     ) -> anyhow::Result<Option<crate::selection_mode::ApplyMovementResult>> {
-        Ok(PositionBased(TopNode)
+        Ok(TopNode
             .current(params, IfCurrentNotFound::LookForward)?
             .map(|selection| crate::selection_mode::ApplyMovementResult {
                 selection,
                 mode: Some(crate::selection::SelectionMode::SyntaxNode),
             }))
     }
-
-    fn get_current_selection_by_cursor(
-        &self,
-        buffer: &crate::buffer::Buffer,
-        cursor_char_index: crate::selection::CharIndex,
-        if_current_not_found: crate::components::editor::IfCurrentNotFound,
-    ) -> anyhow::Result<Option<super::ByteRange>> {
-        let cursor_byte = buffer.char_to_byte(cursor_char_index)?;
-        let tree = buffer
-            .tree()
-            .ok_or(anyhow::anyhow!("Unable to find Treesitter language"))?;
-        get_current_selection_by_cursor_via_iter(
-            buffer,
-            cursor_char_index,
-            if_current_not_found,
-            Rc::new(
-                tree_sitter_traversal2::traverse(tree.walk(), tree_sitter_traversal2::Order::Post)
-                    .filter(|node| node.child_count() == 0)
-                    .map(|node| ByteRange::new(node.byte_range()))
-                    .collect(),
-            ),
-        )
-    }
 }
 
 #[cfg(test)]
 mod test_token {
-    use crate::{buffer::Buffer, selection::Selection, selection_mode::SelectionMode};
+    use crate::{buffer::Buffer, selection::Selection};
 
     use super::*;
 
     #[test]
     fn case_1() {
         let buffer = Buffer::new(Some(tree_sitter_rust::LANGUAGE.into()), "fn main() {}");
-        PositionBased(SyntaxToken).assert_all_selections(
+        SyntaxToken.assert_all_selections(
             &buffer,
             Selection::default(),
             &[

--- a/src/selection_mode/syntax_token.rs
+++ b/src/selection_mode/syntax_token.rs
@@ -2,16 +2,21 @@ pub(crate) struct SyntaxToken;
 
 use std::rc::Rc;
 
-use crate::{buffer::Buffer, components::editor::IfCurrentNotFound, selection_mode::SelectionMode};
+use crate::{
+    buffer::Buffer, components::editor::IfCurrentNotFound,
+    selection_mode::PositionBasedSelectionMode,
+};
 
-use super::{get_current_selection_by_cursor_via_iter, ByteRange, TopNode};
+use super::{
+    get_current_selection_by_cursor_via_iter, ByteRange, PositionBased, SelectionMode, TopNode,
+};
 
-impl SelectionMode for SyntaxToken {
-    fn expand(
+impl PositionBasedSelectionMode for SyntaxToken {
+    fn expand_impl(
         &self,
-        params: super::SelectionModeParams,
+        params: &super::SelectionModeParams,
     ) -> anyhow::Result<Option<crate::selection_mode::ApplyMovementResult>> {
-        Ok(TopNode
+        Ok(PositionBased(TopNode)
             .current(params, IfCurrentNotFound::LookForward)?
             .map(|selection| crate::selection_mode::ApplyMovementResult {
                 selection,
@@ -45,14 +50,14 @@ impl SelectionMode for SyntaxToken {
 
 #[cfg(test)]
 mod test_token {
-    use crate::{buffer::Buffer, selection::Selection};
+    use crate::{buffer::Buffer, selection::Selection, selection_mode::SelectionMode};
 
     use super::*;
 
     #[test]
     fn case_1() {
         let buffer = Buffer::new(Some(tree_sitter_rust::LANGUAGE.into()), "fn main() {}");
-        SyntaxToken.assert_all_selections(
+        PositionBased(SyntaxToken).assert_all_selections(
             &buffer,
             Selection::default(),
             &[

--- a/src/selection_mode/token.rs
+++ b/src/selection_mode/token.rs
@@ -4,15 +4,15 @@ use crate::{
     char_index_range::CharIndexRange, components::editor::IfCurrentNotFound, selection::CharIndex,
 };
 
-use super::{ByteRange, SelectionMode};
+use super::{ByteRange, PositionBased, PositionBasedSelectionMode};
 
 pub struct Token {
     skip_symbols: bool,
 }
 
 impl Token {
-    pub(crate) fn new(skip_symbols: bool) -> anyhow::Result<Self> {
-        Ok(Self { skip_symbols })
+    pub(crate) fn new(skip_symbols: bool) -> Self {
+        Self { skip_symbols }
     }
 }
 
@@ -125,7 +125,7 @@ fn find_word_end(
     // If we've examined all characters to the end, return the last index
     last_char_index
 }
-impl SelectionMode for Token {
+impl PositionBasedSelectionMode for Token {
     fn first(
         &self,
         params: &super::SelectionModeParams,
@@ -241,7 +241,11 @@ impl SelectionMode for Token {
 
 #[cfg(test)]
 mod test_token {
-    use crate::{buffer::Buffer, selection::Selection, selection_mode::SelectionMode};
+    use crate::{
+        buffer::Buffer,
+        selection::Selection,
+        selection_mode::{PositionBasedSelectionMode, SelectionMode},
+    };
 
     use super::*;
 
@@ -251,7 +255,7 @@ mod test_token {
             None,
             "snake_case camelCase PascalCase UPPER_SNAKE kebab-case ->() 123 <_>",
         );
-        Token::new(true).unwrap().assert_all_selections(
+        PositionBased(Token::new(true)).assert_all_selections(
             &buffer,
             Selection::default(),
             &[
@@ -272,7 +276,7 @@ mod test_token {
             None,
             "snake_case camelCase PascalCase UPPER_SNAKE kebab-case ->() 123 <_>",
         );
-        Token::new(false).unwrap().assert_all_selections(
+        PositionBased(Token::new(false)).assert_all_selections(
             &buffer,
             Selection::default(),
             &[

--- a/src/selection_mode/token.rs
+++ b/src/selection_mode/token.rs
@@ -1,10 +1,13 @@
-use crate::buffer::Buffer;
+use ropey::Rope;
+
+use crate::{
+    buffer::Buffer, char_index_range::CharIndexRange, components::editor::IfCurrentNotFound,
+    selection::CharIndex,
+};
 
 use super::{ByteRange, SelectionMode};
 
 pub struct Token {
-    normal_regex: super::Regex,
-    symbol_skipping_regex: super::Regex,
     skip_symbols: bool,
 }
 
@@ -15,23 +18,140 @@ impl Token {
             case_sensitive: false,
             match_whole_word: false,
         };
-        Ok(Self {
-            normal_regex: super::Regex::from_config(buffer, r"((\w|-)+)|([^a-zA-Z\d\s])", config)?,
-            symbol_skipping_regex: super::Regex::from_config(buffer, r"(\w|-)+", config)?,
-            skip_symbols,
-        })
+        Ok(Self { skip_symbols })
     }
+}
+
+fn current_impl(
+    rope: &Rope,
+    cursor_char_index: CharIndex,
+    if_current_not_found: IfCurrentNotFound,
+    skip_symbols: bool,
+) -> anyhow::Result<Option<CharIndexRange>> {
+    let last_char_index = CharIndex(rope.len_chars().saturating_sub(1));
+    let is_word = |char: char| char.is_alphanumeric() || char == '_' || char == '-';
+    let is_symbol = |char: char| !is_word(char) && !char.is_whitespace();
+    if cursor_char_index > last_char_index {
+        return Ok(None);
+    }
+    let Some(current) = ({
+        let predicate = |char: char| {
+            if skip_symbols {
+                is_word(char)
+            } else {
+                is_word(char) || is_symbol(char)
+            }
+        };
+        match if_current_not_found {
+            IfCurrentNotFound::LookForward => {
+                let mut index = cursor_char_index;
+                loop {
+                    let char = rope.char(index.0);
+                    if !predicate(char) {
+                        index = index + 1
+                    } else {
+                        break Some(index);
+                    }
+                    if index >= last_char_index {
+                        break None;
+                    }
+                }
+            }
+            IfCurrentNotFound::LookBackward => {
+                let mut index = cursor_char_index;
+                loop {
+                    if index == CharIndex(0) {
+                        break None;
+                    }
+                    let char = rope.char(index.0);
+                    if !predicate(char) {
+                        index = index - 1
+                    } else {
+                        break Some(index);
+                    }
+                }
+            }
+        }
+    }) else {
+        return Ok(None);
+    };
+    if current.0 >= rope.len_chars() {
+        return Ok(None);
+    }
+    if !skip_symbols && is_symbol(rope.char(current.0)) {
+        return Ok(Some((current..current + 1).into()));
+    }
+    let start = {
+        let mut index = current;
+        loop {
+            if index.0 == 0 {
+                break index;
+            }
+            let char = rope.char(index.0.saturating_sub(1));
+            if is_word(char) {
+                index = index - 1
+            } else {
+                break index;
+            }
+        }
+    };
+    let end = {
+        let mut index = current;
+        loop {
+            if index == last_char_index {
+                break index;
+            }
+            let char = rope.char(index.0 + 1);
+            if is_word(char) {
+                index = index + 1
+            } else {
+                break index;
+            }
+        }
+    } + 1;
+    debug_assert!(is_word(rope.char(current.0)));
+    debug_assert!(is_word(rope.char(start.0)));
+    debug_assert!(is_word(rope.char((end - 1).0)));
+    Ok(Some((start..end).into()))
 }
 impl SelectionMode for Token {
     fn iter<'a>(
         &'a self,
         params: super::SelectionModeParams<'a>,
     ) -> anyhow::Result<Box<dyn Iterator<Item = ByteRange> + 'a>> {
-        if self.skip_symbols {
-            self.symbol_skipping_regex.iter(params)
-        } else {
-            self.normal_regex.iter(params)
+        struct MyIterator<'a> {
+            params: super::SelectionModeParams<'a>,
+            cursor_char_index: CharIndex,
+            skip_symbols: bool,
         }
+        impl<'a> Iterator for MyIterator<'a> {
+            type Item = ByteRange;
+
+            fn next(&mut self) -> Option<Self::Item> {
+                let next_char_index_range = current_impl(
+                    self.params.buffer.rope(),
+                    self.cursor_char_index,
+                    IfCurrentNotFound::LookForward,
+                    self.skip_symbols,
+                )
+                .ok()??;
+                let next_byte_range = ByteRange::new(
+                    self.params
+                        .buffer
+                        .char_index_range_to_byte_range(next_char_index_range)
+                        .ok()?,
+                );
+
+                self.cursor_char_index = next_char_index_range.end;
+
+                Some(next_byte_range)
+            }
+        }
+        Ok(Box::new(MyIterator {
+            params,
+            cursor_char_index: CharIndex(0),
+            skip_symbols: self.skip_symbols,
+        }))
     }
     fn first(
         &self,
@@ -73,6 +193,42 @@ impl SelectionMode for Token {
                         .set_range(buffer.byte_range_to_char_index_range(&range.range).ok()?),
                 )
             }))
+    }
+    fn current(
+        &self,
+        params: super::SelectionModeParams,
+        if_current_not_found: IfCurrentNotFound,
+    ) -> anyhow::Result<Option<crate::selection::Selection>> {
+        let rope = params.buffer.rope();
+        let cursor = params.cursor_char_index();
+        Ok(
+            current_impl(rope, cursor, if_current_not_found, self.skip_symbols)?
+                .map(|range| params.current_selection.clone().set_range(range)),
+        )
+    }
+    fn right(
+        &self,
+        params: super::SelectionModeParams,
+    ) -> anyhow::Result<Option<crate::selection::Selection>> {
+        Ok(current_impl(
+            params.buffer.rope(),
+            params.current_selection.range().end,
+            IfCurrentNotFound::LookForward,
+            self.skip_symbols,
+        )?
+        .map(|range| params.current_selection.clone().set_range(range)))
+    }
+    fn left(
+        &self,
+        params: super::SelectionModeParams,
+    ) -> anyhow::Result<Option<crate::selection::Selection>> {
+        Ok(current_impl(
+            params.buffer.rope(),
+            params.current_selection.range().start - 1,
+            IfCurrentNotFound::LookForward,
+            self.skip_symbols,
+        )?
+        .map(|range| params.current_selection.clone().set_range(range)))
     }
 }
 

--- a/src/selection_mode/top_node.rs
+++ b/src/selection_mode/top_node.rs
@@ -1,9 +1,9 @@
-use super::{ByteRange, SelectionMode};
+use super::{ByteRange, PositionBasedSelectionMode};
 use itertools::Itertools;
 
 pub(crate) struct TopNode;
 
-impl SelectionMode for TopNode {
+impl PositionBasedSelectionMode for TopNode {
     fn get_current_selection_by_cursor(
         &self,
         buffer: &crate::buffer::Buffer,
@@ -37,7 +37,11 @@ impl SelectionMode for TopNode {
 
 #[cfg(test)]
 mod test_top_node {
-    use crate::{buffer::Buffer, selection::Selection};
+    use crate::{
+        buffer::Buffer,
+        selection::Selection,
+        selection_mode::{PositionBased, SelectionMode},
+    };
 
     use super::*;
 
@@ -47,7 +51,7 @@ mod test_top_node {
             Some(tree_sitter_rust::LANGUAGE.into()),
             "fn main(x: usize) { let x = 1; }",
         );
-        TopNode.assert_all_selections(
+        PositionBased(TopNode).assert_all_selections(
             &buffer,
             Selection::default(),
             &[

--- a/src/selection_mode/top_node.rs
+++ b/src/selection_mode/top_node.rs
@@ -1,4 +1,4 @@
-use super::{ByteRange, IterBasedSelectionMode, SelectionMode};
+use super::{ByteRange, IterBasedSelectionMode};
 use itertools::Itertools;
 
 pub(crate) struct TopNode;

--- a/src/selection_mode/top_node.rs
+++ b/src/selection_mode/top_node.rs
@@ -8,6 +8,7 @@ impl SelectionMode for TopNode {
         &self,
         buffer: &crate::buffer::Buffer,
         cursor_char_index: crate::selection::CharIndex,
+        if_current_not_found: crate::components::editor::IfCurrentNotFound,
     ) -> anyhow::Result<Option<super::ByteRange>> {
         let cursor_byte = buffer.char_to_byte(cursor_char_index)?;
         if let Some(tree) = buffer.tree() {

--- a/src/selection_mode/word.rs
+++ b/src/selection_mode/word.rs
@@ -1,11 +1,9 @@
 use ropey::Rope;
 
 use super::{ByteRange, SelectionMode, Token};
-use crate::{buffer::Buffer, selection::CharIndex};
+use crate::{buffer::Buffer, components::editor::IfCurrentNotFound, selection::CharIndex};
 
 pub struct Word {
-    normal_regex: super::Regex,
-    symbol_skipping_regex: super::Regex,
     skip_symbols: bool,
 }
 
@@ -16,51 +14,32 @@ const SUBWORD_SYMBOL_SKIPPING_REGEX: &str =
     r"[A-Z]{2,}(?=[A-Z][a-z])|[A-Z]{2,}|[A-Z][a-z]+|[A-Z]|[a-z]+|[0-9]+";
 
 impl Word {
-    pub(crate) fn new(buffer: &Buffer, skip_symbols: bool) -> anyhow::Result<Self> {
-        Ok(Self {
-            normal_regex: super::Regex::from_config(
-                buffer,
-                SUBWORD_REGEX,
-                crate::list::grep::RegexConfig {
-                    escaped: false,
-                    case_sensitive: true,
-                    match_whole_word: false,
-                },
-            )?,
-            symbol_skipping_regex: super::Regex::from_config(
-                buffer,
-                SUBWORD_SYMBOL_SKIPPING_REGEX,
-                crate::list::grep::RegexConfig {
-                    escaped: false,
-                    case_sensitive: true,
-                    match_whole_word: false,
-                },
-            )?,
-            skip_symbols,
-        })
+    pub(crate) fn new(skip_symbols: bool) -> anyhow::Result<Self> {
+        Ok(Self { skip_symbols })
     }
 }
 
 impl SelectionMode for Word {
     fn first(
         &self,
-        params: super::SelectionModeParams,
+        params: &super::SelectionModeParams,
     ) -> anyhow::Result<Option<crate::selection::Selection>> {
         get_word(params, SelectionPosition::First, self.skip_symbols)
     }
 
     fn last(
         &self,
-        params: super::SelectionModeParams,
+        params: &super::SelectionModeParams,
     ) -> anyhow::Result<Option<crate::selection::Selection>> {
         get_word(params, SelectionPosition::Last, self.skip_symbols)
     }
 
     fn get_current_selection_by_cursor(
         &self,
-        buffer: &crate::buffer::Buffer,
-        cursor_char_index: crate::selection::CharIndex,
-    ) -> anyhow::Result<Option<super::ByteRange>> {
+        buffer: &Buffer,
+        cursor_char_index: CharIndex,
+        if_current_not_found: IfCurrentNotFound,
+    ) -> anyhow::Result<Option<ByteRange>> {
         let rope = buffer.rope();
         let last_char_index = CharIndex(rope.len_chars().saturating_sub(1));
 
@@ -68,108 +47,138 @@ impl SelectionMode for Word {
             return Ok(None);
         }
 
-        let current_char = buffer.char(cursor_char_index);
+        let predicate = |c: char| {
+            if self.skip_symbols {
+                c.is_ascii_alphanumeric()
+            } else {
+                !c.is_whitespace()
+            }
+        };
+        let current = {
+            let mut current = cursor_char_index;
+            loop {
+                if (CharIndex(0)..=last_char_index).contains(&current) {
+                    if predicate(buffer.char(current)) {
+                        break current;
+                    } else {
+                        match if_current_not_found {
+                            IfCurrentNotFound::LookForward if current < last_char_index => {
+                                current = current + 1
+                            }
+                            IfCurrentNotFound::LookBackward if current > CharIndex(0) => {
+                                current = current - 1
+                            }
+                            _ => break current,
+                        }
+                    }
+                } else {
+                    return Ok(None);
+                }
+            }
+        };
 
-        if current_char.is_whitespace() || (self.skip_symbols && !current_char.is_alphanumeric()) {
+        let current_char = buffer.char(current);
+
+        if current_char.is_whitespace()
+            || (self.skip_symbols && !current_char.is_ascii_alphanumeric())
+        {
             return Ok(None);
         }
 
-        let range: crate::char_index_range::CharIndexRange = if current_char.is_alphabetic()
-            && current_char.is_ascii_lowercase()
-        {
-            let start = {
-                let mut index = cursor_char_index;
-                loop {
-                    if index > CharIndex(0) && buffer.char(index - 1).is_ascii_lowercase() {
-                        index = index - 1;
-                    } else {
-                        break index;
-                    }
-                }
-            };
-            let end = {
-                let mut index = cursor_char_index;
-                loop {
-                    if index < last_char_index && buffer.char(index + 1).is_ascii_lowercase() {
-                        index = index + 1;
-                    } else {
-                        break index;
-                    }
-                }
-            };
-            start..end + 1
-        } else if current_char.is_ascii_uppercase() {
-            let start = {
-                let mut index = cursor_char_index;
-                if index < last_char_index && buffer.char(index + 1).is_lowercase() {
-                    index
-                } else {
+        let range: crate::char_index_range::CharIndexRange =
+            if current_char.is_alphabetic() && current_char.is_ascii_lowercase() {
+                let start = {
+                    let mut index = current;
                     loop {
-                        if index == CharIndex(0) {
-                            break index;
-                        }
-                        let char = buffer.char(index - 1);
-                        if char.is_ascii_uppercase() {
+                        if index > CharIndex(0) && buffer.char(index - 1).is_ascii_lowercase() {
                             index = index - 1;
                         } else {
                             break index;
                         }
                     }
-                }
-            };
-            let end = {
-                let mut previous_is_uppercase = buffer.char(cursor_char_index).is_ascii_uppercase();
-                let mut index = cursor_char_index;
-                loop {
-                    println!("hello index = {index:?}");
-                    if index >= last_char_index {
-                        break index;
-                    }
-                    let char = buffer.char(index + 1);
-                    if char.is_ascii_lowercase() {
-                        previous_is_uppercase = char.is_ascii_uppercase();
-                        index = index + 1;
-                    } else if previous_is_uppercase && char.is_ascii_uppercase() {
-                        if index < last_char_index - 1
-                            && buffer.char(index + 2).is_ascii_lowercase()
-                        {
-                            break index;
+                };
+                let end = {
+                    let mut index = current;
+                    loop {
+                        if index < last_char_index && buffer.char(index + 1).is_ascii_lowercase() {
+                            index = index + 1;
                         } else {
+                            break index;
+                        }
+                    }
+                };
+                start..end + 1
+            } else if current_char.is_ascii_uppercase() {
+                let start = {
+                    let mut index = current;
+                    if index < last_char_index && buffer.char(index + 1).is_lowercase() {
+                        index
+                    } else {
+                        loop {
+                            if index == CharIndex(0) {
+                                break index;
+                            }
+                            let char = buffer.char(index - 1);
+                            if char.is_ascii_uppercase() {
+                                index = index - 1;
+                            } else {
+                                break index;
+                            }
+                        }
+                    }
+                };
+                let end = {
+                    let mut previous_is_uppercase = buffer.char(current).is_ascii_uppercase();
+                    let mut index = current;
+                    loop {
+                        if index >= last_char_index {
+                            break index;
+                        }
+                        let char = buffer.char(index + 1);
+                        if char.is_ascii_lowercase() {
                             previous_is_uppercase = char.is_ascii_uppercase();
                             index = index + 1;
+                        } else if previous_is_uppercase && char.is_ascii_uppercase() {
+                            if index < last_char_index - 1
+                                && buffer.char(index + 2).is_ascii_lowercase()
+                            {
+                                break index;
+                            } else {
+                                previous_is_uppercase = char.is_ascii_uppercase();
+                                index = index + 1;
+                            }
+                        } else {
+                            break index;
                         }
-                    } else {
-                        break index;
                     }
-                }
-            };
-            start..end + 1
-        } else if current_char.is_digit(10) {
-            let start = {
-                let mut index = cursor_char_index;
-                loop {
-                    if index > CharIndex(0) && buffer.char(index - 1).is_digit(10) {
-                        index = index - 1;
-                    } else {
-                        break index;
+                };
+                start..end + 1
+            } else if current_char.is_digit(10) {
+                let start = {
+                    let mut index = current;
+                    loop {
+                        if index > CharIndex(0) && buffer.char(index - 1).is_digit(10) {
+                            index = index - 1;
+                        } else {
+                            break index;
+                        }
                     }
-                }
-            };
-            let end = {
-                let mut index = cursor_char_index;
-                loop {
-                    if index < last_char_index && buffer.char(index + 1).is_digit(10) {
-                        index = index + 1;
-                    } else {
-                        break index;
+                };
+                let end = {
+                    let mut index = current;
+                    loop {
+                        if index < last_char_index && buffer.char(index + 1).is_digit(10) {
+                            index = index + 1;
+                        } else {
+                            break index;
+                        }
                     }
-                }
-            };
-            start..end + 1
-        } else {
-            cursor_char_index..cursor_char_index + 1
-        }
-        .into();
+                };
+                start..end + 1
+            } else {
+                current..current + 1
+            }
+            .into();
 
         Ok(Some(ByteRange::new(
             buffer.char_index_range_to_byte_range(range)?,
@@ -188,7 +197,7 @@ mod test_word {
             None,
             "snake_case camelCase PascalCase UPPER_SNAKE ->() 123 <_> HTTPNetwork X",
         );
-        Word::new(&buffer, true).unwrap().assert_all_selections(
+        Word::new(true).unwrap().assert_all_selections(
             &buffer,
             Selection::default(),
             &[
@@ -214,7 +223,7 @@ mod test_word {
             None,
             "snake_case camelCase PascalCase UPPER_SNAKE ->() 123 <_> HTTPNetwork X",
         );
-        Word::new(&buffer, false).unwrap().assert_all_selections(
+        Word::new(false).unwrap().assert_all_selections(
             &buffer,
             Selection::default(),
             &[
@@ -246,7 +255,7 @@ mod test_word {
     #[test]
     fn consecutive_uppercase_letters() {
         let buffer = Buffer::new(None, "XMLParser JSONObject HTMLElement");
-        Word::new(&buffer, true).unwrap().assert_all_selections(
+        Word::new(true).unwrap().assert_all_selections(
             &buffer,
             Selection::default(),
             &[
@@ -268,7 +277,7 @@ pub(crate) enum SelectionPosition {
 }
 
 fn get_word(
-    params: super::SelectionModeParams,
+    params: &super::SelectionModeParams,
     position: SelectionPosition,
     skip_symbols: bool,
 ) -> anyhow::Result<Option<crate::selection::Selection>> {

--- a/src/selection_mode/word.rs
+++ b/src/selection_mode/word.rs
@@ -1,5 +1,3 @@
-use ropey::Rope;
-
 use super::{ByteRange, PositionBased, PositionBasedSelectionMode, SelectionMode, Token};
 use crate::{buffer::Buffer, components::editor::IfCurrentNotFound, selection::CharIndex};
 
@@ -9,9 +7,6 @@ pub struct Word {
 
 const SUBWORD_REGEX: &str =
     r"[A-Z]{2,}(?=[A-Z][a-z])|[A-Z]{2,}|[A-Z][a-z]+|[A-Z]|[a-z]+|[^\w\s]|_|[0-9]+";
-
-const SUBWORD_SYMBOL_SKIPPING_REGEX: &str =
-    r"[A-Z]{2,}(?=[A-Z][a-z])|[A-Z]{2,}|[A-Z][a-z]+|[A-Z]|[a-z]+|[0-9]+";
 
 impl Word {
     pub(crate) fn new(skip_symbols: bool) -> Self {
@@ -154,11 +149,11 @@ impl PositionBasedSelectionMode for Word {
                 }
             };
             start..end + 1
-        } else if current_char.is_digit(10) {
+        } else if current_char.is_ascii_digit() {
             let start = {
                 let mut index = current;
                 loop {
-                    if index > CharIndex(0) && buffer.char(index - 1).is_digit(10) {
+                    if index > CharIndex(0) && buffer.char(index - 1).is_ascii_digit() {
                         index = index - 1;
                     } else {
                         break index;
@@ -168,7 +163,7 @@ impl PositionBasedSelectionMode for Word {
             let end = {
                 let mut index = current;
                 loop {
-                    if index < last_char_index && buffer.char(index + 1).is_digit(10) {
+                    if index < last_char_index && buffer.char(index + 1).is_ascii_digit() {
                         index = index + 1;
                     } else {
                         break index;
@@ -190,7 +185,7 @@ impl PositionBasedSelectionMode for Word {
 #[cfg(test)]
 mod test_word {
     use super::*;
-    use crate::{buffer::Buffer, selection::Selection, selection_mode::PositionBasedSelectionMode};
+    use crate::{buffer::Buffer, selection::Selection};
 
     #[test]
     fn simple_case() {

--- a/src/selection_mode/word.rs
+++ b/src/selection_mode/word.rs
@@ -64,6 +64,16 @@ impl SelectionMode for Word {
     ) -> anyhow::Result<Option<crate::selection::Selection>> {
         get_word(params, SelectionPosition::Last, self.skip_symbols)
     }
+
+    fn current(
+        &self,
+        params: super::SelectionModeParams,
+        if_current_not_found: crate::components::editor::IfCurrentNotFound,
+    ) -> anyhow::Result<Option<crate::selection::Selection>> {
+        let rope = params.buffer.rope();
+        let cursor = params.cursor_char_index();
+        self.current_default_impl(params, if_current_not_found)
+    }
 }
 
 #[cfg(test)]

--- a/src/selection_mode/word.rs
+++ b/src/selection_mode/word.rs
@@ -293,7 +293,7 @@ fn get_word(
     skip_symbols: bool,
 ) -> anyhow::Result<Option<crate::selection::Selection>> {
     if let Some(current_word) = PositionBased(Token::new(skip_symbols)).current(
-        params.clone(),
+        params,
         crate::components::editor::IfCurrentNotFound::LookForward,
     )? {
         let content = params.buffer.slice(&current_word.range())?.to_string();

--- a/src/test_app.rs
+++ b/src/test_app.rs
@@ -242,7 +242,7 @@ impl ExpectKind {
             JumpChars(chars) => {
                 contextualize(
                     component.borrow().editor().jump_chars().into_iter().sorted().collect_vec(),
-                    chars.into_iter().sorted().cloned().collect_vec()
+                    chars.iter().sorted().cloned().collect_vec()
                 )
             }
             CurrentViewAlignment(view_alignment) => contextualize(

--- a/src/test_app.rs
+++ b/src/test_app.rs
@@ -240,7 +240,10 @@ impl ExpectKind {
                 line.to_string(),
             ),
             JumpChars(chars) => {
-                contextualize(component.borrow().editor().jump_chars(), chars.to_vec())
+                contextualize(
+                    component.borrow().editor().jump_chars().into_iter().sorted().collect_vec(),
+                    chars.into_iter().sorted().cloned().collect_vec()
+                )
             }
             CurrentViewAlignment(view_alignment) => contextualize(
                 component.borrow().editor().current_view_alignment(),


### PR DESCRIPTION
## Description
Before this PR, executing `Select Word` when you have say 2000 cursors, the editor will hang, because the underlying code of Selection Mode relies mainly on an iterator method, which is to be implemented by the inheritors and also being used as the base for all movements such as left/right, up/down and first/last.

Turns out using an iterator method as the base is not super performant, the more performant way is to directly use methods under the `Rope` library, such as `Rope::char`, which is meant to be super performant.

## Changes
Split the SelectionMode trait into two kinds:
1. Iterator-based (uses the existing SelectionMode's algorithm)
2. Position-based (new)

## Note
This PR only improves the performance of the following selection modes (which are also selection modes where the current selection around the cursor can be determined without stepping through an iterator):
1. Line
2. Token
3. Word
4. Character