### PR TITLE
chore(Cargo.toml): disable debug by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,4 +123,4 @@ is_ci = "1.2.0"
 
 
 [profile.release]
-debug = true
+debug = false # Set this to true when using `sudo cargo flamegraph`


### PR DESCRIPTION
So that the compiled binary size will be much smaller.