### PR TITLE
fix(render): multiple info window rendered when activating global git hunk

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -878,6 +878,7 @@ impl<T: Frontend> App<T> {
             Dispatch::HandleKeyEvents(key_events) => self.handle_key_events(key_events)?,
             Dispatch::CloseDropdown => self.layout.close_dropdown(),
             Dispatch::CloseEditorInfo => self.layout.close_editor_info(),
+            Dispatch::CloseGlobalInfo => self.layout.close_global_info(),
             Dispatch::RenderDropdown { render } => {
                 if let Some(dropdown) = self.layout.open_dropdown(&self.context) {
                     self.render_dropdown(dropdown, render)?;
@@ -929,6 +930,7 @@ impl<T: Frontend> App<T> {
             Dispatch::ToHostApp(to_host_app) => self.handle_to_host_app(to_host_app)?,
             Dispatch::FromHostApp(from_host_app) => self.handle_from_host_app(from_host_app)?,
             Dispatch::OpenSurroundXmlPrompt => self.open_surround_xml_prompt()?,
+            Dispatch::ShowGlobalInfo(info) => self.show_global_info(info),
         }
         Ok(())
     }
@@ -2405,13 +2407,13 @@ impl<T: Frontend> App<T> {
     }
 
     #[cfg(test)]
-    pub(crate) fn editor_info_open(&self) -> bool {
-        self.layout.editor_info_open()
+    pub(crate) fn editor_info_contents(&self) -> Vec<String> {
+        self.layout.editor_info_contents()
     }
 
     #[cfg(test)]
-    pub(crate) fn editor_info_content(&self) -> Option<String> {
-        self.layout.editor_info_content()
+    pub(crate) fn global_info_contents(&self) -> Vec<String> {
+        self.layout.global_info_contents()
     }
 
     fn reveal_path_in_explorer(&mut self, path: &CanonicalizedPath) -> anyhow::Result<()> {
@@ -2458,8 +2460,8 @@ impl<T: Frontend> App<T> {
     }
 
     #[cfg(test)]
-    pub(crate) fn quickfix_list_info(&self) -> Option<String> {
-        self.layout.quickfix_list_info()
+    pub(crate) fn global_info(&self) -> Option<String> {
+        self.layout.global_info()
     }
 
     #[cfg(test)]
@@ -3074,6 +3076,7 @@ pub(crate) enum Dispatch {
     OtherWindow,
     CloseCurrentWindowAndFocusParent,
     CloseEditorInfo,
+    CloseGlobalInfo,
     CycleMarkedFile(Direction),
     PushPromptHistory {
         key: PromptHistoryKey,
@@ -3104,6 +3107,7 @@ pub(crate) enum Dispatch {
     ToHostApp(ToHostApp),
     FromHostApp(FromHostApp),
     OpenSurroundXmlPrompt,
+    ShowGlobalInfo(Info),
 }
 
 /// Used to send notify host app about changes

--- a/src/components/editor.rs
+++ b/src/components/editor.rs
@@ -758,7 +758,7 @@ impl Editor {
             .into_iter()
             .flatten()
             .reduce(Info::join)
-            .map(Dispatch::ShowEditorInfo);
+            .map(Dispatch::ShowGlobalInfo);
         self.cursor_direction = Direction::Start;
         if store_history {
             self.buffer_mut()
@@ -3276,7 +3276,7 @@ impl Editor {
         let info = node
             .map(|node| node.to_sexp())
             .unwrap_or("[No node found]".to_string());
-        Ok(Dispatches::one(Dispatch::ShowEditorInfo(Info::new(
+        Ok(Dispatches::one(Dispatch::ShowGlobalInfo(Info::new(
             "Tree-sitter node S-expression".to_string(),
             info,
         ))))

--- a/src/components/prompt.rs
+++ b/src/components/prompt.rs
@@ -494,13 +494,13 @@ mod test_prompt {
                     },
                 }),
                 App(HandleKeyEvents(keys!("f o o _").to_vec())),
-                Expect(EditorInfoContent("foo_bar")),
+                Expect(EditorInfoContents(&["foo_bar"])),
                 App(HandleKeyEvents(keys!("alt+q z a m").to_vec())),
-                Expect(EditorInfoContent("zazam")),
+                Expect(EditorInfoContents(&["zazam"])),
                 App(HandleKeyEvents(keys!("alt+q q").to_vec())),
-                Expect(EditorInfoContent("boque")),
+                Expect(EditorInfoContents(&["boque"])),
                 App(HandleKeyEvents(keys!("esc esc").to_vec())),
-                Expect(EditorInfoContent("back to square one")),
+                Expect(EditorInfoContents(&["back to square one"])),
             ])
         })
     }

--- a/src/components/suggestive_editor.rs
+++ b/src/components/suggestive_editor.rs
@@ -99,6 +99,7 @@ impl Component for SuggestiveEditor {
             .chain(match event {
                 key!("esc") => [
                     Dispatch::CloseDropdown,
+                    Dispatch::CloseGlobalInfo,
                     Dispatch::CloseEditorInfo,
                     Dispatch::ToEditor(EnterNormalMode),
                 ]
@@ -300,6 +301,7 @@ mod test_suggestive_editor {
     use crate::lsp::documentation::Documentation;
     use crate::position::Position;
     use crate::selection::SelectionMode;
+    use crate::ui_tree::ComponentKind;
     use crate::{
         app::Dispatch,
         buffer::{Buffer, BufferOwner},
@@ -857,10 +859,18 @@ mod test_suggestive_editor {
                 SuggestiveEditor(CompletionFilter(SuggestiveEditorFilter::CurrentWord)),
                 Editor(EnterInsertMode(Direction::Start)),
                 App(ShowEditorInfo(Info::default())),
-                Expect(EditorInfoOpen(true)),
+                App(ShowGlobalInfo(Info::default())),
+                Expect(ComponentsOrder(
+                    [
+                        ComponentKind::SuggestiveEditor,
+                        ComponentKind::GlobalInfo,
+                        ComponentKind::EditorInfo,
+                    ]
+                    .to_vec(),
+                )),
                 Expect(CurrentPath(s.main_rs())),
                 App(HandleKeyEvent(key!("esc"))),
-                Expect(EditorInfoOpen(false)),
+                Expect(ComponentsOrder([ComponentKind::SuggestiveEditor].to_vec())),
             ])
         })
     }

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -227,7 +227,7 @@ impl DiffEntry {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum DiffMode {
     UnstagedAgainstMainBranch,
     UnstagedAgainstCurrentBranch,

--- a/src/ui_tree.rs
+++ b/src/ui_tree.rs
@@ -326,9 +326,8 @@ impl std::fmt::Debug for KindedComponent {
 pub(crate) enum ComponentKind {
     SuggestiveEditor,
     FileExplorer,
-    GlobalInfo,
     QuickfixList,
-    QuickfixListInfo,
+    GlobalInfo,
     Prompt,
     Dropdown,
     DropdownInfo,


### PR DESCRIPTION
...after activating local git hunk.

This is solved by using the same ComponentKind for both Quickfix List Info and Selection Mode Info.

This issue occurred because previously, the local Git hunk info was coming from Selection Mode Info, which uses a different component kind than the info coming from Quickfix List Info.