### PR TITLE
feat(editor): recalculate scroll offset should align selection to the center

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -809,7 +809,8 @@ impl Buffer {
 
     pub(crate) fn line_to_byte_range(&self, line: usize) -> anyhow::Result<ByteRange> {
         let start = self.line_to_byte(line)?;
-        let end = self.line_to_byte(line + 1)?.saturating_sub(1);
+        let end = self.line_to_byte(line + 1)?.saturating_sub(1).max(start);
+        assert!(start <= end);
         Ok(ByteRange::new(start..end))
     }
 
@@ -1073,6 +1074,7 @@ impl Buffer {
         &self,
         visible_line_range: &Range<usize>,
     ) -> anyhow::Result<Range<usize>> {
+        assert!(visible_line_range.start <= visible_line_range.end);
         let start = self
             .line_to_byte_range(visible_line_range.start)?
             .range()

--- a/src/components/test_editor.rs
+++ b/src/components/test_editor.rs
@@ -4060,14 +4060,12 @@ fn foo() {
             )),
             Editor(MatchLiteral("yyy".to_string())),
             Expect(EditorGrid(
-                "
-🦀  main.rs [*]
+                "🦀  main.rs [*]
 1│fn foo() {
 2│  fn bar() {
-4│        xxx();
 5│        █yy();
-"
-                .trim(),
+6│    }"
+                    .trim(),
             )),
         ])
     })
@@ -4755,7 +4753,7 @@ fn primary_selection_anchor_overlap_with_hidden_parent_line() -> anyhow::Result<
                 focus: true,
             }),
             App(TerminalDimensionChanged(crate::app::Dimension {
-                height: 5,
+                height: 6,
                 // Set width longer than content so that there's no wrapping
                 width: 20,
             })),
@@ -4778,7 +4776,8 @@ fn main() {
                 " 🦀  main.rs [*]
 2│fn main() {
 5│  t();
-6│█"
+6│█
+7│"
                 .to_string(),
             )),
             Expect(GridCellsStyleKey(
@@ -5088,6 +5087,29 @@ zzz
 
 #[test]
 fn copy_paste_special_character_in_word_selection_mode() -> anyhow::Result<()> {
+    execute_test(|s| {
+        Box::new([
+            App(OpenFile {
+                path: s.main_rs(),
+                owner: BufferOwner::User,
+                focus: true,
+            }),
+            Editor(SetContent("│".to_string())),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Word)),
+            Expect(CurrentSelectedTexts(&["│"])),
+            Editor(Copy {
+                use_system_clipboard: false,
+            }),
+            Editor(Paste {
+                use_system_clipboard: false,
+            }),
+            Expect(CurrentComponentContent("││")),
+        ])
+    })
+}
+
+#[test]
+fn recalculate_scroll_offset_consider_last_line_of_multiline_selection() -> anyhow::Result<()> {
     execute_test(|s| {
         Box::new([
             App(OpenFile {

--- a/src/components/test_editor_reveal.rs
+++ b/src/components/test_editor_reveal.rs
@@ -80,13 +80,10 @@ zeta
             Editor(ToggleMark),
             Editor(MatchLiteral("zeta".to_string())),
             Expect(EditorGrid(
-                "
-🦀  main.rs [*]
-3│phi
+                "🦀  main.rs [*]
 4│mark-y
 5│█eta
-"
-                .trim(),
+",
             )),
             Editor(ToggleReveal(Reveal::Mark)),
             Expect(EditorGrid(


### PR DESCRIPTION
Previously it was aligning *cursor* to the center instead, when recalculating the scroll offset.

This change will make navigating top-level sibiling nodes much more natural, as each node selection will be centered automatically.