### PR TITLE
feat(editor): revert git hunk

### DIFF
--- a/docs/docs/normal-mode/space-menu.md
+++ b/docs/docs/normal-mode/space-menu.md
@@ -24,15 +24,29 @@ The space menu can be brought up by pressing `space`.
 
 <KeymapFallback filename="Space"/>
 
-## LSP Actions (only applicable in the main editor):
+## Context Actions (only applicable in the main editor):
 
-<KeymapFallback filename="Space LSP"/>
+<KeymapFallback filename="Space Context"/>
 
-| Label          | Action                |
-| -------------- | --------------------- |
-| `Code Actions` | Request code actions  |
-| `Hover`        | Request hover info    |
-| `Rename`       | Rename current symbol |
+### `Code Actions`
+
+Request code actions.
+
+### `Hover`
+
+Request hover info.
+
+### `Rename`
+
+Rename current symbol.
+
+### `Revert Hunk @`
+
+Revert hunk(s) intersecting with selection(s) to latest commit of current branch.
+
+### `Revert Hunk ^`
+
+Revert hunk(s) intersecting with selection(s) to latest commit of main/master branch.
 
 ## `Pick`
 
@@ -89,7 +103,7 @@ Git status (against current branch) [^1]
 
 ### `Git status ^`
 
-Git status (against main branch) [^2]
+Git status (against main/master branch) [^2]
 [^1]: See more at [Git hunk](./selection-modes/secondary/index.md#hunkhunk)
 [^2]: This is very useful when you want to get the modified/added files commited into the current branch that you are working on.
 

--- a/src/components/editor_keymap.rs
+++ b/src/components/editor_keymap.rs
@@ -139,12 +139,24 @@ pub(crate) const KEYMAP_SPACE_EDITOR: KeyboardMeaningLayout = [
     ],
 ];
 
