### PR TITLE
feat(keymap_legend): show exmatrix keybindings

### DIFF
--- a/src/components/editor_keymap.rs
+++ b/src/components/editor_keymap.rs
@@ -117,7 +117,7 @@ pub(crate) const KEYMAP_SURROUND: KeyboardMeaningLayout = [
 
 pub(crate) const KEYMAP_SPACE: KeyboardMeaningLayout = [
     [
-        QSave, SaveA, Explr, Buffr, KeybL, /****/ _____, RevlS, RevlC, RevlM, _____,
+        QSave, SaveA, Explr, Buffr, _____, /****/ _____, RevlS, RevlC, RevlM, _____,
     ],
     [
         Theme, Symbl, File_, LRnme, GitFC, /****/ _____, LHovr, LCdAc, Pipe_, _____,
@@ -694,8 +694,6 @@ pub(crate) enum Meaning {
     GitFC,
     /// Pick Git Status File (against main branch)
     GitFM,
-    /// Pick Keyboard Layout
-    KeybL,
     /// LSP Hover
     LHovr,
     /// Undo Tree

--- a/src/components/editor_keymap_legend.rs
+++ b/src/components/editor_keymap_legend.rs
@@ -1126,9 +1126,7 @@ impl Editor {
                     Dispatch::ToEditor(DispatchEditor::ShowHelp),
                 )))
                 .chain(Some(Keymap::new(
-                    context
-                        .keyboard_layout_kind()
-                        .get_space_keymap(&Meaning::KeybL),
+                    "*",
                     "Keyboard".to_string(),
                     Dispatch::OpenKeyboardLayoutPrompt,
                 )))

--- a/src/components/editor_keymap_printer.rs
+++ b/src/components/editor_keymap_printer.rs
@@ -118,6 +118,7 @@ impl KeymapPrintSection {
             .any(|keys| keys.iter().any(|key| key.has_content()))
     }
 
+    /// Returns None if the terminal width is too small
     pub(crate) fn display(&self, terminal_width: u16, option: &KeymapDisplayOption) -> String {
         let max_column_width = terminal_width / 11;
         let mut table = Table::new();
@@ -184,9 +185,11 @@ impl KeymapPrintSection {
         let content_width: u16 = table.column_max_content_widths().iter().sum();
         // column content, separators, padding & editor margins
         if content_width + 12 + 22 + 2 < terminal_width {
-            format!("{table}")
+            let exmatrix_keybindings =
+                ["[] Local", "\\ Global", "* Pick Keyboard"].join(&" ".repeat(4));
+            format!("{table}\n{exmatrix_keybindings}")
         } else {
-            String::new()
+            "Window is too small to display keymap legend :(".to_string()
         }
     }
 

--- a/src/components/keymap_legend.rs
+++ b/src/components/keymap_legend.rs
@@ -52,18 +52,12 @@ impl Keymaps {
         terminal_width: u16,
         option: &KeymapDisplayOption,
     ) -> String {
-        let table = KeymapPrintSection::from_keymaps(
+        KeymapPrintSection::from_keymaps(
             "".to_string(),
             self,
             keyboard_layout_kind.get_keyboard_layout(),
         )
-        .display(terminal_width, option);
-
-        if !table.is_empty() {
-            format!("Press space to toggle alt/shift keys.\n{table}")
-        } else {
-            "Window is too small to display keymap legend :(".to_string()
-        }
+        .display(terminal_width, option)
     }
     fn display_mnemonic(&self, indent: usize, width: usize) -> String {
         let width = width.saturating_sub(indent);
@@ -394,8 +388,8 @@ impl KeymapLegend {
             editor,
             config,
             option: KeymapDisplayOption {
-                show_alt: false,
-                show_shift: false,
+                show_alt: true,
+                show_shift: true,
             },
             keymap_layout_kind: context.keyboard_layout_kind().clone(),
         }
@@ -437,20 +431,6 @@ impl Component for KeymapLegend {
             match &event {
                 key!("esc") => {
                     self.editor.enter_normal_mode(context)?;
-                    Ok(Default::default())
-                }
-                key!("space") => {
-                    self.option = if !self.option.show_alt {
-                        KeymapDisplayOption {
-                            show_alt: true,
-                            show_shift: true,
-                        }
-                    } else {
-                        KeymapDisplayOption {
-                            show_alt: false,
-                            show_shift: false,
-                        }
-                    };
                     Ok(Default::default())
                 }
                 key!("ctrl+c") => Ok(Dispatches::one(Dispatch::CloseCurrentWindow)),
@@ -548,7 +528,6 @@ mod test_keymap_legend {
             )
             .to_string();
         let expected = "
-Press space to toggle alt/shift keys.
 ╭───────┬───┬─────────────┬───┬──────┬───┬───┬───┬───┬───┬───╮
 │       ┆   ┆             ┆   ┆      ┆ ∅ ┆   ┆   ┆   ┆   ┆   │
 ├╌╌╌╌╌╌╌┼╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌┼╌╌╌╌╌╌┼╌╌╌┼╌╌╌┼╌╌╌┼╌╌╌┼╌╌╌┼╌╌╌┤
@@ -556,6 +535,7 @@ Press space to toggle alt/shift keys.
 ├╌╌╌╌╌╌╌┼╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌┼╌╌╌╌╌╌┼╌╌╌┼╌╌╌┼╌╌╌┼╌╌╌┼╌╌╌┼╌╌╌┤
 │       ┆   ┆ Caterpillar ┆   ┆ Bomb ┆ ∅ ┆   ┆   ┆   ┆   ┆   │
 ╰───────┴───┴─────────────┴───┴──────┴───┴───┴───┴───┴───┴───╯
+[] Local    \\ Global    * Pick Keyboard
 "
         .trim_matches('\n');
         assert_eq!(actual, expected);
@@ -571,7 +551,6 @@ Press space to toggle alt/shift keys.
             )
             .to_string();
         let expected = "
-Press space to toggle alt/shift keys.
 ╭───────┬───┬─────────────┬─────┬────────┬───┬───┬───┬───┬───┬───╮
 │       ┆   ┆             ┆     ┆        ┆ ⌥ ┆   ┆   ┆   ┆   ┆   │
 │       ┆   ┆             ┆     ┆        ┆ ⇧ ┆   ┆   ┆   ┆   ┆   │
@@ -585,6 +564,7 @@ Press space to toggle alt/shift keys.
 │       ┆   ┆             ┆     ┆        ┆ ⇧ ┆   ┆   ┆   ┆   ┆   │
 │       ┆   ┆ Caterpillar ┆     ┆  Bomb  ┆ ∅ ┆   ┆   ┆   ┆   ┆   │
 ╰───────┴───┴─────────────┴─────┴────────┴───┴───┴───┴───┴───┴───╯
+[] Local    \\ Global    * Pick Keyboard
 "
         .trim_matches('\n');
         assert_eq!(actual, expected);


### PR DESCRIPTION
Also make the Pick Keyboard Layout keybinding standard across different keyboard layouts, so that it is easy to switch keyboard layouts.

This PR closes #731 and #732.