### PR TITLE
keymap: remap Mark to left side of keyboard

### DIFF
--- a/src/components/editor_keymap.rs
+++ b/src/components/editor_keymap.rs
@@ -15,25 +15,25 @@ pub(crate) const KEYMAP_SCORE: [[char; 10]; 3] = [
 
 pub(crate) const KEYMAP_NORMAL: [[Meaning; 10]; 3] = [
     [
-        SrchL, SWord, SrchC, MultC, Swap_, /****/ Mark_, Prev_, Up___, Next_, Paste,
+        SrchL, SWord, SrchC, MultC, Swap_, /****/ Open_, Prev_, Up___, Next_, Paste,
     ],
     [
         Line_, Word_, Sytx_, Chng_, Extnd, /****/ InstP, Left_, Down_, Right, InstN,
     ],
     [
-        Undo_, Rplc_, Copy_, Delte, Open_, /****/ LSrch, Jump_, First, Last_, XAchr,
+        Undo_, Rplc_, Copy_, Delte, Mark_, /****/ LSrch, Jump_, First, Last_, XAchr,
     ],
 ];
 
 pub(crate) const KEYMAP_NORMAL_SHIFTED: [[Meaning; 10]; 3] = [
     [
-        _____, Char_, _____, _____, Raise, /****/ MarkF, RplcP, Join_, RplcN, Pst0G,
+        _____, Char_, _____, _____, Raise, /****/ _____, RplcP, Join_, RplcN, Pst0G,
     ],
     [
         LineF, _____, FStyx, ChngX, Trsfm, /****/ CrsrP, DeDnt, Break, Indnt, CrsrN,
     ],
     [
-        Redo_, PRplc, RplcX, _____, _____, /****/ GSrch, ToIdx, _____, _____, SSEnd,
+        Redo_, PRplc, RplcX, _____, MarkF, /****/ GSrch, ToIdx, _____, _____, SSEnd,
     ],
     // Why is Raise placed at the same Position as Swap?
     // Because Raise is a special-case of Swap where the movement is Up
@@ -57,13 +57,13 @@ pub(crate) const KEYMAP_META: [[Meaning; 10]; 3] = [
 /// are both located on the right-side.
 pub(crate) const KEYMAP_FIND_LOCAL: [[Meaning; 10]; 3] = [
     [
-        OneCh, CSrch, NtrlN, RSrch, Qkfix, /****/ Mark_, _____, _____, _____, _____,
+        OneCh, CSrch, NtrlN, RSrch, Qkfix, /****/ _____, _____, _____, _____, _____,
     ],
     [
         DgAll, DgErr, DgWrn, DgHnt, GHnkC, /****/ _____, _____, _____, _____, _____,
     ],
     [
-        LImpl, LDefn, LType, LRfrE, _____, /****/ LRept, _____, _____, _____, _____,
+        LImpl, LDefn, LType, LRfrE, Mark_, /****/ LRept, _____, _____, _____, _____,
     ],
 ];
 pub(crate) const KEYMAP_FIND_LOCAL_SHIFTED: [[Meaning; 10]; 3] = [

--- a/src/components/test_editor.rs
+++ b/src/components/test_editor.rs
@@ -2233,7 +2233,7 @@ fn surround() -> anyhow::Result<()> {
             }),
             Editor(SetContent("fn main() { x.y() }".to_string())),
             Editor(MatchLiteral("x.y()".to_string())),
-            App(HandleKeyEvents(keys!("g b j").to_vec())),
+            App(HandleKeyEvents(keys!("g y j").to_vec())),
             Expect(CurrentComponentContent("fn main() { (x.y()) }")),
             Expect(SelectionExtensionEnabled(false)),
         ])
@@ -4082,7 +4082,7 @@ fn surround_extended_selection() -> anyhow::Result<()> {
             Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Word)),
             Editor(EnableSelectionExtension),
             Editor(MoveSelection(Right)),
-            App(HandleKeyEvents(keys!("g b j").to_vec())),
+            App(HandleKeyEvents(keys!("g y j").to_vec())),
             Expect(CurrentComponentContent("(foo bar)")),
         ])
     })