-pub(crate) const KEYMAP_SPACE_LSP: KeyboardMeaningLayout = [
+pub(crate) const KEYMAP_SPACE_CONTEXT: KeyboardMeaningLayout = [
     [
         _____, _____, _____, _____, _____, /****/ _____, _____, _____, _____, _____,
     ],
     [
-        _____, LHovr, LCdAc, LRnme, _____, /****/ _____, _____, _____, _____, _____,
+        _____, LHovr, LCdAc, LRnme, RvHkC, /****/ _____, _____, _____, _____, _____,
+    ],
+    [
+        _____, _____, _____, _____, _____, /****/ _____, _____, _____, _____, _____,
+    ],
+];
+
+pub(crate) const KEYMAP_SPACE_CONTEXT_SHIFTED: KeyboardMeaningLayout = [
+    [
+        _____, _____, _____, _____, _____, /****/ _____, _____, _____, _____, _____,
+    ],
+    [
+        _____, _____, _____, _____, RvHkM, /****/ _____, _____, _____, _____, _____,
     ],
     [
         _____, _____, _____, _____, _____, /****/ _____, _____, _____, _____, _____,
@@ -246,7 +258,7 @@ struct KeySet {
     find_global: HashMap<Meaning, &'static str>,
     surround: HashMap<Meaning, &'static str>,
     space: HashMap<Meaning, &'static str>,
-    space_lsp: HashMap<Meaning, &'static str>,
+    space_context: HashMap<Meaning, &'static str>,
     space_picker: HashMap<Meaning, &'static str>,
     space_editor: HashMap<Meaning, &'static str>,
     transform: HashMap<Meaning, &'static str>,
@@ -334,11 +346,17 @@ impl KeySet {
                     .flatten()
                     .zip(layout.into_iter().flatten()),
             ),
-            space_lsp: HashMap::from_iter(
-                KEYMAP_SPACE_LSP
+            space_context: HashMap::from_iter(
+                KEYMAP_SPACE_CONTEXT
                     .into_iter()
                     .flatten()
-                    .zip(layout.into_iter().flatten()),
+                    .zip(layout.into_iter().flatten())
+                    .chain(
+                        KEYMAP_SPACE_CONTEXT_SHIFTED
+                            .into_iter()
+                            .flatten()
+                            .zip(layout.into_iter().flatten().map(shifted)),
+                    ),
             ),
             space_picker: HashMap::from_iter(
                 KEYMAP_SPACE_PICKER
@@ -446,10 +464,10 @@ impl KeyboardLayoutKind {
             .unwrap_or_else(|| panic!("Unable to find key binding of {meaning:#?}"))
     }
 
-    pub(crate) fn get_space_lsp_keymap(&self, meaning: &Meaning) -> &'static str {
+    pub(crate) fn get_space_context_keymap(&self, meaning: &Meaning) -> &'static str {
         let keyset = self.get_keyset();
         keyset
-            .space_lsp
+            .space_context
             .get(meaning)
             .cloned()
             .unwrap_or_else(|| panic!("Unable to find key binding of {meaning:#?}"))
@@ -792,6 +810,10 @@ pub(crate) enum Meaning {
     SpPck,
     /// Space LSP
     SpLsp,
+    /// Revert hunk (to main branch)
+    RvHkM,
+    /// Revert hunk (to current branch)
+    RvHkC,
 }
 pub(crate) fn shifted(c: &'static str) -> &'static str {
     match c {

--- a/src/components/editor_keymap_legend.rs
+++ b/src/components/editor_keymap_legend.rs
@@ -1025,7 +1025,10 @@ impl Editor {
         }
     }
 
-    pub(crate) fn space_lsp_keymap_legend_config(&self, context: &Context) -> KeymapLegendConfig {
+    pub(crate) fn space_context_keymap_legend_config(
+        &self,
+        context: &Context,
+    ) -> KeymapLegendConfig {
         KeymapLegendConfig {
             title: "LSP".to_string(),
 
@@ -1033,7 +1036,7 @@ impl Editor {
                 Keymap::new(
                     context
                         .keyboard_layout_kind()
-                        .get_space_lsp_keymap(&Meaning::LCdAc),
+                        .get_space_context_keymap(&Meaning::LCdAc),
                     "Code Actions".to_string(),
                     {
                         let cursor_char_index = self.get_cursor_char_index();
@@ -1056,16 +1059,40 @@ impl Editor {
                 Keymap::new(
                     context
                         .keyboard_layout_kind()
-                        .get_space_lsp_keymap(&Meaning::LHovr),
+                        .get_space_context_keymap(&Meaning::LHovr),
                     "Hover".to_string(),
                     Dispatch::RequestHover,
                 ),
                 Keymap::new(
                     context
                         .keyboard_layout_kind()
-                        .get_space_lsp_keymap(&Meaning::LRnme),
+                        .get_space_context_keymap(&Meaning::LRnme),
                     "Rename".to_string(),
                     Dispatch::PrepareRename,
+                ),
+                Keymap::new(
+                    context
+                        .keyboard_layout_kind()
+                        .get_space_context_keymap(&Meaning::RvHkC),
+                    format!(
+                        "Revert Hunk{}",
+                        DiffMode::UnstagedAgainstCurrentBranch.display()
+                    ),
+                    Dispatch::ToEditor(DispatchEditor::RevertHunk(
+                        DiffMode::UnstagedAgainstCurrentBranch,
+                    )),
+                ),
+                Keymap::new(
+                    context
+                        .keyboard_layout_kind()
+                        .get_space_context_keymap(&Meaning::RvHkM),
+                    format!(
+                        "Revert Hunk{}",
+                        DiffMode::UnstagedAgainstMainBranch.display()
+                    ),
+                    Dispatch::ToEditor(DispatchEditor::RevertHunk(
+                        DiffMode::UnstagedAgainstMainBranch,
+                    )),
                 ),
             ]),
         }
@@ -1173,7 +1200,9 @@ impl Editor {
                             .keyboard_layout_kind()
                             .get_space_keymap(&Meaning::SpLsp),
                         "LSP".to_string(),
-                        Dispatch::ShowKeymapLegend(self.space_lsp_keymap_legend_config(context)),
+                        Dispatch::ShowKeymapLegend(
+                            self.space_context_keymap_legend_config(context),
+                        ),
                     ),
                     Keymap::new(
                         context

--- a/src/components/editor_keymap_printer.rs
+++ b/src/components/editor_keymap_printer.rs
@@ -313,8 +313,10 @@ impl KeymapPrintSections {
                 layout,
             ),
             KeymapPrintSection::from_keymaps(
-                "Space LSP".to_string(),
-                &editor.space_lsp_keymap_legend_config(&context).keymaps(),
+                "Space Context".to_string(),
+                &editor
+                    .space_context_keymap_legend_config(&context)
+                    .keymaps(),
                 layout,
             ),
             KeymapPrintSection::from_keymaps(

--- a/src/git/hunk.rs
+++ b/src/git/hunk.rs
@@ -28,6 +28,7 @@ pub(crate) struct Hunk {
 pub(crate) struct SimpleHunk {
     /// 0-based index
     pub(crate) new_line_range: Range<usize>,
+    pub(crate) old_content: String,
 
     pub(crate) kind: SimpleHunkKind,
 }
@@ -48,6 +49,13 @@ impl Hunk {
         let diff = imara_diff::Diff::compute(imara_diff::Algorithm::Histogram, &input);
         diff.hunks()
             .map(|hunk| SimpleHunk {
+                old_content: format!(
+                    "{}\n",
+                    old.lines()
+                        .skip(hunk.before.start as usize)
+                        .take((hunk.before.end - hunk.before.start) as usize)
+                        .join("\n")
+                ),
                 new_line_range: hunk.after.start as usize
                     ..hunk.after.end.max(hunk.after.start + 1) as usize,
                 kind: if hunk.is_pure_insertion() {


### PR DESCRIPTION
This commit also rename LSP to Context in Space Menu.

Context means Context Menu, which is related to the position of the selections, similar to right-click in GUI.