### PR TITLE
feat(render): highlight cursor line number

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -390,6 +390,7 @@ impl<T: Frontend> App<T> {
                 }]
                 .to_vec(),
                 self.context.theme(),
+                None,
             );
             Window::new(
                 grid,

--- a/src/themes/mod.rs
+++ b/src/themes/mod.rs
@@ -57,6 +57,9 @@ impl Theme {
             StyleKey::UiPrimarySelection => {
                 Style::new().background_color(self.ui.primary_selection_background)
             }
+            StyleKey::UiCursorLineNumber => {
+                Style::new().background_color(self.ui.primary_selection_background)
+            }
             StyleKey::UiPrimarySelectionAnchors => {
                 Style::new().background_color(self.ui.primary_selection_anchor_background)
             }


### PR DESCRIPTION
| Before | After |
|--------|--------|
| <img width="1222" alt="image" src="https://github.com/user-attachments/assets/e986bb4f-d90e-4859-af8b-8cb7c30fa004" /> | <img width="1222" alt="image" src="https://github.com/user-attachments/assets/36ad781a-89fc-4942-a964-c6ba8e1fe8c4" /> | 