### PR TITLE
feat(token): repurpose Alpha/Beta movement to mean symbols navigation

### DIFF
--- a/docs/docs/components/file-explorer.md
+++ b/docs/docs/components/file-explorer.md
@@ -62,11 +62,11 @@ Because the File Explorer is just a YAML file, the following actions are free[^1
 | Action                                                                       | How?                                      |
 | ---------------------------------------------------------------------------- | ----------------------------------------- |
 | Go to parent folder                                                          | Use [`a j`][^4]                           |
-| Go to first/last file in current folder                                      | Use [First/Last][2] with [Syntax Node][3] |
+| Go to first/last file in current folder                                      | Use [Alpha/Beta][2] with [Syntax Node][3] |
 | Go to next/previous file/folder at current level, skipping expanded children | Use [Left/Right][4] with [Syntax Node][3] |
 
 [1]: ../normal-mode/selection-modes/primary.md#line
-[2]: ../normal-mode/core-movements.md#--firstlast
+[2]: ../normal-mode/core-movements.md#--alphabeta
 [3]: ../normal-mode/selection-modes/primary.md#syntax-1
 [4]: ../normal-mode/core-movements.md#--leftright
 

--- a/docs/docs/normal-mode/core-movements.md
+++ b/docs/docs/normal-mode/core-movements.md
@@ -16,7 +16,7 @@ There are 9 movements in total:
 
 1. [Left/Right](#--leftright)
 1. [Up/Down](#--updown)
-1. [First/Last](#--firstlast)
+1. [Alpha/Beta](#--alphabeta)
 1. [Jump](#jump)
 1. [To Index](#index-jump-to-index)
 1. [Current](#current)
@@ -46,16 +46,22 @@ the following selection modes:
 | Syntax Node    | Parent or First-Sibling             |
 | Quickfix       | To first item of next/previous file |
 
-### `◀◀` `▶▶` First/Last
+### `◀◀` `▶▶` Alpha/Beta
 
-| Selection Mode   | Meaning                                  |
-| ---------------- | ---------------------------------------- |
-| Syntax Node      | First/Last named sibling                 |
-| Quickfix         | First/Last item                          |
-| Char             | First/Last char in the current word      |
-| Word             | First/Last word in the current token     |
-| Token            | First/Last token in the current sentence |
-| Line & Full Line | First/Last line of the current file      |
+By default, Alpha/Beta moves to the First/Last selection of the current selection mode.
+
+However, since First/Last functionality isn't equally useful across all selection modes, certain modes like Token override this default behavior to provide more practical functionality.
+
+This is why the movement was renamed from First/Last to the more generic Alpha/Beta.
+
+| Selection Mode   | Meaning                              |
+| ---------------- | ------------------------------------ |
+| Syntax Node      | First/Last named sibling             |
+| Quickfix         | First/Last item                      |
+| Char             | First/Last char in the current word  |
+| Word             | First/Last word in the current token |
+| Token            | Previous/Next symbolic tokens        |
+| Line & Full Line | First/Last line of the current file  |
 
 ### `Jump`
 

--- a/docs/docs/normal-mode/selection-modes/primary.md
+++ b/docs/docs/normal-mode/selection-modes/primary.md
@@ -99,7 +99,7 @@ and trailing spaces of each line are not selected.
 | Movement   | Meaning                                         |
 | ---------- | ----------------------------------------------- |
 | Up/Down    | Move to line above/below                        |
-| First/Last | Move to the first/last line of the current file |
+| Alpha/Beta | Move to the first/last line of the current file |
 | Left       | Move to the parent line                         |
 
 Parent lines are highlighted lines that represent the parent nodes of the current selection.
@@ -118,21 +118,52 @@ Same as [Line](#line), however, leading whitespaces are selected, and trailing w
 
 ## `Token`
 
-Token (skip symbols).
+Token.
 
 Each unit is a sequence of alphanumeric characters including `-` and `_`.
+
+| Movement   | Symbols | Alphanumeric |
+| ---------- | ------- | ------------ |
+| Left/Right |         | ✓            |
+| Alpha/Beta | ✓       |              |
+| Jump       | ✓       | ✓            |
+| Up/Down    | ✓       | ✓            |
+| Current    | ✓       | ✓            |
+
+Left/Right movement skips symbols, while Alpha/Beta movement moves to symbols only.
+
+This means Left/Right movements are optimized for navigating alphanumeric tokens,
+while Alpha/Beta movements are optimized for symbolic tokens, which is useful for navigating sentences.
+
+Why don't Left/Right movements also navigate symbols? Because they would be too slow; it would take a lot of unnecessary keypresses to reach the target.
+
+Suppose the following example:
+
+```rs
+use crate::{components::editor::OpenFile, char_index::CharIndex};
+```
+
+If the current selection is selecting `use`, the following table demonstrates how many steps it takes to navigate to `OpenFile`.
+
+| Navigation include/exclude symbols | Steps                                                                | Count |
+| ---------------------------------- | -------------------------------------------------------------------- | ----- |
+| Include                            | `crate` `:` `:` `{` `components` `:` `:` `editor` `:` `:` `OpenFile` | 11    |
+| Exclude                            | `crate` `components` `editor` `OpenFile`                             | 4     |
+
+Why do we need the Alpha/Beta movements to navigate symbols? Because sometimes, we just need to move to a symbol.
+
+For example, in the following code, suppose we wanted to add an `&` symbol before `[Color]`.
+
+```rs
+fn apply_style(&self, colors: [Color]);
+```
+
+If there are no movements for Token which navigate to symbols, then we are forced to change the selection mode to either Word or Char, before inserting.
 
 <TutorialFallback filename="token"/>
 
 [^1]: This is possible because even Prompt is an editor, so the Word mode also works there. See [Core Concepts](../../core-concepts.md#2-every-component-is-a-buffereditor)
-
-## `Token*`
-
-Fine Token.
-
-This is similar to Token, but does not skip symbols.
-
-<TutorialFallback filename="token-fine"/>
+[^1]: This is possible because even Prompt is an editor, so the Word mode also works there. See [Core Concepts](../../core-concepts.md#2-every-component-is-a-buffereditor)
 
 ## `Word`
 
@@ -158,6 +189,6 @@ Character.
 
 In this selection mode, the movements behave like the usual editor, where [Left/Right](./../core-movements.md#--leftright) means left/right, and so on.
 
-[First/Last](./../core-movements.md#--firstlast) means the first/last character of the current word.
+[Alpha/Beta](./../core-movements.md#--alphabeta) means the first/last character of the current word.
 
 <TutorialFallback filename="char"/>

--- a/src/components/dropdown.rs
+++ b/src/components/dropdown.rs
@@ -473,8 +473,8 @@ impl Dropdown {
             Movement::Right => self.next_item(),
             Movement::Current(_) => {}
             Movement::Left => self.previous_item(),
-            Movement::Last => self.last_item(),
-            Movement::First => self.first_item(),
+            Movement::Beta => self.last_item(),
+            Movement::Alpha => self.first_item(),
             Movement::Up => self.previous_group(),
             Movement::Down => self.next_group(),
             _ => {}

--- a/src/components/editor_keymap.rs
+++ b/src/components/editor_keymap.rs
@@ -18,10 +18,10 @@ pub(crate) const KEYMAP_NORMAL: [[Meaning; 10]; 3] = [
         SrchN, WordF, SrchC, MultC, Swap_, /****/ FindP, InstP, Up___, InstN, FindN,
     ],
     [
-        Line_, Tokn_, Sytx_, Extnd, OpenN, /****/ DeltN, Left_, Down_, Right, Jump_,
+        Line_, Token, Sytx_, Extnd, OpenN, /****/ DeltN, Left_, Down_, Right, Jump_,
     ],
     [
-        Undo_, Rplc_, Copy_, PsteN, Mark_, /****/ Globl, Chng_, First, Last_, XAchr,
+        Undo_, Rplc_, Copy_, PsteN, Mark_, /****/ Globl, Chng_, Alpha, Beta_, XAchr,
     ],
 ];
 
@@ -30,7 +30,7 @@ pub(crate) const KEYMAP_NORMAL_SHIFTED: [[Meaning; 10]; 3] = [
         SrchP, Word_, Char_, _____, Raise, /****/ CrsrP, RplcP, Join_, RplcN, CrsrN,
     ],
     [
-        LineF, FTokn, FStyx, Trsfm, OpenP, /****/ DeltP, DeDnt, Break, Indnt, ToIdx,
+        LineF, _____, FStyx, Trsfm, OpenP, /****/ DeltP, DeDnt, Break, Indnt, ToIdx,
     ],
     [
         Redo_, PRplc, RplcX, PsteP, MarkF, /****/ _____, ChngX, _____, _____, SSEnd,
@@ -531,8 +531,8 @@ pub(crate) enum Meaning {
     FindN,
     /// Local find backward
     FindP,
-    /// First
-    First,
+    /// Alpha
+    Alpha,
     /// Go back
     GBack,
     /// Go forward
@@ -557,8 +557,8 @@ pub(crate) enum Meaning {
     KilLN,
     /// Kill to line start
     KilLP,
-    /// Last
-    Last_,
+    /// Beta
+    Beta_,
     /// Left
     Left_,
     /// Line Up
@@ -622,9 +622,7 @@ pub(crate) enum Meaning {
     /// GoToIndex
     ToIdx,
     /// Select Token
-    Tokn_,
-    /// Select Fine Token
-    FTokn,
+    Token,
     /// Transform
     Trsfm,
     /// Paste (End)

--- a/src/components/editor_keymap_legend.rs
+++ b/src/components/editor_keymap_legend.rs
@@ -56,16 +56,16 @@ impl Editor {
                 Dispatch::ToEditor(MoveSelection(Down)),
             ),
             Keymap::new_extended(
-                context.keyboard_layout_kind().get_key(&Meaning::First),
+                context.keyboard_layout_kind().get_key(&Meaning::Alpha),
                 "◀◀".to_string(),
-                "First".to_string(),
-                Dispatch::ToEditor(MoveSelection(Movement::First)),
+                "Alph".to_string(),
+                Dispatch::ToEditor(MoveSelection(Movement::Alpha)),
             ),
             Keymap::new_extended(
-                context.keyboard_layout_kind().get_key(&Meaning::Last_),
+                context.keyboard_layout_kind().get_key(&Meaning::Beta_),
                 "▶▶".to_string(),
-                "Last".to_string(),
-                Dispatch::ToEditor(MoveSelection(Movement::Last)),
+                "Beta".to_string(),
+                Dispatch::ToEditor(MoveSelection(Movement::Beta)),
             ),
             Keymap::new_extended(
                 context.keyboard_layout_kind().get_key(&Meaning::Jump_),
@@ -200,23 +200,12 @@ impl Editor {
                 )),
             ),
             Keymap::new_extended(
-                context.keyboard_layout_kind().get_key(&Meaning::Tokn_),
+                context.keyboard_layout_kind().get_key(&Meaning::Token),
                 "Token".to_string(),
                 "Select Token".to_string(),
                 Dispatch::ToEditor(SetSelectionMode(
                     self.cursor_direction.reverse().to_if_current_not_found(),
-                    Token { skip_symbols: true },
-                )),
-            ),
-            Keymap::new_extended(
-                context.keyboard_layout_kind().get_key(&Meaning::FTokn),
-                "Token*".to_string(),
-                "Select Token*".to_string(),
-                Dispatch::ToEditor(SetSelectionMode(
-                    self.cursor_direction.reverse().to_if_current_not_found(),
-                    Token {
-                        skip_symbols: false,
-                    },
+                    Token,
                 )),
             ),
             Keymap::new_extended(

--- a/src/components/prompt.rs
+++ b/src/components/prompt.rs
@@ -97,7 +97,7 @@ impl Prompt {
                         SelectionMode::Line,
                     )),
                     Dispatch::ToEditor(DispatchEditor::MoveSelection(
-                        super::editor::Movement::Last,
+                        super::editor::Movement::Beta,
                     )),
                     Dispatch::ToEditor(DispatchEditor::MoveToLineEnd),
                 ]

--- a/src/components/test_editor.rs
+++ b/src/components/test_editor.rs
@@ -64,22 +64,17 @@ fn toggle_visual_mode() -> anyhow::Result<()> {
             Editor(SetContent(
                 "fn f(){ let x = S(a); let y = S(b); }".to_string(),
             )),
-            Editor(SetSelectionMode(
-                IfCurrentNotFound::LookForward,
-                Token {
-                    skip_symbols: false,
-                },
-            )),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Token)),
             Editor(EnableSelectionExtension),
             Editor(MoveSelection(Right)),
-            Editor(MoveSelection(Right)),
+            Editor(MoveSelection(Beta)),
             Expect(CurrentSelectedTexts(&["fn f("])),
             Editor(SwapExtensionAnchor),
             Editor(MoveSelection(Right)),
             Expect(CurrentSelectedTexts(&["f("])),
             Editor(Reset),
             Expect(CurrentSelectedTexts(&["f"])),
-            Editor(MoveSelection(Right)),
+            Editor(MoveSelection(Beta)),
             Expect(CurrentSelectedTexts(&["("])),
         ])
     })
@@ -96,12 +91,7 @@ fn delete_should_kill_if_possible_1() -> anyhow::Result<()> {
                 focus: true,
             }),
             Editor(SetContent("fn main() {}".to_string())),
-            Editor(SetSelectionMode(
-                IfCurrentNotFound::LookForward,
-                Token {
-                    skip_symbols: false,
-                },
-            )),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Token)),
             Editor(Delete(Direction::End)),
             Expect(CurrentComponentContent("main() {}")),
             Expect(CurrentSelectedTexts(&["main"])),
@@ -140,12 +130,7 @@ fn delete_should_kill_if_possible_3() -> anyhow::Result<()> {
             }),
             Editor(SetContent("fn main() {}".to_string())),
             Editor(MatchLiteral("}".to_string())),
-            Editor(SetSelectionMode(
-                IfCurrentNotFound::LookForward,
-                Token {
-                    skip_symbols: false,
-                },
-            )),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Token)),
             Editor(Delete(Direction::End)),
             Expect(CurrentComponentContent("fn main() {")),
         ])
@@ -409,13 +394,8 @@ fn test_delete_extended_selection_whole_file() -> anyhow::Result<()> {
                 owner: BufferOwner::User,
                 focus: true,
             }),
-            Editor(SetContent("who lives in a pineapple".to_string())),
-            Editor(SetSelectionMode(
-                IfCurrentNotFound::LookForward,
-                Token {
-                    skip_symbols: false,
-                },
-            )),
+            Editor(SetContent("who lives\nin a\npineapple".to_string())),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Line)),
             Editor(MoveSelection(Right)),
             Editor(SelectAll),
             Editor(Delete(Direction::End)),
