### PR TITLE
fix(help/keymap): handle multiline description widths

### DIFF
--- a/src/components/editor_keymap_printer.rs
+++ b/src/components/editor_keymap_printer.rs
@@ -143,7 +143,7 @@ impl KeymapPrintSection {
                         .unwrap_or_default() as u16
                 })
                 .max()
-                .unwrap_or_default() as u16;
+                .unwrap_or_default();
             ColumnConstraint::LowerBoundary(Width::Fixed(min_width.min(max_column_width)))
         };
 

--- a/src/components/editor_keymap_printer.rs
+++ b/src/components/editor_keymap_printer.rs
@@ -135,7 +135,13 @@ impl KeymapPrintSection {
                 .keys
                 .iter()
                 .filter_map(|row| row.get(column_index))
-                .map(|key| key.display(show_shift_alt_keys).len())
+                .map(|key| {
+                    key.display(show_shift_alt_keys)
+                        .lines()
+                        .map(|line| line.len())
+                        .max()
+                        .unwrap_or(0)
+                })
                 .max()
                 .unwrap_or_default() as u16;
             ColumnConstraint::LowerBoundary(Width::Fixed(min_width.min(max_column_width)))

--- a/src/components/editor_keymap_printer.rs
+++ b/src/components/editor_keymap_printer.rs
@@ -138,9 +138,9 @@ impl KeymapPrintSection {
                 .map(|key| {
                     key.display(show_shift_alt_keys)
                         .lines()
-                        .map(|line| line.len())
+                        .map(|line| line.chars().count())
                         .max()
-                        .unwrap_or(0)
+                        .unwrap_or_default() as u16
                 })
                 .max()
                 .unwrap_or_default() as u16;


### PR DESCRIPTION
So the width used for cell width was using length of all lines.

This is not very important, if you think its not worth bothering with that's fine. 😄 

I had noticed there was a lot of padding when Help or Space menu was showing the shift and option keys.
My terminal width on my right monitor was wide enough for data without the extra padding and it was bugging me that it was wrapping. Took a while and some more practice reading Rust but I got there.

The original code used the length of all 3 lines of text concatenated for width not the longest line in a multiline scenario.

In addition for general String processing the original code used `len()` and not `chars().count()` so it doesnt handle multi byte UTF-8. But I left it with `len()` for now as original was len().