### PR TITLE
feat(theme): add Alabaster theme

### DIFF
--- a/src/themes/from_zed_theme.rs
+++ b/src/themes/from_zed_theme.rs
@@ -12,6 +12,8 @@ use zed_theme::*;
 
 const ZED_THEME_AYU_URL: &str =
     "https://raw.githubusercontent.com/zed-industries/zed/main/assets/themes/ayu/ayu.json";
+const ZED_THEME_ALABASTER_URL: &str =
+    "https://raw.githubusercontent.com/tsimoshka/zed-theme-alabaster/refs/heads/main/themes/alabaster-color-theme.json";
 const ZED_THEME_CATPPUCCIN_URL: &str =
     "https://raw.githubusercontent.com/catppuccin/zed/main/themes/catppuccin-mauve.json";
 const ZED_THEME_DRACULA_URL: &str =
@@ -48,6 +50,11 @@ pub(crate) fn theme_descriptors() -> Vec<ThemeDescriptor> {
         ("Ayu Dark", ZED_THEME_AYU_URL),
         ("Ayu Light", ZED_THEME_AYU_URL),
         ("Ayu Mirage", ZED_THEME_AYU_URL),
+        ("Alabaster", ZED_THEME_ALABASTER_URL),
+        ("Alabaster Dark", ZED_THEME_ALABASTER_URL),
+        ("Alabaster Mono", ZED_THEME_ALABASTER_URL),
+        ("Alabaster Dark Mono", ZED_THEME_ALABASTER_URL),
+        ("Alabaster BG", ZED_THEME_ALABASTER_URL),
         ("Catppuccin Frappé", ZED_THEME_CATPPUCCIN_URL),
         ("Catppuccin Latte", ZED_THEME_CATPPUCCIN_URL),
         ("Catppuccin Macchiato", ZED_THEME_CATPPUCCIN_URL),


### PR DESCRIPTION
Resolves #887 

Theme Preview:

1. Alabaster

This is called the light theme in json

<img width="841" height="947" alt="image" src="https://github.com/user-attachments/assets/009d5f6d-4673-4926-87d9-01f2785a871e" />

2. Alabaster Dark

<img width="895" height="924" alt="image" src="https://github.com/user-attachments/assets/9dcfc0cc-7142-48a4-992b-31d077841a8d" />


3. Alabaster Mono

<img width="894" height="946" alt="image" src="https://github.com/user-attachments/assets/d1e3b796-0006-4209-988f-51ae1a46eef2" />


4. Alabaster Dark Mono

<img width="895" height="927" alt="image" src="https://github.com/user-attachments/assets/76c84fe1-fee7-49ce-b699-d1673aa01ff7" />

5. Alabaster BG

The highlights are ki marks.

<img width="844" height="848" alt="image" src="https://github.com/user-attachments/assets/7568afc4-b676-40c9-a016-8eab7a33e58d" />

Didn't notice what mentioned in the blog about something like this:

<img width="517" height="100" alt="image" src="https://github.com/user-attachments/assets/385730fa-d634-4ba0-8ec4-51dee1aab206" />