@@ -437,12 +417,7 @@ fn test_delete_word_short_backward_from_middle_of_file() -> anyhow::Result<()> {
             Editor(SetContent(
                 "fn snake_case(camelCase: String) {}".to_string(),
             )),
-            Editor(SetSelectionMode(
-                IfCurrentNotFound::LookForward,
-                Token {
-                    skip_symbols: false,
-                },
-            )),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Token)),
             // Go to the middle of the file
             Editor(MoveSelection(Index(3))),
             Expect(CurrentSelectedTexts(&["camelCase"])),
@@ -477,12 +452,7 @@ fn test_pipe_to_shell_1() -> anyhow::Result<()> {
                 focus: true,
             }),
             Editor(SetContent("snake_case".to_string())),
-            Editor(SetSelectionMode(
-                IfCurrentNotFound::LookForward,
-                Token {
-                    skip_symbols: false,
-                },
-            )),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Token)),
             Editor(PipeToShell {
                 command: "tr '_' ' '".to_string(),
             }),
@@ -844,12 +814,7 @@ def main():
                 .to_string(),
             )),
             Editor(MatchLiteral("hello".to_string())),
-            Editor(SetSelectionMode(
-                IfCurrentNotFound::LookForward,
-                Token {
-                    skip_symbols: false,
-                },
-            )),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Token)),
             Editor(Open(Direction::Start)),
             Expect(CurrentComponentContent(
                 "
@@ -910,12 +875,7 @@ fn main() {
                 .to_string(),
             )),
             Editor(MatchLiteral("hello".to_string())),
-            Editor(SetSelectionMode(
-                IfCurrentNotFound::LookForward,
-                Token {
-                    skip_symbols: false,
-                },
-            )),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Token)),
             Expect(CurrentSelectedTexts(&["hello"])),
             Editor(Open(Direction::End)),
             Editor(Insert("// world".to_string())),
@@ -1310,12 +1270,7 @@ fn highlight_kill() -> anyhow::Result<()> {
                 focus: true,
             }),
             Editor(SetContent("fn main() {}".to_string())),
-            Editor(SetSelectionMode(
-                IfCurrentNotFound::LookForward,
-                Token {
-                    skip_symbols: false,
-                },
-            )),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Token)),
             Editor(EnableSelectionExtension),
             Editor(MoveSelection(Right)),
             Expect(CurrentSelectedTexts(&["fn main"])),
@@ -2829,12 +2784,7 @@ c1 c2 c3"
                 )),
                 Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Line)),
                 Editor(CursorAddToAllSelections),
