### PR TITLE
feat(doc/keymap): css make default content area wider

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -15,6 +15,7 @@
   --ifm-color-primary-lightest: #3cad6e;
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
+  --ifm-container-width-xl: 1600px;
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */


### PR DESCRIPTION
Modify theme settings used default values was 1320px. At 1600px the keyboard map just fits.