### PR TITLE
keymap: map previous/next historical selection to Backspace/Tab

### DIFF
--- a/docs/docs/normal-mode/other-movements.md
+++ b/docs/docs/normal-mode/other-movements.md
@@ -49,6 +49,8 @@ This is similar to Vim's Visual Mode `o`.
 
 ### `← Select`/`Select →`
 
+Keybindings: `backspace`/`tab`
+
 Go to the previous/next selection. This is similar to Vim's `ctrl+o`/`ctrl+i`, but it onlys work within a file.
 
 This is useful when you messed up the current selection, especially when you are

--- a/src/components/editor_keymap.rs
+++ b/src/components/editor_keymap.rs
@@ -42,7 +42,7 @@ pub(crate) const KEYMAP_NORMAL_SHIFTED: [[Meaning; 10]; 3] = [
 /// Meta also means Alt (Windows) or Option (Mac).
 pub(crate) const KEYMAP_META: [[Meaning; 10]; 3] = [
     [
-        KilLP, CSrch, LineU, _____, KilLN, /****/ NBack, GBack, ScrlU, GForw, NForw,
+        KilLP, CSrch, LineU, _____, KilLN, /****/ NBack, _____, ScrlU, _____, NForw,
     ],
     [
         _____, LineP, LineD, LineN, OpenM, /****/ DTknP, MrkFP, ScrlD, MrkFN, SView,
@@ -520,10 +520,6 @@ pub(crate) enum Meaning {
     FindP,
     /// First
     First,
-    /// Go back
-    GBack,
-    /// Go forward
-    GForw,
     /// Navigate back (faster alternative of Go Back, skips contiguous navigation, works across files)
     NBack,
     /// Navigate forward

--- a/src/components/editor_keymap_legend.rs
+++ b/src/components/editor_keymap_legend.rs
@@ -120,13 +120,13 @@ impl Editor {
                 Dispatch::ToEditor(ScrollPageUp),
             ),
             Keymap::new_extended(
-                context.keyboard_layout_kind().get_key(&Meaning::GBack),
+                "backspace",
                 Direction::Start.format_action("Select"),
                 "Go back".to_string(),
                 Dispatch::ToEditor(GoBack),
             ),
             Keymap::new_extended(
-                context.keyboard_layout_kind().get_key(&Meaning::GForw),
+                "tab",
                 Direction::End.format_action("Select"),
                 "Go forward".to_string(),
                 Dispatch::ToEditor(GoForward),

--- a/src/components/test_editor.rs
+++ b/src/components/test_editor.rs
@@ -4573,3 +4573,38 @@ fuor
         ])
     })
 }
+
+#[test]
+fn line_move_right_back_to_historical_position() -> anyhow::Result<()> {
+    execute_test(|s| {
+        Box::new([
+            App(OpenFile {
+                path: s.main_rs(),
+                owner: BufferOwner::User,
+                focus: true,
+            }),
+            Editor(SetContent(
+                "
+fn main() {
+    foo();
+    bar();
+}
+                "
+                .trim()
+                .to_string(),
+            )),
+            Editor(MatchLiteral("bar".to_string())),
+            Editor(SetSelectionMode(
+                IfCurrentNotFound::LookForward,
+                SelectionMode::Line,
+            )),
+            Expect(CurrentSelectedTexts(&["bar();"])),
+            Editor(MoveSelection(Left)),
+            Expect(CurrentSelectedTexts(&["fn main() {"])),
+            App(HandleKeyEvents(keys!("backspace").to_vec())),
+            Expect(CurrentSelectedTexts(&["bar();"])),
+            App(HandleKeyEvents(keys!("tab").to_vec())),
+            Expect(CurrentSelectedTexts(&["fn main() {"])),
+        ])
+    })
+}


### PR DESCRIPTION
So that it will be usable in VS Code Ki, as these actions were previously bound to alt keys which are not handled by VS Code.