-                Editor(SetSelectionMode(
-                    IfCurrentNotFound::LookForward,
-                    Token {
-                        skip_symbols: false,
-                    },
-                )),
+                Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Token)),
                 Expect(CurrentSelectedTexts(&["a1", "b1", "c1"])),
                 Editor(Copy {
                     use_system_clipboard: false,
@@ -2979,12 +2929,7 @@ Editor(MatchLiteral(amos.foo())),
                 Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Line)),
                 App(HandleKeyEvents(keys!("Q ( enter").to_vec())),
                 Expect(CurrentSelectedTexts(&["("])),
-                Editor(SetSelectionMode(
-                    IfCurrentNotFound::LookForward,
-                    Token {
-                        skip_symbols: false,
-                    },
-                )),
+                Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Token)),
                 Expect(CurrentSelectedTexts(&["("])),
                 Editor(MoveSelection(Left)),
                 Expect(CurrentSelectedTexts(&["to_string"])),
@@ -3004,13 +2949,9 @@ fn selection_set_history_updates_upon_edit() -> Result<(), anyhow::Error> {
                     focus: true,
                 }),
                 Editor(SetContent("foo bar spam".to_string())),
-                Editor(SetSelectionMode(
-                    IfCurrentNotFound::LookForward,
-                    Token {
-                        skip_symbols: false,
-                    },
-                )),
-                Editor(MoveSelection(Last)),
+                Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Token)),
+                Editor(MoveSelection(Right)),
+                Editor(MoveSelection(Right)),
                 Expect(CurrentSelectedTexts(&["spam"])),
                 Editor(MoveSelection(Left)),
                 Expect(CurrentSelectedTexts(&["bar"])),
@@ -3094,23 +3035,13 @@ fn last_contiguous_selection_mode() -> Result<(), anyhow::Error> {
                     focus: true,
                 }),
                 Editor(SetContent("who lives in a".to_string())),
-                Editor(SetSelectionMode(
-                    IfCurrentNotFound::LookForward,
-                    Token {
-                        skip_symbols: false,
-                    },
-                )),
+                Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Token)),
                 Editor(ToggleMark),
                 Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Mark)),
-                Editor(SetSelectionMode(
-                    IfCurrentNotFound::LookForward,
-                    Token {
-                        skip_symbols: false,
-                    },
-                )),
+                Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Token)),
                 Expect(CurrentSelectedTexts(&["who"])),
-                Editor(MoveSelection(Last)),
-                Expect(CurrentSelectedTexts(&["a"])),
+                Editor(MoveSelection(Right)),
+                Expect(CurrentSelectedTexts(&["lives"])),
                 App(UseLastNonContiguousSelectionMode(
                     IfCurrentNotFound::LookForward,
                 )),
@@ -3281,13 +3212,9 @@ fn cycle_primary_selection_should_based_on_range_order() -> anyhow::Result<()> {
                 focus: true,
             }),
             Editor(SetContent("foo bar spam".to_string())),
-            Editor(SetSelectionMode(
-                IfCurrentNotFound::LookForward,
-                Token {
-                    skip_symbols: false,
-                },
-            )),
-            Editor(MoveSelection(Last)),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Token)),
+            Editor(MoveSelection(Right)),
+            Editor(MoveSelection(Right)),
             Expect(CurrentPrimarySelection("spam")),
             Editor(EnterMultiCursorMode),
             Editor(MoveSelection(Left)),
@@ -3397,10 +3324,7 @@ fn expand_to_nearest_enclosure_1_inside() -> anyhow::Result<()> {
                 focus: true,
             }),
             Editor(SetContent("hello (world yo)".to_string())),
-            Editor(SetSelectionMode(
-                IfCurrentNotFound::LookForward,
-                Token { skip_symbols: true },
-            )),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Token)),
             Editor(MoveSelection(Right)),
             Editor(MoveSelection(Expand)),
             Expect(CurrentSelectedTexts(&["world yo"])),
@@ -3419,12 +3343,7 @@ fn expand_to_nearest_enclosure_1_inside_2() -> anyhow::Result<()> {
             }),
             Editor(SetContent("hello (world yo)".to_string())),
             Editor(MatchLiteral("yo".to_string())),
-            Editor(SetSelectionMode(
-                IfCurrentNotFound::LookForward,
-                Token {
-                    skip_symbols: false,
-                },
-            )),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Token)),
             Editor(MoveSelection(Expand)),
             Expect(CurrentSelectedTexts(&["world yo"])),
         ])
@@ -3441,10 +3360,7 @@ fn expand_to_nearest_enclosure_2_around() -> anyhow::Result<()> {
                 focus: true,
             }),
             Editor(SetContent("hello ((world_yo))".to_string())),
-            Editor(SetSelectionMode(
-                IfCurrentNotFound::LookForward,
-                Token { skip_symbols: true },
-            )),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Token)),
             Editor(MoveSelection(Right)),
             Expect(CurrentSelectedTexts(&["world_yo"])),
             Editor(MoveSelection(Expand)),
@@ -3465,12 +3381,7 @@ fn expand_to_nearest_enclosure_3_nested_brackets() -> anyhow::Result<()> {
                 focus: true,
             }),
             Editor(SetContent("{hello (world yo)}".to_string())),
-            Editor(SetSelectionMode(
-                IfCurrentNotFound::LookForward,
-                Token {
-                    skip_symbols: false,
-                },
-            )),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Token)),
             Editor(MoveSelection(Right)),
             Editor(MoveSelection(Expand)),
             Expect(CurrentSelectedTexts(&["hello (world yo)"])),
@@ -3488,10 +3399,7 @@ fn expand_to_nearest_enclosure_4_brackets_and_quotes() -> anyhow::Result<()> {
                 focus: true,
             }),
             Editor(SetContent("hello '{World Foo} bar'".to_string())),
-            Editor(SetSelectionMode(
-                IfCurrentNotFound::LookForward,
-                Token { skip_symbols: true },
-            )),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Token)),
             Editor(MoveSelection(Right)),
             Editor(MoveSelection(Expand)),
             Expect(CurrentSelectedTexts(&["World Foo"])),
@@ -3518,12 +3426,7 @@ fn expand_to_nearest_enclosure_5() -> anyhow::Result<()> {
             }),
             Editor(SetContent("'hello world' (foo bar 'spam baz')".to_string())),
             Editor(MatchLiteral("foo".to_string())),
-            Editor(SetSelectionMode(
-                IfCurrentNotFound::LookForward,
-                Token {
-                    skip_symbols: false,
-                },
-            )),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Token)),
             Editor(MoveSelection(Expand)),
             Expect(CurrentSelectedTexts(&["foo bar 'spam baz'"])),
         ])
@@ -3543,12 +3446,7 @@ fn expand_to_nearest_enclosure_6_with_escaped_quotes() -> anyhow::Result<()> {
                 r#"result1.query.contains("\"require\" @keyword.import")"#.to_string(),
             )),
             Editor(MatchLiteral("require".to_string())),
-            Editor(SetSelectionMode(
-                IfCurrentNotFound::LookForward,
-                Token {
-                    skip_symbols: false,
-                },
-            )),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Token)),
             Editor(MoveSelection(Expand)),
             Expect(CurrentSelectedTexts(&[r#"\"require\" @keyword.import"#])),
         ])
@@ -3566,12 +3464,7 @@ fn expand_to_nearest_enclosure_7_cursor_on_open_enclosure() -> anyhow::Result<()
             }),
             Editor(SetContent(r#"foo bar (hello world)"#.to_string())),
             Editor(MatchLiteral("(".to_string())),
-            Editor(SetSelectionMode(
-                IfCurrentNotFound::LookForward,
-                Token {
-                    skip_symbols: false,
-                },
-            )),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Token)),
             Editor(MoveSelection(Expand)),
             Expect(CurrentSelectedTexts(&["(hello world)"])),
         ])
@@ -3589,12 +3482,7 @@ fn expand_to_nearest_enclosure_8_cursor_on_close_enclosure() -> anyhow::Result<(
             }),
             Editor(SetContent(r#"foo bar (hello world)"#.to_string())),
             Editor(MatchLiteral(")".to_string())),
-            Editor(SetSelectionMode(
-                IfCurrentNotFound::LookForward,
-                Token {
-                    skip_symbols: false,
-                },
-            )),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Token)),
             Editor(MoveSelection(Expand)),
             Expect(CurrentSelectedTexts(&["(hello world)"])),
         ])
@@ -3635,12 +3523,7 @@ foov foou bar
                 },
             })),
             Expect(CurrentMode(Mode::Normal)),
-            Editor(SetSelectionMode(
-                IfCurrentNotFound::LookForward,
-                Token {
-                    skip_symbols: false,
-                },
-            )),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Token)),
             Expect(CurrentSelectedTexts(&["fooz", "fooy", "foox", "foow"])),
         ])
     })
@@ -3657,7 +3540,7 @@ fn select_current_line_when_cursor_is_at_last_space_of_current_line() -> anyhow:
             }),
             Editor(SetContent("abc \n yo".to_string())),
             Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Character)),
