### PR TITLE
fix(editor): unable to copy special symbol in Word selection mode

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -846,7 +846,11 @@ impl Buffer {
         &self,
         range: &Range<usize>,
     ) -> anyhow::Result<CharIndexRange> {
-        Ok((self.byte_to_char(range.start)?..self.byte_to_char(range.end)?).into())
+        dbg!(&range);
+        Ok((self.byte_to_char(range.start)?
+            ..(self.byte_to_char(range.end.saturating_sub(1))? + 1)
+                .min(CharIndex(self.len_chars())))
+            .into())
     }
 
     pub(crate) fn position_range_to_char_index_range(

--- a/src/components/test_editor.rs
+++ b/src/components/test_editor.rs
@@ -5085,3 +5085,26 @@ zzz
     )?;
     Ok(())
 }
+
+#[test]
+fn copy_paste_special_character_in_word_selection_mode() -> anyhow::Result<()> {
+    execute_test(|s| {
+        Box::new([
+            App(OpenFile {
+                path: s.main_rs(),
+                owner: BufferOwner::User,
+                focus: true,
+            }),
+            Editor(SetContent("│".to_string())),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Word)),
+            Expect(CurrentSelectedTexts(&["│"])),
+            Editor(Copy {
+                use_system_clipboard: false,
+            }),
+            Editor(Paste {
+                use_system_clipboard: false,
+            }),
+            Expect(CurrentComponentContent("││")),
+        ])
+    })
+}


### PR DESCRIPTION
Root cause:

`Buffer::byte_range_to_char_index_range` was incorrect. We shouldn't use `range.end`, we should use `range.end.saturating_sub(1)` instead, because `range.end` is exclusive, which means it will be potentially out of bound.