--- a/src/recipes.rs
+++ b/src/recipes.rs
@@ -311,7 +311,7 @@ Why?
                     content: "hello world".trim(),
                     file_extension: "md",
                     prepare_events: &[],
-                    events: keys!("a g b j"),
+                    events: keys!("a g y j"),
                     expectations: Box::new([CurrentComponentContent("(hello world)")]),
                     terminal_height: None,
                     similar_vim_combos: &[],
@@ -322,7 +322,7 @@ Why?
                     content: "hello world".trim(),
                     file_extension: "md",
                     prepare_events: &[],
-                    events: keys!("s g b p x y enter"),
+                    events: keys!("s g y p x y enter"),
                     expectations: Box::new([
                         CurrentComponentContent("<xy>hello</xy> world"),
                         CurrentSelectedTexts(&["<xy>hello</xy>"]),
@@ -619,7 +619,7 @@ impl<C> Iterator for PostorderTraverse<C>
                     content: "def foo(bar: Bar, spam: Spam): pass",
                     file_extension: "py",
                     prepare_events: keys!("q s p a m enter"),
-                    events: keys!("d b x esc / b y"),
+                    events: keys!("d y x esc / y y"),
                     expectations: Box::new([CurrentComponentContent("def foo(bar: Bar, spam: Spam, y, x): pass")]),
                     terminal_height: None,
                     similar_vim_combos: &[],
@@ -636,7 +636,7 @@ function foo() {
 ".trim(),
                     file_extension: "js",
                     prepare_events: keys!("q l e t space y enter"),
-                    events: keys!("d b l e t space z"),
+                    events: keys!("d y l e t space z"),
                     expectations: Box::new([CurrentComponentContent("function foo() {
   let x = hello();
   let y = hey()
@@ -655,7 +655,7 @@ fn foo() {
 }".trim(),
                     file_extension: "md",
                     prepare_events: &[],
-                    events: keys!("w b x esc / b y"),
+                    events: keys!("w y x esc / y y"),
                     expectations: Box::new([CurrentComponentContent("fn foo() {
     y
     x
@@ -901,7 +901,7 @@ fn main(foo: str) {
                     .trim(),
                     file_extension: "md",
                     prepare_events: &[],
-                    events: keys!("s y l l y a r n y"),
+                    events: keys!("s b l l b a r n b"),
                     expectations: Box::new([
                         CurrentSelectedTexts(&["foo", "spam"]),
                     ]),
@@ -1375,7 +1375,7 @@ foo bar spam
             .trim(),
             file_extension: "md",
             prepare_events: &[],
-            events: keys!("space d m enter Y space d f enter Y space d g enter Y alt+l alt+l alt+j alt+j Y"),
+            events: keys!("space d m enter B space d f enter B space d g enter B alt+l alt+l alt+j alt+j B"),
             expectations: Box::new([CurrentComponentTitle("\u{200b} # 🦀 foo.rs \u{200b} # 🦀 main.rs ".to_string())]),
             terminal_height: Some(10),
             similar_vim_combos: &[],
@@ -1584,7 +1584,7 @@ pub(crate) fn from_text(language: Option<tree_sitter::Language>, text: &str) -> 
                     file_extension: "rs",
                     prepare_events: &[],
                     events: keys!(
-                        "q y x enter d r r k l g b j h S o m e esc d k l k T r f"
+                        "q y x enter d r r k l g y j h S o m e esc d k l k T r f"
                     ),
                     expectations: Box::new([]),
                     terminal_height: None,
@@ -1872,7 +1872,7 @@ fn reveal_marks() -> RecipeGroup {
                 .trim(),
             file_extension: "md",
             prepare_events: &[],
-            events: keys!("q f o o enter l y space o l j j"),
+            events: keys!("q f o o enter l b space o l j j"),
             expectations: Box::new([CurrentSelectedTexts(&["foo"])]),
             terminal_height: Some(9),
             similar_vim_combos: &[],


### PR DESCRIPTION
## Reasons

1. Executing Find Mark (`n y`) is hard to press.
2. Mark (currently `y`) used to be on the left side of the keyboard.
3. This makes the Find (Local or Global) menu more consistent, as every item will solely be on the left side of the keyboard.