-            Editor(MoveSelection(Last)),
+            Editor(MoveSelection(Beta)),
             Editor(MoveSelection(Right)),
             Expect(CurrentSelectedTexts(&[" "])),
             Editor(MoveSelection(Left)),
@@ -3682,9 +3565,9 @@ fn first_last_char() -> anyhow::Result<()> {
             Editor(SetContent("babyHelloCamp".to_string())),
             Editor(MatchLiteral("Hello".to_string())),
             Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Character)),
-            Editor(MoveSelection(Last)),
+            Editor(MoveSelection(Beta)),
             Expect(CurrentSelectedTexts(&["o"])),
-            Editor(MoveSelection(First)),
+            Editor(MoveSelection(Alpha)),
             Expect(CurrentSelectedTexts(&["H"])),
         ])
     })
@@ -3708,35 +3591,10 @@ fn first_last_word() -> anyhow::Result<()> {
             )),
             Editor(MoveSelection(Right)),
             Expect(CurrentSelectedTexts(&["HTTP"])),
-            Editor(MoveSelection(Last)),
+            Editor(MoveSelection(Beta)),
             Expect(CurrentSelectedTexts(&["Request"])),
-            Editor(MoveSelection(First)),
+            Editor(MoveSelection(Alpha)),
             Expect(CurrentSelectedTexts(&["HTTP"])),
-        ])
-    })
-}
-
-#[test]
-fn first_last_token() -> anyhow::Result<()> {
-    execute_test(|s| {
-        Box::new([
-            App(OpenFile {
-                path: s.main_rs(),
-                owner: BufferOwner::User,
-                focus: true,
-            }),
-            Editor(SetContent("who lives in\na pineapple".to_string())),
-            Editor(SetSelectionMode(
-                IfCurrentNotFound::LookForward,
-                Token {
-                    skip_symbols: false,
-                },
-            )),
-            Editor(MoveSelection(Last)),
-            Expect(CurrentSelectedTexts(&["in"])),
-            Editor(MoveSelection(Down)),
-            Editor(MoveSelection(First)),
-            Expect(CurrentSelectedTexts(&["a"])),
         ])
     })
 }
@@ -3757,7 +3615,7 @@ fn swap_till_last() -> anyhow::Result<()> {
             Editor(SetSelectionMode(IfCurrentNotFound::LookForward, SyntaxNode)),
             Expect(CurrentSelectedTexts(&["apple: T"])),
             Editor(EnterSwapMode),
-            Editor(MoveSelection(Last)),
+            Editor(MoveSelection(Beta)),
             Expect(CurrentComponentContent(
                 "fn main(foo: T, banana: T, coffee: T, apple: T) {}",
             )),
@@ -3781,7 +3639,7 @@ fn swap_till_first() -> anyhow::Result<()> {
             Editor(SetSelectionMode(IfCurrentNotFound::LookForward, SyntaxNode)),
             Expect(CurrentSelectedTexts(&["banana: T"])),
             Editor(EnterSwapMode),
-            Editor(MoveSelection(First)),
+            Editor(MoveSelection(Alpha)),
             Expect(CurrentComponentContent(
                 "fn main(banana: T, foo: T, apple: T, coffee: T) {}",
             )),
@@ -3805,7 +3663,7 @@ fn add_cursor_till_first() -> anyhow::Result<()> {
             Editor(SetSelectionMode(IfCurrentNotFound::LookForward, SyntaxNode)),
             Expect(CurrentSelectedTexts(&["banana: T"])),
             Editor(EnterMultiCursorMode),
-            Editor(MoveSelection(First)),
+            Editor(MoveSelection(Alpha)),
             Expect(CurrentSelectedTexts(&["foo: T", "apple: T", "banana: T"])),
         ])
     })
@@ -3827,7 +3685,7 @@ fn add_cursor_till_last() -> anyhow::Result<()> {
             Editor(SetSelectionMode(IfCurrentNotFound::LookForward, SyntaxNode)),
             Expect(CurrentSelectedTexts(&["apple: T"])),
             Editor(EnterMultiCursorMode),
-            Editor(MoveSelection(Last)),
+            Editor(MoveSelection(Beta)),
             Expect(CurrentSelectedTexts(&[
                 "apple: T",
                 "banana: T",
@@ -4001,12 +3859,7 @@ fn visual_select_anchor_change_selection_mode() -> anyhow::Result<()> {
                 focus: true,
             }),
             Editor(SetContent("helloWorld fooBar".trim().to_string())),
-            Editor(SetSelectionMode(
-                IfCurrentNotFound::LookForward,
-                Token {
-                    skip_symbols: false,
-                },
-            )),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Token)),
             Expect(CurrentSelectedTexts(&["helloWorld"])),
             Editor(EnterExtendMode),
             App(HandleKeyEvent(key!("l"))),
@@ -4105,10 +3958,7 @@ fn search_current_selection() -> anyhow::Result<()> {
             Editor(SetContent(
                 "foo bar test foo bary moss foo bars".to_string(),
             )),
-            Editor(SetSelectionMode(
-                IfCurrentNotFound::LookForward,
-                Token { skip_symbols: true },
-            )),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Token)),
             Editor(EnableSelectionExtension),
             Editor(MoveSelection(Right)),
             Expect(CurrentSelectedTexts(&["foo bar"])),
@@ -4132,8 +3982,8 @@ fn should_search_backward_if_primary_and_secondary_cursor_swapped() -> anyhow::R
                 owner: BufferOwner::User,
                 focus: true,
             }),
-            Editor(SetContent("hello world()".to_string())),
-            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Line)),
+            Editor(SetContent("  hello world  ".to_string())),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, LineFull)),
             Editor(SwapCursor),
             App(HandleKeyEvent(key!("s"))), // Token selection mode (Qwerty)
             Expect(CurrentSelectedTexts(&["world"])),
@@ -4279,12 +4129,7 @@ fn surround_extended_selection() -> anyhow::Result<()> {
                 focus: true,
             }),
             Editor(SetContent("foo bar".to_string())),
-            Editor(SetSelectionMode(
-                IfCurrentNotFound::LookForward,
-                Token {
-                    skip_symbols: false,
-                },
-            )),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Token)),
             Editor(EnableSelectionExtension),
             Editor(MoveSelection(Right)),
             App(HandleKeyEvents(keys!("f g j").to_vec())),
@@ -4303,12 +4148,7 @@ fn undo_redo_1() -> anyhow::Result<()> {
                 focus: true,
             }),
             Editor(SetContent("foo bar".to_string())),
-            Editor(SetSelectionMode(
-                IfCurrentNotFound::LookForward,
-                Token {
-                    skip_symbols: false,
-                },
-            )),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Token)),
             Editor(Delete(Direction::End)),
             Editor(Delete(Direction::End)),
             Expect(CurrentComponentContent("")),
@@ -4340,12 +4180,7 @@ fn undo_redo_should_clear_redo_stack_upon_new_edits() -> anyhow::Result<()> {
                 focus: true,
             }),
             Editor(SetContent("foo bar".to_string())),
-            Editor(SetSelectionMode(
-                IfCurrentNotFound::LookForward,
-                Token {
-                    skip_symbols: false,
-                },
-            )),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Token)),
             Editor(Delete(Direction::End)),
             Editor(Delete(Direction::End)),
             Expect(CurrentComponentContent("")),
@@ -4378,12 +4213,7 @@ fn undo_redo_multicursor() -> anyhow::Result<()> {
                 focus: true,
             }),
             Editor(SetContent("foo bar".to_string())),
-            Editor(SetSelectionMode(
-                IfCurrentNotFound::LookForward,
-                Token {
-                    skip_symbols: false,
-                },
-            )),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Token)),
             Editor(CursorAddToAllSelections),
             Editor(EnterInsertMode(Direction::End)),
             App(HandleKeyEvents(keys!("x").to_vec())),
@@ -4464,14 +4294,9 @@ tim
                 .to_string(),
             )),
             Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Line)),
-            Editor(MoveSelection(Last)),
+            Editor(MoveSelection(Beta)),
             Expect(CurrentSelectedTexts(&["tim"])),
-            Editor(SetSelectionMode(
-                IfCurrentNotFound::LookForward,
-                Token {
-                    skip_symbols: false,
-                },
-            )),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Token)),
             Editor(MoveSelection(Up)),
             Expect(CurrentSelectedTexts(&["baz"])),
         ])
@@ -4495,12 +4320,7 @@ foo bar
 "
                 .to_string(),
             )),
-            Editor(SetSelectionMode(
-                IfCurrentNotFound::LookForward,
-                Token {
-                    skip_symbols: false,
-                },
-            )),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Token)),
             Expect(CurrentSelectedTexts(&["foo"])),
             Editor(MoveSelection(Down)),
             Expect(CurrentSelectedTexts(&["spam"])),

