### PR TITLE
revert(editor): enter normal mode select selection before cursor

### DIFF
--- a/docs/docs/insert-mode/index.md
+++ b/docs/docs/insert-mode/index.md
@@ -14,14 +14,7 @@ the keyboard types them into the current opened file.
 
 To enter the normal mode, press `esc` (regardless of keyboard layout).
 
-If the current selection mode is any of the following, then the selection before the cursor will be selected:
-
-1. Line
-2. Line Full
-3. Token
-4. Word
-
-Otherwise, only one character before the cursor will be selected, this is because except the selection modes above,
+When entering normal mode, only one character before the cursor will be selected, this is because except the selection modes above,
 the cursor might jump beyond the current view, causing unintended disorientation.
 
 <TutorialFallback filename="enter-normal-mode"/>

--- a/ki-vscode/package-lock.json
+++ b/ki-vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ki-editor-vscode",
-    "version": "0.0.15",
+    "version": "0.0.16",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "ki-editor-vscode",
-            "version": "0.0.15",
+            "version": "0.0.16",
             "license": "MPL-2.0",
             "dependencies": {
                 "async-mutex": "0.5.0",

--- a/src/components/keymap_legend.rs
+++ b/src/components/keymap_legend.rs
@@ -435,7 +435,10 @@ impl Component for KeymapLegend {
         let close_current_window = Dispatch::CloseCurrentWindowAndFocusParent;
         if self.editor.mode == Mode::Insert {
             match &event {
-                key!("esc") => self.editor.enter_normal_mode(context),
+                key!("esc") => {
+                    self.editor.enter_normal_mode(context)?;
+                    Ok(Default::default())
+                }
                 key!("space") => {
                     self.option = if !self.option.show_alt {
                         KeymapDisplayOption {

--- a/src/components/test_editor.rs
+++ b/src/components/test_editor.rs
@@ -2239,7 +2239,7 @@ fn tree_sitter_should_not_reparse_in_insert_mode() -> anyhow::Result<()> {
     assert_eq!(current_range, new_range);
 
     // Entering normal mode should reparse the tree
-    let _ = editor.enter_normal_mode(&context)?;
+    editor.enter_normal_mode(&context)?;
     let new_range = editor.buffer().tree().unwrap().root_node().range();
     assert_ne!(current_range, new_range);
 
@@ -4087,6 +4087,8 @@ fn undo_redo_multicursor() -> anyhow::Result<()> {
             Editor(Undo),
             Editor(Redo),
             Editor(EnterNormalMode),
+            Expect(CurrentSelectedTexts(&["x", "x"])),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookBackward, Token)),
             Expect(CurrentSelectedTexts(&["foox", "barx"])),
         ])
     })
@@ -4379,51 +4381,6 @@ fn test_search_query_should_not_trim_surrounding_whitespace() -> Result<(), anyh
             Expect(CurrentSelectedTexts(&["xfoo", "foobarfoo"])),
         ])
     })
-}
-
-#[test]
-fn enter_normal_mode_select_previous_selection() -> anyhow::Result<()> {
-    let run_test = |selection_mode: SelectionMode,
-                    expected_selection: &'static [&str],
-                    expected_content: &'static str| {
-        execute_test(|s| {
-            Box::new([
-                App(OpenFile {
-                    path: s.main_rs(),
-                    owner: BufferOwner::User,
-                    focus: true,
-                }),
-                Editor(SetContent("  -fooBar spam\nhello world".to_string())),
-                Editor(SetSelectionMode(
-                    IfCurrentNotFound::LookForward,
-                    selection_mode.clone(),
-                )),
-                Editor(EnterInsertMode(Direction::End)),
-                App(HandleKeyEvents(keys!("x").to_vec())),
-                Editor(EnterNormalMode),
-                Expect(CurrentComponentContent(expected_content)),
-                Expect(CurrentSelectedTexts(expected_selection)),
-            ])
-        })
-    };
-    run_test(Token, &["-fooBarx"], "  -fooBarx spam\nhello world")?;
-    run_test(Word, &["xfoo"], "  -xfooBar spam\nhello world")?;
-    run_test(Line, &["-fooBar spamx"], "  -fooBar spamx\nhello world")?;
-    run_test(LineFull, &["xhello world"], "  -fooBar spam\nxhello world")?;
-
-    // Other than the 4 selection modes above, other mode should select only one character
-    run_test(Character, &["x"], " x -fooBar spam\nhello world")?;
-    run_test(
-        SelectionMode::Find {
-            search: Search {
-                mode: Default::default(),
-                search: "foob".to_string(),
-            },
-        },
-        &["x"],
-        "  -fooBxar spam\nhello world",
-    )?;
-    Ok(())
 }
 
 #[test]

--- a/src/recipes.rs
+++ b/src/recipes.rs
@@ -1343,7 +1343,7 @@ foo bar spam
                 expectations: Box::new([CurrentSelectedTexts(&["k"])]),
                 terminal_height: None,
                 similar_vim_combos: &[],
-                only: true,
+                only: false,
             }].to_vec(),
         },
         RecipeGroup {

--- a/src/recipes.rs
+++ b/src/recipes.rs
@@ -1335,15 +1335,15 @@ foo bar spam
             filename: "enter-normal-mode",
             recipes: [
             Recipe {
-                description: "Enter Normal mode select selection before cursor",
+                description: "Enter Normal mode",
                 content: "foo bar spam",
                 file_extension: "md",
                 prepare_events: &[],
                 events: keys!("s l ; o k esc"),
-                expectations: Box::new([CurrentSelectedTexts(&["barok"])]),
+                expectations: Box::new([CurrentSelectedTexts(&["k"])]),
                 terminal_height: None,
                 similar_vim_combos: &[],
-                only: false,
+                only: true,
             }].to_vec(),
         },
         RecipeGroup {


### PR DESCRIPTION
## Description
This reverts a5fedfa.

## Reason
Because I find the following flow annoying:

1. Enter Line selection mode
2. Execute Insert After
3. Type in a new word, say `foo`
4. Press esc to enter normal mode
5. I expect the cursor to be at somewhere near `foo`, but the cursor goes to the first non-whitespace character of the current line, because the last selection mode was Line, so the current line becomes selected, and so to go back to `foo`, I have to press a significant amount of keys.