### PR TITLE
feat(editor/align): align consider multiple line selections

### DIFF
--- a/docs/docs/universal-keybindings.md
+++ b/docs/docs/universal-keybindings.md
@@ -3,6 +3,7 @@ sidebar_position: 8
 ---
 
 import {KeymapFallback} from '@site/src/components/KeymapFallback';
+import {TutorialFallback} from '@site/src/components/TutorialFallback';
 
 # Universal Keybindings
 
@@ -18,13 +19,17 @@ The keybindings presented here work in any [Modes](./modes.md).
 
 Switch view alignment.
 
+This is similar to Vim's `zt`, `zz` and `zb`, however, it works for multiple line selections.
+
 There are 3 kinds of view alignments (in order):
 
-1. Top
-1. Center
-1. Bottom
+1. Top: align first line of selection to the top
+1. Center: align the middle line of selection to the center
+1. Bottom: align the last line of the selection to the bottom
 
 Executing this action continuously cycles through the list above in order, starting from Top.
+
+<TutorialFallback filename="align-view"/>
 
 ### `⇋ Window`
 

--- a/src/components/editor.rs
+++ b/src/components/editor.rs
@@ -18,6 +18,7 @@ use crate::{
     rectangle::Rectangle,
     search::parse_search_config,
     selection::{CharIndex, Selection, SelectionMode, SelectionSet},
+    soft_wrap::{self, WrappedLines},
 };
 use crate::{
     app::{Dispatches, RequestParams, Scope},
@@ -39,6 +40,7 @@ use ropey::Rope;
 use shared::canonicalized_path::CanonicalizedPath;
 use std::{
     cell::{Ref, RefCell, RefMut},
+    cmp::Ordering,
     ops::{Not, Range},
     rc::Rc,
 };
@@ -186,9 +188,9 @@ impl Component for Editor {
         let last_visible_line = self.last_visible_line(context);
         match dispatch {
             #[cfg(test)]
-            AlignViewTop => self.align_cursor_to_top(),
+            AlignViewTop => self.align_selection_to_top(),
             #[cfg(test)]
-            AlignViewBottom => self.align_cursor_to_bottom(context),
+            AlignViewBottom => self.align_selection_to_bottom(context),
             Transform(transformation) => return self.transform_selection(transformation, context),
             SetSelectionMode(if_current_not_found, selection_mode) => {
                 return self.set_selection_mode(
@@ -291,6 +293,9 @@ impl Component for Editor {
             Paste {
                 use_system_clipboard,
             } => return self.paste(context, use_system_clipboard, true),
+            PasteNoGap {
+                use_system_clipboard,
+            } => return self.paste(context, use_system_clipboard, false),
             SwapCursor => self.swap_cursor(context),
             SetDecorations(decorations) => self.buffer_mut().set_decorations(&decorations),
             MoveCharacterBack => self.selection_set.move_left(&self.cursor_direction),
@@ -788,15 +793,13 @@ impl Editor {
         Ok(SelectionSet::new(NonEmpty::new(primary)).set_mode(mode))
     }
 
-    fn cursor_row(&self) -> u16 {
-        self.get_cursor_char_index()
-            .to_position(&self.buffer.borrow())
-            .line as u16
-    }
-
+    /// Scroll offset recalculation is always based on the position of the cursor
     fn recalculate_scroll_offset(&mut self, context: &Context) {
         // Update scroll_offset if primary selection is out of view.
-        let cursor_row = self.cursor_row();
+        let cursor_row = self
+            .buffer()
+            .char_to_line(self.get_cursor_char_index())
+            .unwrap_or_default() as u16;
         let render_area = self.render_area(context);
         if cursor_row.saturating_sub(self.scroll_offset) > render_area.height.saturating_sub(1)
             || cursor_row < self.scroll_offset
@@ -806,28 +809,122 @@ impl Editor {
         }
     }
 
-    pub(crate) fn align_cursor_to_bottom(&mut self, context: &Context) {
-        self.scroll_offset = self.cursor_row().saturating_sub(
+    fn align_selection<F: Fn(u16) -> u16>(
+        &mut self,
+        context: &Context,
+        target_line_index: u16,
+        available_height_multiplier: F,
+    ) {
+        let hidden_parent_lines_count = self.hidden_parent_line_ranges().unwrap_or_default().len();
+
+        let available_height = available_height_multiplier(
             self.rectangle
                 .height
                 .saturating_sub(1)
+                .saturating_sub(hidden_parent_lines_count as u16)
                 .saturating_sub(self.window_title_height(context)),
+        );
+
+        let line_number_width = self.buffer().len_lines().to_string().chars().count();
+
+        // dbg!(line_number_width);
+        let separator_width = 1;
+        let width = self
+            .rectangle
+            .width
+            .saturating_sub((line_number_width + separator_width) as u16);
+
+        // dbg!(available_height, self.rectangle.width, width);
+
+        let max_number_of_lines_that_can_be_taken_to_stack_on_top_of_target_row = {
+            let mut accumulated_height = 0;
+            let mut line_index = target_line_index as usize;
+            while line_index > 0 {
+                let text = &self
+                    .buffer()
+                    .get_line_by_line_index(line_index)
+                    .map(|slice| slice.to_string())
+                    .unwrap_or_default();
+                let line_height: usize = soft_wrap::soft_wrap(text, width as usize)
+                    .lines()
+                    .iter()
+                    .map(|line| line.lines().len())
+                    .sum();
+
+                // println!("=====");
+                // dbg!(text, line_height, accumulated_height, line_index);
+
+                if accumulated_height + line_height > available_height as usize {
+                    break;
+                } else {
+                    accumulated_height += line_height;
+                    line_index -= 1;
+                }
+            }
+
+            let lines_count = (target_line_index - line_index as u16);
+            lines_count
+        };
+
+        // dbg!(&max_number_of_lines_that_can_be_taken_to_stack_on_top_of_cursor_row);
+        // dbg!(&selection_end_line_index);
+
+        self.scroll_offset = target_line_index.saturating_sub(
+            max_number_of_lines_that_can_be_taken_to_stack_on_top_of_target_row as u16,
         );
     }
 
-    pub(crate) fn align_cursor_to_top(&mut self) {
-        self.scroll_offset = self.cursor_row();
+    /// If the primary selection has multiple lines
+    /// then the last line will be used for bottom alignment
+    pub(crate) fn align_selection_to_bottom(&mut self, context: &Context) {
+        let selection_end_line_index = self
+            .buffer()
+            .char_to_line(self.selection_set.primary_selection().range().end)
+            .unwrap_or_default() as u16;
+
+        self.align_selection(context, selection_end_line_index, |height| height)
+    }
+
+    /// If the primary selection has multiple lines
+    /// then the first line will be used for top alignment
+    pub(crate) fn align_selection_to_top(&mut self) {
+        let selection_first_line = self
+            .buffer()
+            .char_to_line(self.selection_set.primary_selection().range().start)
+            .unwrap_or_default() as u16;
+        self.scroll_offset = selection_first_line;
+    }
+
+    /// If the primary selection has multiple lines
+    /// then the middle line will be used for center alignment
+    /// TODO: need to cater for wrapped lines
+    fn align_selection_to_center(&mut self, context: &Context) {
+        let line_range = self
+            .buffer()
+            .char_index_range_to_line_range(self.selection_set.primary_selection().range())
+            .unwrap_or_default();
+
+        let mid = line_range.start + ((line_range.end - line_range.start) / 2);
+        self.align_selection(context, mid as u16, |height| height / 2);
+    }
+
+    fn cursor_row(&self) -> usize {
+        self.buffer()
+            .char_to_line(self.get_cursor_char_index())
+            .unwrap_or_default()
     }
 
     fn align_cursor_to_center(&mut self, context: &Context) {
-        self.scroll_offset = self.cursor_row().saturating_sub(
+        let cursor_row = self.cursor_row();
+
+        self.scroll_offset = cursor_row.saturating_sub(
             (self
                 .rectangle
                 .height
                 .saturating_sub(self.window_title_height(context)) as f64
                 / 2.0)
-                .ceil() as u16,
-        );
+                .ceil() as usize,
+        ) as u16;
     }
 
     pub(crate) fn select(
@@ -2837,15 +2934,15 @@ impl Editor {
     pub(crate) fn switch_view_alignment(&mut self, context: &Context) {
         self.current_view_alignment = Some(match self.current_view_alignment {
             Some(ViewAlignment::Top) => {
-                self.align_cursor_to_center(context);
+                self.align_selection_to_center(context);
                 ViewAlignment::Center
             }
             Some(ViewAlignment::Center) => {
-                self.align_cursor_to_bottom(context);
+                self.align_selection_to_bottom(context);
                 ViewAlignment::Bottom
             }
             None | Some(ViewAlignment::Bottom) => {
-                self.align_cursor_to_top();
+                self.align_selection_to_top();
                 ViewAlignment::Top
             }
         })
@@ -3844,6 +3941,22 @@ impl Editor {
         });
         Ok(dispatches)
     }
+
+    fn max_wrapped_lines_above_cursor_row(&self, context: &Context) -> WrappedLines {
+        let height = self.render_area(context).height.into();
+        let cursor_row = self.cursor_row();
+
+        let content = self
+            .buffer()
+            .rope()
+            .lines()
+            .skip(cursor_row.saturating_sub(height))
+            .take(height)
+            .map(|slice| slice.to_string())
+            .collect_vec()
+            .join("");
+        soft_wrap::soft_wrap(&content, self.render_area(context).width as usize)
+    }
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug)]
@@ -3943,6 +4056,9 @@ pub(crate) enum DispatchEditor {
     ReplaceCurrentSelectionWith(String),
     SelectLineAt(usize),
     Paste {
+        use_system_clipboard: bool,
+    },
+    PasteNoGap {
         use_system_clipboard: bool,
     },
     SwapCursor,

--- a/src/components/editor.rs
+++ b/src/components/editor.rs
@@ -19,7 +19,6 @@ use crate::{
     rectangle::Rectangle,
     search::parse_search_config,
     selection::{CharIndex, Selection, SelectionMode, SelectionSet},
-    soft_wrap::{self, WrappedLines},
 };
 use crate::{
     app::{Dispatches, RequestParams, Scope},
@@ -828,7 +827,6 @@ impl Editor {
         available_height_multiplier: F,
     ) {
         let primary_selection_range = self.selection_set.primary_selection().range();
-        dbg!(primary_selection_range);
         let line_range = self
             .buffer()
             .char_index_range_to_line_range(primary_selection_range)
@@ -845,29 +843,16 @@ impl Editor {
         } else {
             line_range_to_target(line_range.clone()) as u16
         };
-        dbg!(
-            &line_range,
-            available_height,
-            line_range.len(),
-            available_height <= line_range.len() as u16,
-            target_line_index
-        );
-
         for i in (0..available_height_multiplier(available_height)).rev() {
-            println!("========");
             let new_scroll_offset = target_line_index.saturating_sub(i);
-            dbg!(new_scroll_offset);
             let grid = self.get_grid_with_scroll_offset(context, false, new_scroll_offset);
             let grid_string = grid.grid.to_string();
-            println!("{}", grid_string);
             let grid_string_lines = grid_string.lines().collect_vec();
             let target_line_number =
                 format!("{}{}", target_line_index + 1, LINE_NUMBER_VERTICAL_BORDER);
-            dbg!(&target_line_number);
             let target_line_index_in_range = grid_string_lines
                 .iter()
                 .any(|line| line.contains(&target_line_number));
-            dbg!(target_line_index_in_range);
             if target_line_index_in_range {
                 self.scroll_offset = new_scroll_offset;
                 return;
@@ -3442,7 +3427,6 @@ impl Editor {
                     let linewise_range = self
                         .buffer()
                         .line_range_to_full_char_index_range(line_range.clone())?;
-                    dbg!(&linewise_range);
                     let content = self.buffer().slice(&linewise_range)?;
                     let get_remove_leading_char_count = |line: &str| {
                         let leading_indent_count =

--- a/src/components/render_editor.rs
+++ b/src/components/render_editor.rs
@@ -40,6 +40,14 @@ pub(crate) fn markup_focused_tab(path: &str) -> String {
 
 impl Editor {
     pub(crate) fn get_grid(&self, context: &Context, focused: bool) -> GetGridResult {
+        self.get_grid_with_scroll_offset(context, focused, self.scroll_offset())
+    }
+    pub(crate) fn get_grid_with_scroll_offset(
+        &self,
+        context: &Context,
+        focused: bool,
+        scroll_offset: u16,
+    ) -> GetGridResult {
         let title = self.title(context);
         let title_grid_height = title.lines().count() as u16;
         let render_area = {
@@ -53,7 +61,7 @@ impl Editor {
             None => self.get_grid_with_dimension(
                 context,
                 render_area,
-                self.scroll_offset(),
+                scroll_offset,
                 Some(self.selection_set.primary_selection().range()),
                 false,
                 true,

--- a/src/components/test_editor.rs
+++ b/src/components/test_editor.rs
@@ -2,7 +2,6 @@ use crate::app::{Dimension, LocalSearchConfigUpdate, Scope};
 use crate::buffer::BufferOwner;
 use crate::char_index_range::CharIndexRange;
 use crate::clipboard::CopiedTexts;
-use crate::components::component::Component;
 use crate::components::editor::{DispatchEditor::*, Movement::*, PriorChange};
 use crate::context::{Context, GlobalMode, LocalSearchConfigMode, Search};
 use crate::grid::IndexedHighlightGroup;
@@ -26,7 +25,6 @@ use crate::{
 use itertools::Itertools;
 use my_proc_macros::{hex, key, keys};
 
-use quickcheck::{Arbitrary, TestResult};
 use SelectionMode::*;
 
 use super::editor::IfCurrentNotFound;

--- a/src/components/test_editor.rs
+++ b/src/components/test_editor.rs
@@ -2,6 +2,7 @@ use crate::app::{Dimension, LocalSearchConfigUpdate, Scope};
 use crate::buffer::BufferOwner;
 use crate::char_index_range::CharIndexRange;
 use crate::clipboard::CopiedTexts;
+use crate::components::component::Component;
 use crate::components::editor::{DispatchEditor::*, Movement::*, PriorChange};
 use crate::context::{Context, GlobalMode, LocalSearchConfigMode, Search};
 use crate::grid::IndexedHighlightGroup;
@@ -25,6 +26,7 @@ use crate::{
 use itertools::Itertools;
 use my_proc_macros::{hex, key, keys};
 
+use quickcheck::{Arbitrary, TestResult};
 use SelectionMode::*;
 
 use super::editor::IfCurrentNotFound;
@@ -4854,36 +4856,154 @@ fn escaping_quicfix_list_mode_should_not_change_selection() -> anyhow::Result<()
 }
 
 #[test]
-fn last_line_of_selection_should_be_visible_when_aligning_bottom() -> anyhow::Result<()> {
-    execute_test(|s| {
-        Box::new([
-            App(OpenFile {
-                path: s.main_rs(),
-                owner: BufferOwner::User,
-                focus: true,
-            }),
-            Editor(SetContent(
-                "
+fn last_line_of_multiline_selection_should_be_at_bottom_when_aligning_bottom() -> anyhow::Result<()>
+{
+    fn run_test(width: u16, height: u16, expected_output: &'static str) -> anyhow::Result<()> {
+        execute_test(|s| {
+            Box::new([
+                App(OpenFile {
+                    path: s.main_rs(),
+                    owner: BufferOwner::User,
+                    focus: true,
+                }),
+                Editor(SetContent(
+                    "
 // padding 1
 // padding 2
 // padding 3
 
 fn main() {
-  hello_worldly();
+  this_is_a_long_line_for_testing_wrapping();
   foo {
     x: 2
+  } // this line should be at bottom
+}
+// padding 4
+// padding 5
+// padding 6"
+                        .to_string(),
+                )),
+                App(SetGlobalTitle("[Global Title]".to_string())),
+                App(TerminalDimensionChanged(Dimension { height, width })),
+                Editor(MatchLiteral("foo".to_string())),
+                Editor(SetSelectionMode(IfCurrentNotFound::LookForward, SyntaxNode)),
+                Editor(AlignViewBottom),
+                Expect(AppGrid(expected_output.to_string())),
+            ])
+        })
+    }
+
+    // Case 1: Nothing is wrapped
+
+    run_test(
+        300,
+        9,
+        " 🦀  main.rs [*]
+ 4│// padding 3
+ 5│
+ 6│fn main() {
+ 7│  this_is_a_long_line_for_testing_wrapping();
+ 8│  █oo {
+ 9│    x: 2
+10│  } // this line should be at bottom
+ [Global Title]",
+    )?;
+
+    // Case 2: The long line is wrapped
+    run_test(
+        30,
+        7,
+        " 🦀  main.rs [*]
+ 6│fn main() {
+ 8│  █oo {
+ 9│    x: 2
+10│  } // this line should be
+ ↪│ at bottom
+ [Global Title]",
+    )?;
+
+    Ok(())
+}
+
+#[test]
+fn middle_line_of_multiline_selection_should_be_centered_when_aligning_center() -> anyhow::Result<()>
+{
+    fn run_test(width: u16, height: u16, expected_output: &'static str) -> anyhow::Result<()> {
+        execute_test(|s| {
+            Box::new([
+                App(OpenFile {
+                    path: s.main_rs(),
+                    owner: BufferOwner::User,
+                    focus: true,
+                }),
+                Editor(SetContent(
+                    "
+// padding 1
+// padding 2
+// padding 3
+
+fn main() {
+  this_is_a_long_line_for_testing_wrapping();
+  foo {
+    x: 2 // this line should be at center
   }
-}"
-                .to_string(),
-            )),
-            App(TerminalDimensionChanged(Dimension {
-                height: 7,
-                width: 20,
-            })),
-            Editor(MatchLiteral("foo".to_string())),
-            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, SyntaxNode)),
-            Editor(AlignViewBottom),
-            Expect(AppGrid("".to_string())),
-        ])
-    })
+}
+// padding 4
+// padding 5
+// padding 6"
+                        .to_string(),
+                )),
+                App(SetGlobalTitle("[Global Title]".to_string())),
+                App(TerminalDimensionChanged(Dimension { height, width })),
+                Editor(MatchLiteral("foo".to_string())),
+                Editor(SetSelectionMode(IfCurrentNotFound::LookForward, SyntaxNode)),
+                Editor(AlignViewCenter),
+                Expect(AppGrid(expected_output.to_string())),
+            ])
+        })
+    }
+
+    // Case 1: Nothing is wrapped
+
+    run_test(
+        300,
+        9,
+        " 🦀  main.rs [*]
+ 6│fn main() {
+ 7│  this_is_a_long_line_for_testing_wrapping();
+ 8│  █oo {
+ 9│    x: 2 // this line should be at center
+10│  }
+11│}
+12│// padding 4
+ [Global Title]",
+    )?;
+
+    // Case 2: Some line is wrapped
+    run_test(
+        30,
+        7,
+        " 🦀  main.rs [*]
+ 6│fn main() {
+ 8│  █oo {
+ 9│    x: 2 // this line
+ ↪│should be at center
+10│  }
+ [Global Title]",
+    )?;
+
+    // Case 3: available height <= height of `foo` node (3 lines):
+    //     center the cursor instead of the middle line of the `foo` node
+
+    run_test(
+        300,
+        5,
+        " 🦀  main.rs [*]
+ 6│fn main() {
+ 8│  █oo {
+ 9│    x: 2 // this line should be at center
+ [Global Title]",
+    )?;
+
+    Ok(())
 }

--- a/src/generate_recipes.rs
+++ b/src/generate_recipes.rs
@@ -67,7 +67,7 @@ fn doc_assets_generate_recipes() -> anyhow::Result<()> {
                                         Editor(SetRectangle(Rectangle {
                                             origin: Position::default(),
                                             width,
-                                            height: height as u16,
+                                            height: (height as u16).saturating_sub(1), // Minus one because of app global status bar,
                                         })),
                                         // Editor(ApplySyntaxHighlight),
                                         App(HandleKeyEvent(key!("esc"))),

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -20,6 +20,7 @@ pub(crate) struct Grid {
 }
 
 const DEFAULT_TAB_SIZE: usize = 4;
+pub(crate) const LINE_NUMBER_VERTICAL_BORDER: &'static str = "│";
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub(crate) struct Cell {
@@ -161,7 +162,6 @@ impl Ord for PositionedCell {
         self.position.cmp(&other.position)
     }
 }
-#[cfg(test)]
 impl std::fmt::Display for Grid {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
@@ -552,7 +552,7 @@ impl Grid {
                                 line_index,
                                 Some(max_line_number_len),
                                 Some(max_line_number_len + 1),
-                                "│",
+                                LINE_NUMBER_VERTICAL_BORDER,
                                 &theme.ui.border,
                             ))
                             .map(|cell_update| {

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -20,7 +20,7 @@ pub(crate) struct Grid {
 }
 
 const DEFAULT_TAB_SIZE: usize = 4;
-pub(crate) const LINE_NUMBER_VERTICAL_BORDER: &'static str = "│";
+pub(crate) const LINE_NUMBER_VERTICAL_BORDER: &str = "│";
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub(crate) struct Cell {

--- a/src/recipes.rs
+++ b/src/recipes.rs
@@ -39,7 +39,7 @@ fn main() {
                     expectations: Box::new([CurrentSelectedTexts(&["foo {\n        bar: spam\n    }"])]),
                     terminal_height: Some(9),
                     similar_vim_combos: &[],
-                    only: true,
+                    only: false,
                 }
             ].to_vec(),
         },

--- a/src/recipes.rs
+++ b/src/recipes.rs
@@ -17,6 +17,33 @@ pub(crate) fn recipe_groups() -> Vec<RecipeGroup> {
         syntax_node(),
         multicursors(),
         RecipeGroup {
+            filename: "align-view",
+            recipes: [
+                Recipe {
+                    description: "Align view",
+                    content: "
+fn main() {
+// padding top 1
+// padding top 2
+// padding top 3
+	foo {
+        bar: spam
+    }
+// padding bottom 4
+// padding bottom 5
+// padding bottom 6
+}".trim(),
+                    file_extension: "rs",
+                    prepare_events: keys!("q f o o enter d"),
+                    events: keys!("alt+; alt+; alt+;"),
+                    expectations: Box::new([CurrentSelectedTexts(&["foo {\n        bar: spam\n    }"])]),
+                    terminal_height: Some(9),
+                    similar_vim_combos: &[],
+                    only: true,
+                }
+            ].to_vec(),
+        },
+        RecipeGroup {
             filename: "jump",
             recipes: [
                 Recipe {

--- a/src/test_app.rs
+++ b/src/test_app.rs
@@ -226,8 +226,8 @@ impl ExpectKind {
             AppGrid(grid) => {
                                 let expected = grid.to_string().trim_matches('\n').to_string();
                                 let actual = app.get_screen()?.stringify().trim_matches('\n').to_string();
-                                println!("Expected=\n{}", expected);
-                                println!("Actual=\n{}", actual);
+                                println!("Expected=\n{expected}");
+                                println!("Actual=\n{actual}");
                                 contextualize(actual, expected)
                             }
             CurrentPath(path) => contextualize(app.get_current_file_path().unwrap(), path.clone()),

--- a/src/test_app.rs
+++ b/src/test_app.rs
@@ -226,8 +226,8 @@ impl ExpectKind {
             AppGrid(grid) => {
                                 let expected = grid.to_string().trim_matches('\n').to_string();
                                 let actual = app.get_screen()?.stringify().trim_matches('\n').to_string();
-                                log(format!("expected =\n{expected}"));
-                                log(format!("actual   =\n{actual}"));
+                                println!("Expected=\n{}", expected);
+                                println!("Actual=\n{}", actual);
                                 contextualize(actual, expected)
                             }
             CurrentPath(path) => contextualize(app.get_current_file_path().unwrap(), path.clone()),


### PR DESCRIPTION
## Preface
Align view currently does not work well, especially when we are using the Syntax Node selection mode.

This is because syntactic selection usually spans multiple lines, and we expect align center to center the whole selection, but now it just center the cursor.

## Solution
Align top    = use selection first line
Align center = use selection middle
Align bottom = use selection last line


## Related issues
- https://github.com/ki-editor/ki-editor/issues/561