### PR TITLE
add support for xaml & axaml files

### DIFF
--- a/shared/src/languages.rs
+++ b/shared/src/languages.rs
@@ -848,7 +848,7 @@ const fn unison() -> Language {
 
 const fn xml() -> Language {
     Language {
-        extensions: &["xml"],
+        extensions: &["xml", "xaml", "axaml"],
         tree_sitter_grammar_config: Some(GrammarConfig {
             id: "xml",
             url: "https://github.com/tree-sitter-grammars/tree-sitter-xml",


### PR DESCRIPTION
XAML files are used by WPF, and AXAML files are used by Avalonia. They're XML files sytactically so XML tree sitter works fine