### PR TITLE
fix(editor): `AlignViewTop` not working if selection height exceeds viewport height

### DIFF
--- a/src/components/editor.rs
+++ b/src/components/editor.rs
@@ -111,8 +111,13 @@ impl Component for Editor {
     }
 
     fn set_rectangle(&mut self, rectangle: Rectangle, context: &Context) {
-        self.rectangle = rectangle;
-        self.recalculate_scroll_offset(context);
+        // Only update and recalculate scroll offset
+        // if the new rectangle is different from the current rectangle
+
+        if self.rectangle != rectangle {
+            self.rectangle = rectangle;
+            self.recalculate_scroll_offset(context);
+        }
     }
 
     fn rectangle(&self) -> &Rectangle {


### PR DESCRIPTION
### Problem
The `AlignViewTop` command fails to work correctly when the selection height is larger than the viewport height. Instead of aligning the selection to the top of the viewport as expected, the editor automatically centers the cursor.

### Root Cause
During each render cycle, this function call chain executes:
```
App::get_screen
├── Layout::recalculate_layout
    ├── Component::set_rectangle
        ├── Editor::set_rectangle
            └── Editor::recalculate_scroll_offset
```

The issue occurs in `Editor::recalculate_scroll_offset`, which unconditionally attempts to center the cursor whenever the selection height exceeds the viewport height. This centering behavior overrides the intended `AlignViewTop` positioning.

### Solution
Add a guard condition in `Editor::set_rectangle` to skip calling `Editor::recalculate_scroll_offset` when the incoming `Rectangle` is identical to the current `Rectangle`. This prevents unnecessary recalculation that interferes with explicit alignment commands.
