### PR TITLE
fix(editor): jump should not exit extend mode

### DIFF
--- a/src/components/editor.rs
+++ b/src/components/editor.rs
@@ -1453,7 +1453,13 @@ impl Editor {
                             Movement::Jump(jump.selection.extended_range()),
                         )?;
                         self.mode = Mode::Normal;
-                        Ok(dispatches)
+                        Ok(dispatches.append_some(if context.is_running_as_embedded() {
+                            // We need to manually send a SelectionChanged dispatch here
+                            // because although SelectionChanged is dispatched automatically in most cases, it is not for this case.
+                            Some(self.dispatch_selection_changed())
+                        } else {
+                            None
+                        }))
                     }
                     Some(_) => {
                         self.jumps = Some(

--- a/src/components/editor.rs
+++ b/src/components/editor.rs
@@ -1447,9 +1447,14 @@ impl Editor {
                     .collect_vec();
                 match matching_jumps.split_first() {
                     None => Ok(Default::default()),
-                    Some((jump, [])) => Ok(self
-                        .handle_movement(context, Movement::Jump(jump.selection.extended_range()))?
-                        .append(Dispatch::ToEditor(EnterNormalMode))),
+                    Some((jump, [])) => {
+                        let dispatches = self.handle_movement(
+                            context,
+                            Movement::Jump(jump.selection.extended_range()),
+                        )?;
+                        self.mode = Mode::Normal;
+                        Ok(dispatches)
+                    }
                     Some(_) => {
                         self.jumps = Some(
                             matching_jumps

--- a/src/components/test_editor.rs
+++ b/src/components/test_editor.rs
@@ -325,6 +325,37 @@ fn test_delete_extended_selection() -> anyhow::Result<()> {
 }
 
 #[test]
+fn extend_jump() -> anyhow::Result<()> {
+    execute_test(move |s| {
+        Box::new([
+            App(OpenFile {
+                path: s.main_rs(),
+                owner: BufferOwner::User,
+                focus: true,
+            }),
+            Editor(SetContent("apple banana cake durian egg".to_string())),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Word)),
+            Editor(MoveSelection(Right)),
+            Expect(CurrentSelectedTexts(&["banana"])),
+            Editor(EnableSelectionExtension),
+            Editor(SetRectangle(Rectangle {
+                origin: Position::default(),
+                width: 100,
+                height: 1,
+            })),
+            Editor(ShowJumps {
+                use_current_selection_mode: true,
+                prior_change: None,
+            }),
+            App(HandleKeyEvents(keys!("d").to_vec())),
+            Expect(CurrentSelectedTexts(&["banana cake durian"])),
+            Editor(MoveSelection(Right)),
+            Expect(CurrentSelectedTexts(&["banana cake durian egg"])),
+        ])
+    })
+}
+
+#[test]
 fn test_delete_extended_selection_is_last_selection() -> anyhow::Result<()> {
     execute_test(|s| {
         Box::new([


### PR DESCRIPTION
## Root cause

https://github.com/ki-editor/ki-editor/blob/8826f9c2e911fecea054aa47fd6e6476776ae5b3/src/components/editor.rs#L1450-L1452

The code that handles jump mode also issued an `EnterNormalMode` dispatch, which will deactivate extension mode.

## Solution
Change the mode to Normal mode without using `EnterNormalMode` (which actually does more than just changing the mode.