--- a/src/components/test_editor_reveal.rs
+++ b/src/components/test_editor_reveal.rs
@@ -621,10 +621,7 @@ fn reveal_cursor_selection_extension() -> anyhow::Result<()> {
                 .trim(),
             )),
             Editor(EnableSelectionExtension),
-            Editor(SetSelectionMode(
-                IfCurrentNotFound::LookForward,
-                Token { skip_symbols: true },
-            )),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Token)),
             Editor(MoveSelection(Right)),
             Expect(EditorGrid(
                 "

--- a/src/recipes.rs
+++ b/src/recipes.rs
@@ -185,7 +185,7 @@ Why?
                     content: "camelCase snake_case PascalCase".trim(),
                     file_extension: "md",
                     prepare_events: &[],
-                    events: keys!("s . H H"),
+                    events: keys!("s l l H H"),
                     expectations: Box::new([CurrentSelectedTexts(&["camelCase"])]),
                     terminal_height: None,
                     similar_vim_combos: &[],
@@ -196,7 +196,7 @@ Why?
                     content: "foo bar spam".trim(),
                     file_extension: "md",
                     prepare_events: &[],
-                    events: keys!("s . h h"),
+                    events: keys!("s l l h h"),
                     expectations: Box::new([CurrentSelectedTexts(&["foo"])]),
                     terminal_height: None,
                     similar_vim_combos: &[],
@@ -621,7 +621,7 @@ snake_case 99 PascalCase
                     only: false,
                 },
                 Recipe {
-                    description: "Word: first/last movement",
+                    description: "Word: alpha/beta movement",
                     content: "hello HTTPNetworkRequestMiddleware world"
                     .trim(),
                     file_extension: "md",
@@ -656,51 +656,29 @@ camelCase , kebab-case snake_case
             .to_vec(),
         },
         RecipeGroup {
-            filename: "Token",
+            filename: "token",
             recipes: [
                 Recipe {
-                    description: "Token (skip symbols)",
+                    description: "Token: Left/Right skip symbols",
                     content: "
-camelCase ,  kebab-case 
-snake_case + PascalCase
+camelCase , kebab-case -> snake_case 
 "
                     .trim(),
                     file_extension: "md",
                     prepare_events: &[],
-                    events: keys!("s l k j i"),
+                    events: keys!("s l l j j"),
                     expectations: Box::new([CurrentSelectedTexts(&["camelCase"])]),
                     terminal_height: None,
                     similar_vim_combos: &[],
                     only: false,
                 },
                 Recipe {
-                    description: "Token: first/last movement (line boundary)",
-                    content: "The quick brown fox jumps\nOver the lazy dog today...".trim(),
+                    description: "Token: Alpha/Beta moves to symbols only",
+                    content: "camelCase , kebab-case -> snake_case".trim(),
                     file_extension: "md",
                     prepare_events: &[],
-                    events: keys!("s . k , i ."),
-                    expectations: Box::new([CurrentSelectedTexts(&["jumps"])]),
-                    terminal_height: None,
-                    similar_vim_combos: &[],
-                    only: false,
-                },
-            ]
-            .to_vec(),
-        },
-        RecipeGroup {
-            filename: "token-fine",
-            recipes: [
-                Recipe {
-                    description: "Fine Token Movements",
-                    content: "
-camelCase ,  kebab-case 
-snake_case + PascalCase
-"
-                    .trim(),
-                    file_extension: "md",
-                    prepare_events: &[],
-                    events: keys!("S l l k j j i"),
-                    expectations: Box::new([CurrentSelectedTexts(&["camelCase"])]),
+                    events: keys!("s . . , ,"),
+                    expectations: Box::new([CurrentSelectedTexts(&[","])]),
                     terminal_height: None,
                     similar_vim_combos: &[],
                     only: false,
@@ -727,7 +705,7 @@ snake
                     only: false,
                 },
                 Recipe {
-                    description: "Char: first/last movement (first/last char of current word)",
+                    description: "Char: alpha/beta movement (alpha/beta char of current word)",
                     content: "campHelloDun".trim(),
                     file_extension: "md",
                     prepare_events: keys!("q h e l l o enter"),
@@ -899,7 +877,7 @@ foo ha"
                     .trim(),
                     file_extension: "md",
                     prepare_events: &[],
-                    events: keys!("s . r j j"),
+                    events: keys!("a / s r j j"),
                     expectations: Box::new([
                         CurrentSelectedTexts(&["bar", "spam", "baz"]),
                     ]),
@@ -1519,7 +1497,7 @@ fn syntax_node() -> RecipeGroup {
                 only: false,
             },
             Recipe {
-                description: "Navigate sibling nodes via First/Last movement",
+                description: "Navigate sibling nodes via alpha/beta movement",
                 content: "[{\"x\": 123}, true, {\"y\": {}}]".trim(),
                 file_extension: "json",
                 prepare_events: keys!("w l"),
@@ -1695,7 +1673,7 @@ fn main() {
                 file_extension: "md",
                 prepare_events: &[],
                 events: keys!("a / s"),
-                expectations: Box::new([CurrentSelectedTexts(&["baz"])]),
+                expectations: Box::new([CurrentSelectedTexts(&[")"])]),
                 terminal_height: None,
                 similar_vim_combos: &[],
                 only: false,

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -409,7 +409,7 @@ impl SelectionSet {
 pub(crate) enum SelectionMode {
     // Regex
     Word { skip_symbols: bool },
-    Token { skip_symbols: bool },
+    Token,
     Line,
     Character,
     Custom,
@@ -460,9 +460,7 @@ impl SelectionMode {
             SelectionMode::Word { skip_symbols } => {
                 format!("{}WORD", if *skip_symbols { "" } else { "FINE " })
             }
-            SelectionMode::Token { skip_symbols } => {
-                format!("{}TOKEN", if *skip_symbols { "" } else { "FINE " })
-            }
+            SelectionMode::Token => "Token".to_string(),
         }
     }
 
@@ -472,7 +470,7 @@ impl SelectionMode {
         current_selection: &Selection,
         cursor_direction: &Direction,
         context: &Context,
-    ) -> anyhow::Result<Box<dyn selection_mode::SelectionMode>> {
+    ) -> anyhow::Result<Box<dyn selection_mode::SelectionModeTrait>> {
         let params = SelectionModeParams {
             buffer,
             current_selection,
@@ -482,9 +480,7 @@ impl SelectionMode {
             SelectionMode::Word { skip_symbols } => {
                 Box::new(PositionBased(selection_mode::Word::new(*skip_symbols)))
             }
-            SelectionMode::Token { skip_symbols } => {
-                Box::new(PositionBased(selection_mode::Token::new(*skip_symbols)))
-            }
+            SelectionMode::Token => Box::new(selection_mode::Token),
             SelectionMode::Line => Box::new(PositionBased(selection_mode::LineTrimmed)),
             SelectionMode::LineFull => Box::new(PositionBased(selection_mode::LineFull::new())),
             SelectionMode::Character => {

--- a/src/selection_mode/character.rs
+++ b/src/selection_mode/character.rs
@@ -3,8 +3,8 @@ use ropey::Rope;
 use crate::{components::editor::IfCurrentNotFound, selection::Selection};
 
 use super::{
-    word::SelectionPosition, ByteRange, PositionBased, PositionBasedSelectionMode, SelectionMode,
-    SelectionModeParams, Word,
+    word::SelectionPosition, ByteRange, PositionBased, PositionBasedSelectionMode,
+    SelectionModeParams, SelectionModeTrait, Word,
 };
 
 pub(crate) struct Character {
@@ -18,14 +18,14 @@ impl Character {
 }
 
 impl PositionBasedSelectionMode for Character {
-    fn first(
+    fn alpha(
         &self,
         params: &super::SelectionModeParams,
     ) -> anyhow::Result<Option<crate::selection::Selection>> {
         get_char(params, SelectionPosition::First)
     }
 
-    fn last(
+    fn beta(
         &self,
         params: &super::SelectionModeParams,
     ) -> anyhow::Result<Option<crate::selection::Selection>> {
@@ -129,7 +129,7 @@ mod test_character {
 
         // First line
         let selection = Selection::default();
-        crate::selection_mode::SelectionMode::assert_all_selections(
+        crate::selection_mode::SelectionModeTrait::assert_all_selections(
             &PositionBased(Character::new(0)),
             &buffer,
             selection,
@@ -148,7 +148,7 @@ mod test_character {
         // Second line
         let char_index = buffer.line_to_char(1)?;
         let selection = Selection::default().set_range((char_index..char_index).into());
-        crate::selection_mode::SelectionMode::assert_all_selections(
+        crate::selection_mode::SelectionModeTrait::assert_all_selections(
             &PositionBased(Character::new(0)),
             &buffer,
             selection,

--- a/src/selection_mode/line_full.rs
+++ b/src/selection_mode/line_full.rs
@@ -139,7 +139,7 @@ mod test_line_full {
     use crate::{
         buffer::Buffer,
         selection::Selection,
-        selection_mode::{PositionBased, SelectionMode as _},
+        selection_mode::{PositionBased, SelectionModeTrait as _},
     };
 
     use super::*;

--- a/src/selection_mode/line_trimmed.rs
+++ b/src/selection_mode/line_trimmed.rs
@@ -1,7 +1,7 @@
 use crate::{components::editor::IfCurrentNotFound, selection::CharIndex};
 
 use super::{
-    ByteRange, PositionBased, PositionBasedSelectionMode, SelectionMode, SelectionModeParams,
+    ByteRange, PositionBased, PositionBasedSelectionMode, SelectionModeParams, SelectionModeTrait,
 };
 
 #[derive(Clone)]

--- a/src/selection_mode/token.rs
+++ b/src/selection_mode/token.rs
@@ -2,17 +2,9 @@ use ropey::Rope;
 
 use crate::{components::editor::IfCurrentNotFound, selection::CharIndex};
 
-use super::{ByteRange, PositionBasedSelectionMode};
+use super::{ByteRange, PositionBasedSelectionMode, SelectionModeTrait};
 
-pub struct Token {
-    skip_symbols: bool,
-}
-
-impl Token {
-    pub(crate) fn new(skip_symbols: bool) -> Self {
-        Self { skip_symbols }
-    }
-}
+pub struct Token;
 
 fn find_word_start(rope: &Rope, current: CharIndex, is_word: impl Fn(char) -> bool) -> CharIndex {
     // Create a reverse range from current.0 down to 1 (not including 0)
@@ -42,66 +34,114 @@ fn find_word_end(
     // If we've examined all characters to the end, return the last index
     last_char_index
 }
-impl PositionBasedSelectionMode for Token {
-    fn first(
+
+impl SelectionModeTrait for Token {
+    fn alpha(
         &self,
         params: &super::SelectionModeParams,
     ) -> anyhow::Result<Option<crate::selection::Selection>> {
-        // return Token { skip_symbols: !self.skip_symbols, } .left(params);
-        let buffer = params.buffer;
-        let current_line_index = buffer.char_to_line(params.cursor_char_index())?;
-        let line_start_char_index = buffer.line_to_char(current_line_index)?;
-        let current_selection = params.current_selection.clone();
-        if let Some(range) = self.get_current_selection_by_cursor(
-            params.buffer,
-            line_start_char_index,
-            IfCurrentNotFound::LookForward,
-        )? {
-            if buffer.byte_to_line(range.range.start)? == current_line_index {
-                return Ok(Some(range.to_selection(buffer, &current_selection)?));
-            }
-        }
-        Ok(None)
+        TokenSymbolOnly.left(params)
     }
-    fn last(
+
+    fn beta(
         &self,
         params: &super::SelectionModeParams,
     ) -> anyhow::Result<Option<crate::selection::Selection>> {
-        // return Token { skip_symbols: !self.skip_symbols, } .right(params);
-        let buffer = params.buffer;
-        let current_line_index = buffer.char_to_line(params.cursor_char_index())?;
-        let next_line_index = current_line_index + 1;
-        let line_end_char_index = buffer.line_to_char(next_line_index)? - 1;
-        let current_selection = params.current_selection.clone();
-        if let Some(range) = self.get_current_selection_by_cursor(
-            params.buffer,
-            line_end_char_index,
-            IfCurrentNotFound::LookBackward,
-        )? {
-            if buffer.byte_to_line(range.range.start)? == current_line_index {
-                return Ok(Some(range.to_selection(buffer, &current_selection)?));
-            }
-        }
-        Ok(None)
+        TokenSymbolOnly.right(params)
     }
+
+    fn delete_backward(
+        &self,
+        params: &super::SelectionModeParams,
+    ) -> anyhow::Result<Option<crate::selection::Selection>> {
+        TokenNoSkipSymbol.left(params)
+    }
+
+    fn delete_forward(
+        &self,
+        params: &super::SelectionModeParams,
+    ) -> anyhow::Result<Option<crate::selection::Selection>> {
+        TokenNoSkipSymbol.right(params)
+    }
+
+    fn current(
+        &self,
+        params: &super::SelectionModeParams,
+        if_current_not_found: IfCurrentNotFound,
+    ) -> anyhow::Result<Option<crate::selection::Selection>> {
+        TokenNoSkipSymbol.current(params, if_current_not_found)
+    }
+
+    #[cfg(test)]
+    fn all_selections_gathered_inversely<'a>(
+        &'a self,
+        params: &super::SelectionModeParams<'a>,
+    ) -> anyhow::Result<Vec<ByteRange>> {
+        TokenNoSkipSymbol.all_selections_gathered_inversely(params)
+    }
+
+    fn expand(
+        &self,
+        params: &super::SelectionModeParams,
+    ) -> anyhow::Result<Option<super::ApplyMovementResult>> {
+        params.expand()
+    }
+
+    fn up(
+        &self,
+        params: &super::SelectionModeParams,
+    ) -> anyhow::Result<Option<crate::selection::Selection>> {
+        TokenNoSkipSymbol.up(params)
+    }
+
+    fn down(
+        &self,
+        params: &super::SelectionModeParams,
+    ) -> anyhow::Result<Option<crate::selection::Selection>> {
+        TokenNoSkipSymbol.down(params)
+    }
+
+    fn selections_in_line_number_ranges(
+        &self,
+        params: &super::SelectionModeParams,
+        line_number_ranges: Vec<std::ops::Range<usize>>,
+    ) -> anyhow::Result<Vec<ByteRange>> {
+        TokenNoSkipSymbol.selections_in_line_number_ranges(params, line_number_ranges)
+    }
+
+    fn to_index(
+        &self,
+        params: &super::SelectionModeParams,
+        index: usize,
+    ) -> anyhow::Result<Option<crate::selection::Selection>> {
+        TokenNoSkipSymbol.to_index(params, index)
+    }
+
+    fn right(
+        &self,
+        params: &super::SelectionModeParams,
+    ) -> anyhow::Result<Option<crate::selection::Selection>> {
+        TokenSkipSymbol.right(params)
+    }
+
+    fn left(
+        &self,
+        params: &super::SelectionModeParams,
+    ) -> anyhow::Result<Option<crate::selection::Selection>> {
+        TokenSkipSymbol.left(params)
+    }
+}
+
+struct TokenSymbolOnly;
+
+impl PositionBasedSelectionMode for TokenSymbolOnly {
     fn get_current_selection_by_cursor(
         &self,
         buffer: &crate::buffer::Buffer,
-        cursor_char_index: crate::selection::CharIndex,
+        cursor_char_index: CharIndex,
         if_current_not_found: IfCurrentNotFound,
-    ) -> anyhow::Result<Option<super::ByteRange>> {
+    ) -> anyhow::Result<Option<ByteRange>> {
         let last_char_index = CharIndex(buffer.len_chars().saturating_sub(1));
-
-        // Define predicates once
-        let is_word = |char: char| char.is_alphanumeric() || char == '_' || char == '-';
-        let is_symbol = |char: char| !is_word(char) && !char.is_whitespace();
-        let is_target = |char: char| {
-            if self.skip_symbols {
-                is_word(char)
-            } else {
-                is_word(char) || is_symbol(char)
-            }
-        };
 
         if cursor_char_index > last_char_index {
             return Ok(None);
@@ -113,7 +153,7 @@ impl PositionBasedSelectionMode for Token {
             let mut current = cursor_char_index;
             loop {
                 if (CharIndex(0)..=last_char_index).contains(&current) {
-                    if is_target(buffer.char(current)?) {
+                    if is_symbol(buffer.char(current)?) {
                         break current;
                     } else {
                         match if_current_not_found {
@@ -133,69 +173,138 @@ impl PositionBasedSelectionMode for Token {
         };
 
         let rope = buffer.rope();
-        if !is_target(rope.char(current.0)) {
+        if !is_symbol(rope.char(current.0)) {
             return Ok(None);
         }
 
-        // Handle single symbol case
-        if !self.skip_symbols && is_symbol(rope.char(current.0)) {
-            let current_byte = rope.try_char_to_byte(current.0)?;
-            return Ok(Some(ByteRange::new(current_byte..current_byte + 1)));
-        }
-
-        // Find word boundaries
-        let start = find_word_start(rope, current, is_word);
-        let end = find_word_end(rope, current, last_char_index, is_word) + 1;
-
-        // Validate results
-        debug_assert!(is_word(rope.char(current.0)));
-        debug_assert!(is_word(rope.char(start.0)));
-        debug_assert!(is_word(rope.char((end - 1).0)));
-
-        Ok(Some(ByteRange::new(
-            rope.try_char_to_byte(start.0)?..rope.try_char_to_byte(end.0)?,
-        )))
+        let current_byte = rope.try_char_to_byte(current.0)?;
+        return Ok(Some(ByteRange::new(current_byte..current_byte + 1)));
     }
+}
+
+struct TokenNoSkipSymbol;
+
+impl PositionBasedSelectionMode for TokenNoSkipSymbol {
+    fn get_current_selection_by_cursor(
+        &self,
+        buffer: &crate::buffer::Buffer,
+        cursor_char_index: CharIndex,
+        if_current_not_found: IfCurrentNotFound,
+    ) -> anyhow::Result<Option<ByteRange>> {
+        get_current_token_by_cursor(false, buffer, cursor_char_index, if_current_not_found)
+    }
+}
+
+struct TokenSkipSymbol;
+
+impl PositionBasedSelectionMode for TokenSkipSymbol {
+    fn get_current_selection_by_cursor(
+        &self,
+        buffer: &crate::buffer::Buffer,
+        cursor_char_index: CharIndex,
+        if_current_not_found: IfCurrentNotFound,
+    ) -> anyhow::Result<Option<ByteRange>> {
+        get_current_token_by_cursor(true, buffer, cursor_char_index, if_current_not_found)
+    }
+}
+
+fn is_word(char: char) -> bool {
+    char.is_alphanumeric() || char == '_' || char == '-'
+}
+
+fn is_symbol(char: char) -> bool {
+    !is_word(char) && !char.is_whitespace()
+}
+
+fn get_current_token_by_cursor(
+    skip_symbols: bool,
+    buffer: &crate::buffer::Buffer,
+    cursor_char_index: crate::selection::CharIndex,
+    if_current_not_found: IfCurrentNotFound,
+) -> anyhow::Result<Option<super::ByteRange>> {
+    let last_char_index = CharIndex(buffer.len_chars().saturating_sub(1));
+
+    // Define predicates once
+    let is_target = |char: char| {
+        if skip_symbols {
+            is_word(char)
+        } else {
+            is_word(char) || is_symbol(char)
+        }
+    };
+
+    if cursor_char_index > last_char_index {
+        return Ok(None);
+    }
+
+    let last_char_index = CharIndex(buffer.len_chars().saturating_sub(1));
+
+    let current = {
+        let mut current = cursor_char_index;
+        loop {
+            if (CharIndex(0)..=last_char_index).contains(&current) {
+                if is_target(buffer.char(current)?) {
+                    break current;
+                } else {
+                    match if_current_not_found {
+                        IfCurrentNotFound::LookForward if current < last_char_index => {
+                            current = current + 1
+                        }
+                        IfCurrentNotFound::LookBackward if current > CharIndex(0) => {
+                            current = current - 1
+                        }
+                        _ => break current,
+                    }
+                }
+            } else {
+                return Ok(None);
+            }
+        }
+    };
+
+    let rope = buffer.rope();
+    if !is_target(rope.char(current.0)) {
+        return Ok(None);
+    }
+
+    // Handle single symbol case
+    if !skip_symbols && is_symbol(rope.char(current.0)) {
+        let current_byte = rope.try_char_to_byte(current.0)?;
+        return Ok(Some(ByteRange::new(current_byte..current_byte + 1)));
+    }
+
+    // Find word boundaries
+    let start = find_word_start(rope, current, is_word);
+    let end = find_word_end(rope, current, last_char_index, is_word) + 1;
+
+    // Validate results
+    debug_assert!(is_word(rope.char(current.0)));
+    debug_assert!(is_word(rope.char(start.0)));
+    debug_assert!(is_word(rope.char((end - 1).0)));
+
+    Ok(Some(ByteRange::new(
+        rope.try_char_to_byte(start.0)?..rope.try_char_to_byte(end.0)?,
+    )))
 }
 
 #[cfg(test)]
 mod test_token {
-    use crate::{
-        buffer::Buffer,
-        selection::Selection,
-        selection_mode::{PositionBased, SelectionMode},
-    };
+    use crate::buffer::BufferOwner;
+    use crate::components::editor::Direction;
+    use crate::selection::SelectionMode;
+    use crate::test_app::*;
+
+    use crate::{buffer::Buffer, selection::Selection, selection_mode::SelectionModeTrait};
 
     use super::*;
 
     #[test]
-    fn skip_symbols() {
+    fn all_selections_no_skip_symbols() {
         let buffer = Buffer::new(
             None,
             "snake_case camelCase PascalCase UPPER_SNAKE kebab-case ->() 123 <_>",
         );
-        PositionBased(Token::new(true)).assert_all_selections(
-            &buffer,
-            Selection::default(),
-            &[
-                (0..10, "snake_case"),
-                (11..20, "camelCase"),
-                (21..31, "PascalCase"),
-                (32..43, "UPPER_SNAKE"),
-                (44..54, "kebab-case"),
-                (55..56, "-"),
-                (60..63, "123"),
-                (65..66, "_"),
-            ],
-        );
-    }
-    #[test]
-    fn no_skip_symbols() {
-        let buffer = Buffer::new(
-            None,
-            "snake_case camelCase PascalCase UPPER_SNAKE kebab-case ->() 123 <_>",
-        );
-        PositionBased(Token::new(false)).assert_all_selections(
+        super::Token.assert_all_selections(
             &buffer,
             Selection::default(),
             &[
@@ -214,5 +323,123 @@ mod test_token {
                 (66..67, ">"),
             ],
         );
+    }
+
+    #[test]
+    fn alpha_beta_moves_to_symbols_only() -> anyhow::Result<()> {
+        execute_test(|s| {
+            Box::new([
+                App(OpenFile {
+                    path: s.main_rs(),
+                    owner: BufferOwner::User,
+                    focus: true,
+                }),
+                Editor(SetContent("foo bar ? spam : baz".to_string())),
+                Editor(SetSelectionMode(
+                    IfCurrentNotFound::LookForward,
+                    SelectionMode::Token,
+                )),
+                Expect(CurrentSelectedTexts(&["foo"])),
+                Editor(MoveSelection(Beta)),
+                Expect(CurrentSelectedTexts(&["?"])),
+                Editor(MoveSelection(Beta)),
+                Expect(CurrentSelectedTexts(&[":"])),
+                Editor(MoveSelection(Alpha)),
+                Expect(CurrentSelectedTexts(&["?"])),
+            ])
+        })
+    }
+
+    #[test]
+    fn current_no_skip_symbols() -> anyhow::Result<()> {
+        execute_test(|s| {
+            Box::new([
+                App(OpenFile {
+                    path: s.main_rs(),
+                    owner: BufferOwner::User,
+                    focus: true,
+                }),
+                Editor(SetContent(".red".to_string())),
+                Editor(SetSelectionMode(
+                    IfCurrentNotFound::LookForward,
+                    SelectionMode::Token,
+                )),
+                Expect(CurrentSelectedTexts(&["."])),
+            ])
+        })
+    }
+
+    #[test]
+    fn up_down_no_skip_symbols() -> anyhow::Result<()> {
+        execute_test(|s| {
+            Box::new([
+                App(OpenFile {
+                    path: s.main_rs(),
+                    owner: BufferOwner::User,
+                    focus: true,
+                }),
+                Editor(SetContent(".foo\n=bar\n+spam".to_string())),
+                Editor(SetSelectionMode(
+                    IfCurrentNotFound::LookForward,
+                    SelectionMode::Token,
+                )),
+                Expect(CurrentSelectedTexts(&["."])),
+                Editor(MoveSelection(Down)),
+                Expect(CurrentSelectedTexts(&["="])),
+                Editor(MoveSelection(Down)),
+                Expect(CurrentSelectedTexts(&["+"])),
+                Editor(MoveSelection(Up)),
+                Expect(CurrentSelectedTexts(&["="])),
+                Editor(MoveSelection(Up)),
+                Expect(CurrentSelectedTexts(&["."])),
+            ])
+        })
+    }
+
+    #[test]
+    fn jump_no_skip_symbols() -> anyhow::Result<()> {
+        execute_test(|s| {
+            Box::new([
+                App(OpenFile {
+                    path: s.main_rs(),
+                    owner: BufferOwner::User,
+                    focus: true,
+                }),
+                Editor(SetContent("foo ? bar : spam".to_string())),
+                Editor(SetSelectionMode(
+                    IfCurrentNotFound::LookForward,
+                    SelectionMode::Token,
+                )),
+                App(TerminalDimensionChanged(crate::app::Dimension {
+                    height: 3,
+                    width: 50,
+                })),
+                Editor(ShowJumps {
+                    use_current_selection_mode: true,
+                }),
+                Expect(JumpChars(&['f', '?', 'b', ':', 's'])),
+            ])
+        })
+    }
+
+    #[test]
+    fn delete_no_skip_symbols() -> anyhow::Result<()> {
+        execute_test(|s| {
+            Box::new([
+                App(OpenFile {
+                    path: s.main_rs(),
+                    owner: BufferOwner::User,
+                    focus: true,
+                }),
+                Editor(SetContent("foo.bar.spam".to_string())),
+                Editor(SetSelectionMode(
+                    IfCurrentNotFound::LookForward,
+                    SelectionMode::Token,
+                )),
+                Expect(CurrentSelectedTexts(&["foo"])),
+                Editor(Delete(Direction::End)),
+                Expect(CurrentSelectedTexts(&["."])),
+            ])
+        })
     }
 }

--- a/src/selection_mode/word.rs
+++ b/src/selection_mode/word.rs
@@ -1,4 +1,4 @@
-use super::{ByteRange, PositionBased, PositionBasedSelectionMode, SelectionMode, Token};
+use super::{ByteRange, PositionBasedSelectionMode, SelectionModeTrait, Token};
 use crate::{buffer::Buffer, components::editor::IfCurrentNotFound, selection::CharIndex};
 
 pub struct Word {
@@ -15,18 +15,18 @@ impl Word {
 }
 
 impl PositionBasedSelectionMode for Word {
-    fn first(
+    fn alpha(
         &self,
         params: &super::SelectionModeParams,
     ) -> anyhow::Result<Option<crate::selection::Selection>> {
-        get_word(params, SelectionPosition::First, self.skip_symbols)
+        get_word(params, SelectionPosition::First)
     }
 
-    fn last(
+    fn beta(
         &self,
         params: &super::SelectionModeParams,
     ) -> anyhow::Result<Option<crate::selection::Selection>> {
-        get_word(params, SelectionPosition::Last, self.skip_symbols)
+        get_word(params, SelectionPosition::Last)
     }
 
     fn get_current_selection_by_cursor(
@@ -185,7 +185,7 @@ impl PositionBasedSelectionMode for Word {
 #[cfg(test)]
 mod test_word {
     use super::*;
-    use crate::{buffer::Buffer, selection::Selection};
+    use crate::{buffer::Buffer, selection::Selection, selection_mode::PositionBased};
 
     #[test]
     fn simple_case() {
@@ -285,9 +285,8 @@ pub(crate) enum SelectionPosition {
 fn get_word(
     params: &super::SelectionModeParams,
     position: SelectionPosition,
-    skip_symbols: bool,
 ) -> anyhow::Result<Option<crate::selection::Selection>> {
-    if let Some(current_word) = PositionBased(Token::new(skip_symbols)).current(
+    if let Some(current_word) = Token.current(
         params,
         crate::components::editor::IfCurrentNotFound::LookForward,
     )? {

--- a/src/test_app.rs
+++ b/src/test_app.rs
@@ -714,23 +714,18 @@ fn copy_replace() -> anyhow::Result<()> {
                 focus: true,
             }),
             Editor(SetContent("fn main() { let x = 1; }".to_string())),
-            Editor(SetSelectionMode(
-                IfCurrentNotFound::LookForward,
-                SelectionMode::Token {
-                    skip_symbols: false,
-                },
-            )),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Token)),
             Editor(Copy {
                 use_system_clipboard: false,
             }),
-            Editor(MoveSelection(Movement::Right)),
+            Editor(MoveSelection(Right)),
             Editor(ReplaceWithCopiedText {
                 use_system_clipboard: false,
                 cut: false,
             }),
             Expect(CurrentComponentContent("fn fn() { let x = 1; }")),
             Expect(CurrentSelectedTexts(&["fn"])),
-            Editor(MoveSelection(Right)),
+            Editor(MoveSelection(Beta)),
             Editor(ReplaceWithCopiedText {
                 use_system_clipboard: false,
                 cut: false,
@@ -750,10 +745,7 @@ fn cut_replace() -> anyhow::Result<()> {
                 focus: true,
             }),
             Editor(SetContent("fn main() { let x = 1; }".to_string())),
-            Editor(SetSelectionMode(
-                IfCurrentNotFound::LookForward,
-                Token { skip_symbols: true },
-            )),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Token)),
             Editor(ChangeCut {
                 use_system_clipboard: false,
             }),
@@ -782,16 +774,11 @@ fn highlight_mode_cut() -> anyhow::Result<()> {
             Editor(SetContent(
                 "fn f(){ let x = S(a); let y = S(b); }".to_string(),
             )),
-            Editor(SetSelectionMode(
-                IfCurrentNotFound::LookForward,
-                Token {
-                    skip_symbols: false,
-                },
-            )),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Token)),
             Editor(EnableSelectionExtension),
             Editor(MoveSelection(Right)),
-            Editor(MoveSelection(Right)),
-            Editor(MoveSelection(Right)),
+            Editor(MoveSelection(Beta)),
+            Editor(MoveSelection(Beta)),
             Expect(CurrentSelectedTexts(&["fn f()"])),
             Editor(ChangeCut {
                 use_system_clipboard: false,
@@ -820,22 +807,17 @@ fn highlight_mode_copy() -> anyhow::Result<()> {
             Editor(SetContent(
                 "fn f(){ let x = S(a); let y = S(b); }".to_string(),
             )),
-            Editor(SetSelectionMode(
-                IfCurrentNotFound::LookForward,
-                SelectionMode::Token {
-                    skip_symbols: false,
-                },
-            )),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Token)),
             Editor(EnableSelectionExtension),
             Editor(MoveSelection(Movement::Right)),
-            Editor(MoveSelection(Movement::Right)),
-            Editor(MoveSelection(Movement::Right)),
+            Editor(MoveSelection(Movement::Beta)),
+            Editor(MoveSelection(Movement::Beta)),
             Expect(CurrentSelectedTexts(&["fn f()"])),
             Editor(Copy {
                 use_system_clipboard: false,
             }),
             Editor(Reset),
-            Editor(MoveSelection(Right)),
+            Editor(MoveSelection(Beta)),
             Expect(CurrentSelectedTexts(&["{"])),
             Editor(ReplaceWithCopiedText {
                 use_system_clipboard: false,
@@ -860,16 +842,11 @@ fn highlight_mode_replace() -> anyhow::Result<()> {
             Editor(SetContent(
                 "fn f(){ let x = S(a); let y = S(b); }".to_string(),
             )),
-            Editor(SetSelectionMode(
-                IfCurrentNotFound::LookForward,
-                SelectionMode::Token {
-                    skip_symbols: false,
-                },
-            )),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Token)),
             Editor(EnableSelectionExtension),
             Editor(MoveSelection(Movement::Right)),
-            Editor(MoveSelection(Movement::Right)),
-            Editor(MoveSelection(Movement::Right)),
+            Editor(MoveSelection(Movement::Beta)),
+            Editor(MoveSelection(Movement::Beta)),
             Expect(CurrentSelectedTexts(&["fn f()"])),
             Editor(Copy {
                 use_system_clipboard: false,
@@ -967,12 +944,7 @@ fn signature_help() -> anyhow::Result<()> {
             Editor(SetContent(
                 "fn f(){ let x = S(a); let y = S(b); }".to_string(),
             )),
-            Editor(SetSelectionMode(
-                IfCurrentNotFound::LookForward,
-                SelectionMode::Token {
-                    skip_symbols: false,
-                },
-            )),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Token)),
             Expect(CurrentMode(Mode::Normal)),
             //
             // Signature help should not be shown in normal mode
@@ -1831,9 +1803,9 @@ fn same_range_diagnostics_should_be_merged() -> Result<(), anyhow::Error> {
             Expect(EditorInfoContent(expected_info)),
             // Expect there's only one diagnostic, by the fact that moving to the first and
             // last diagnostic still renders the same info
-            Editor(MoveSelection(First)),
+            Editor(MoveSelection(Alpha)),
             Expect(EditorInfoContent(expected_info)),
-            Editor(MoveSelection(Last)),
+            Editor(MoveSelection(Beta)),
             Expect(EditorInfoContent(expected_info)),
         ])
     })
@@ -2431,10 +2403,7 @@ c1 c2 c3"
                 )),
                 Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Line)),
                 Editor(CursorAddToAllSelections),
-                Editor(SetSelectionMode(
-                    IfCurrentNotFound::LookForward,
-                    Token { skip_symbols: true },
-                )),
+                Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Token)),
                 Expect(CurrentSelectedTexts(&["a1", "b1", "c1"])),
                 Editor(Copy {
                     use_system_clipboard: true,
@@ -2485,10 +2454,7 @@ c1 c2 c3"
                 )),
                 Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Line)),
                 Editor(CursorAddToAllSelections),
-                Editor(SetSelectionMode(
-                    IfCurrentNotFound::LookForward,
-                    Token { skip_symbols: true },
-                )),
+                Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Token)),
                 Expect(CurrentSelectedTexts(&["a1", "b1", "c1"])),
                 Editor(Copy {
                     use_system_clipboard: true,


### PR DESCRIPTION
The First/Last movement is renamed to Alpha/Beta to allow it to carry connotations beyond moving to the first or last selection.