### PR TITLE
keymap: promote Repeat Last Search to first layer

### DIFF
--- a/docs/docs/normal-mode/selection-modes/primary.md
+++ b/docs/docs/normal-mode/selection-modes/primary.md
@@ -173,3 +173,8 @@ In this selection mode, the movements behave like the usual editor, where [Left/
 [First/Last](./../core-movements.md#firstlast) means the first/last character of the current word.
 
 <TutorialFallback filename="char"/>
+
+
+## `Last Search`
+
+Repeats the last search.

--- a/docs/docs/normal-mode/selection-modes/secondary/index.md
+++ b/docs/docs/normal-mode/selection-modes/secondary/index.md
@@ -28,7 +28,7 @@ first layer due to their ubiquity.
 
 - `[` : Local (Backward)
 - `]` : Local (Forward)
-- `n` (Qwerty) : Global
+- `\**\**`: Global
 
 Local Find is directional, meaning that if the cursor position does not overlap
 with any selections of the chosen secondary selection mode, the cursor will
@@ -51,9 +51,9 @@ They are almost identical except:
 1. `One` and `Int` are only applicable for the Local keymaps
 2. `Search` and `This` are only applicable for the Global keymap
 3. Position of `Repeat` is different all 3 keymaps to enable easy combo:  
-   a. To repeat the last secondary selection backward, press `y` (Qwerty) twice  
-   b. To repeat the last secondary selection forward, press `p` (Qwerty) twice  
-   c. To repeat the last secondary selection globally, press `n` (Qwerty) twice
+   a. To repeat the last secondary selection backward, press `[` twice  
+   b. To repeat the last secondary selection forward, press `]` twice  
+   c. To repeat the last secondary selection globally, press `\\` twice
 
 ### Local (Forward)
 

--- a/justfile
+++ b/justfile
@@ -54,6 +54,10 @@ tree-sitter-quickfix:
 
 doc-assets testname="":
     cargo test --workspace -- --nocapture 'doc_assets_' {{testname}}
+    
+# This command helps you locate the actual recipe that is failing
+doc-assets-get-recipes-error:
+    just doc-assets generate_recipes > /dev/null
 
 doc: doc-assets
     just -f docs/justfile

--- a/src/app.rs
+++ b/src/app.rs
@@ -3131,6 +3131,7 @@ pub(crate) enum GlobalSearchFilterGlob {
 pub(crate) enum LocalSearchConfigUpdate {
     Mode(LocalSearchConfigMode),
     Replacement(String),
+    #[cfg(test)]
     Search(String),
     Config(crate::context::LocalSearchConfig),
 }

--- a/src/components/editor_keymap.rs
+++ b/src/components/editor_keymap.rs
@@ -21,7 +21,7 @@ pub(crate) const KEYMAP_NORMAL: [[Meaning; 10]; 3] = [
         Line_, Token, Sytx_, Extnd, OpenN, /****/ DeltN, Left_, Down_, Right, Jump_,
     ],
     [
-        Undo_, Rplc_, Copy_, PsteN, Mark_, /****/ Globl, Chng_, First, Last_, XAchr,
+        Undo_, Rplc_, Copy_, PsteN, Mark_, /****/ LSrhF, Chng_, First, Last_, XAchr,
     ],
 ];
 
@@ -33,7 +33,7 @@ pub(crate) const KEYMAP_NORMAL_SHIFTED: [[Meaning; 10]; 3] = [
         LineF, _____, FStyx, Trsfm, OpenP, /****/ DeltP, DeDnt, Break, Indnt, ToIdx,
     ],
     [
-        Redo_, PRplc, RplcX, PsteP, MarkF, /****/ _____, ChngX, _____, _____, SSEnd,
+        Redo_, PRplc, RplcX, PsteP, MarkF, /****/ LSrhB, ChngX, _____, _____, SSEnd,
     ],
     // Why is Raise placed at the same Position as Swap?
     // Because Raise is a special-case of Swap where the movement is Up
@@ -57,7 +57,7 @@ pub(crate) const KEYMAP_META: [[Meaning; 10]; 3] = [
 /// are both located on the right-side.
 pub(crate) const KEYMAP_FIND_LOCAL: [[Meaning; 10]; 3] = [
     [
-        OneCh, CSrch, NtrlN, PSrch, Qkfix, /****/ FindP, _____, _____, _____, FindN,
+        OneCh, CSrch, NtrlN, _____, Qkfix, /****/ FindP, _____, _____, _____, FindN,
     ],
     [
         DgAll, DgErr, DgWrn, DgHnt, GHnkC, /****/ _____, _____, _____, _____, _____,
@@ -81,13 +81,13 @@ pub(crate) const KEYMAP_FIND_LOCAL_SHIFTED: [[Meaning; 10]; 3] = [
 /// This keymap should be almost identical with that of Find Local
 pub(crate) const KEYMAP_FIND_GLOBAL: [[Meaning; 10]; 3] = [
     [
-        Srch_, CSrch, SrchC, PSrch, Qkfix, /****/ _____, _____, _____, _____, _____,
+        Srch_, CSrch, SrchC, _____, Qkfix, /****/ _____, _____, _____, _____, _____,
     ],
     [
         DgAll, DgErr, DgWrn, DgHnt, GHnkC, /****/ _____, _____, _____, _____, _____,
     ],
     [
-        LImpl, LDefn, LType, LRfrE, Mark_, /****/ Globl, _____, _____, _____, _____,
+        LImpl, LDefn, LType, LRfrE, Mark_, /****/ LSrhB, _____, _____, _____, _____,
     ],
 ];
 pub(crate) type KeyboardMeaningLayout = [[Meaning; 10]; 3];
@@ -524,8 +524,6 @@ pub(crate) enum Meaning {
     NBack,
     /// Navigate forward
     NForw,
-    /// Find (global)
-    Globl,
     /// Indent
     Indnt,
     /// Remove selections matching search
@@ -628,8 +626,10 @@ pub(crate) enum Meaning {
     SSEnd,
     /// Search (directionless)
     Srch_,
-    /// Search (using previous search)
-    PSrch,
+    /// Last Search (Backward)
+    LSrhB,
+    /// Last Search (Forward)
+    LSrhF,
     /// Quickfix
     Qkfix,
     /// Git Hunk (against current branch)

--- a/src/components/test_editor.rs
+++ b/src/components/test_editor.rs
@@ -3821,7 +3821,9 @@ fn background_editor_focused_not_in_buffer_list() -> anyhow::Result<()> {
 fn background_editor_forefront_on_edit() -> anyhow::Result<()> {
     execute_test(|_| {
         Box::new([
-            App(HandleKeyEvents(keys!("n q f o o : : f o o enter").to_vec())),
+            App(HandleKeyEvents(
+                keys!("backslash q f o o : : f o o enter").to_vec(),
+            )),
             Expect(OpenedFilesCount(0)),
             Expect(CurrentComponentTitle(markup_focused_tab(" 🦀 main.rs "))),
             Editor(EnterInsertMode(Direction::Start)),

--- a/src/context.rs
+++ b/src/context.rs
@@ -440,6 +440,7 @@ impl LocalSearchConfig {
             LocalSearchConfigUpdate::Replacement(replacement) => {
                 self.set_replacment(replacement);
             }
+            #[cfg(test)]
             LocalSearchConfigUpdate::Search(search) => {
                 self.set_search(search);
             }

--- a/src/recipes.rs
+++ b/src/recipes.rs
@@ -1888,17 +1888,6 @@ hello_world
             only: false,
         },
         Recipe {
-            description: "Repeat last non-contigous selection mode",
-            content: "fo world fo where".trim(),
-            file_extension: "md",
-            prepare_events: &[],
-            events: keys!("q f o enter w h ] p"),
-            expectations: Box::new([CurrentSelectedTexts(&["fo"])]),
-            terminal_height: None,
-            similar_vim_combos: &[],
-            only: false,
-        },
-        Recipe {
             description: "Multi-cursor: add using movement",
             content: "
 foo bar spam

--- a/src/recipes.rs
+++ b/src/recipes.rs
@@ -825,6 +825,26 @@ foov foou bar",
                     only: false,
                 },
                 Recipe {
+                    description: "Split selections by last search",
+                    content: "
+fn main(foo: str) {
+    bar(foo);
+
+    foo = x + foo;
+    return foo;
+}"
+                    .trim(),
+                    file_extension: "rs",
+                    prepare_events: &[],
+                    events: keys!("s l l e a d r n"),
+                    expectations: Box::new([
+                        CurrentSelectedTexts(&["foo", "foo", "foo", "foo", "foo",]),
+                    ]),
+                    terminal_height: Some(7),
+                    similar_vim_combos: &[],
+                    only: true,
+                },
+                Recipe {
                     description: "Split selections by marks",
                     content: "foo bar spam"
                     .trim(),

--- a/src/recipes.rs
+++ b/src/recipes.rs
@@ -842,7 +842,7 @@ fn main(foo: str) {
                     ]),
                     terminal_height: Some(7),
                     similar_vim_combos: &[],
-                    only: true,
+                    only: false,
                 },
                 Recipe {
                     description: "Split selections by marks",


### PR DESCRIPTION
Keymap changes:
1. `n`/`N` is now bound to `Repeat last search (forward)`/`Repeat last search (backward)`
2. Global is changed from `n` to `\`

Reason:
Previously, Repeat Last Search is bound to `[ r` or `] r`, which is frankly a little tedious considering how often we need to repeat the last search.