### PR TITLE
feat(render/quickfix_list): highlight matching range

### DIFF
--- a/src/components/dropdown.rs
+++ b/src/components/dropdown.rs
@@ -1,9 +1,8 @@
 use std::{cmp::Reverse, ops::Range};
 
 use crate::{
-    app::Dispatches, buffer::BufferOwner, char_index_range::CharIndexRange,
-    components::editor::Movement, grid::StyleKey, position::Position,
-    selection_range::SelectionRange,
+    app::Dispatches, buffer::BufferOwner, components::editor::Movement, grid::StyleKey,
+    position::Position, selection_range::SelectionRange,
 };
 
 use itertools::Itertools;
@@ -496,10 +495,12 @@ impl Dropdown {
             content: String,
             highlight_column_range: Option<Range<usize>>,
         }
+        let filtered_item_groups_length = self.filtered_item_groups.len();
         let lines = self
             .filtered_item_groups
             .iter()
-            .flat_map(|group| {
+            .enumerate()
+            .flat_map(|(group_index, group)| {
                 if let Some(group_key) = group.group_key.as_ref() {
                     let items = group.items.iter().map(|item| {
                         let content = item.item.display();
@@ -520,6 +521,17 @@ impl Dropdown {
                     })
                     .into_iter()
                     .chain(items)
+                    // Add a newline to separate groups
+                    .chain(
+                        if group_index < filtered_item_groups_length.saturating_sub(1) {
+                            Some(Line {
+                                content: "".to_string(),
+                                highlight_column_range: None,
+                            })
+                        } else {
+                            None
+                        },
+                    )
                     .collect_vec()
                 } else {
                     group

--- a/src/components/render_editor.rs
+++ b/src/components/render_editor.rs
@@ -888,7 +888,6 @@ impl Editor {
             .into_iter()
             .chain(visible_parent_lines)
             .chain(filtered_highlighted_spans)
-            .chain(extra_decorations)
             .chain(possible_selections)
             .chain(primary_selection_highlight_span)
             .chain(secondary_selections_highlight_spans)
@@ -901,6 +900,7 @@ impl Editor {
             .chain(secondary_selection_cursors)
             .chain(custom_regex_highlights)
             .chain(regex_highlight_rules)
+            .chain(extra_decorations)
             .chain(incremental_search_matches)
             .collect_vec()
     }

--- a/src/quickfix_list.rs
+++ b/src/quickfix_list.rs
@@ -62,7 +62,7 @@ impl QuickfixListItem {
                         .trim_matches(|c: char| c.is_whitespace())
                         .to_string()
                 });
-            format!("{}{}", prefix, content)
+            format!("{prefix}{content}")
         })
         .set_info(self.info.clone())
         .set_group({

--- a/src/test_app.rs
+++ b/src/test_app.rs
@@ -2063,6 +2063,49 @@ src/main.rs
 }
 
 #[test]
+fn quickfix_list_item_matching_range_should_be_highlighted_as_search() -> anyhow::Result<()> {
+    execute_test(|s| {
+        Box::new([
+            App(SetQuickfixList(
+                crate::quickfix_list::QuickfixListType::Items(
+                    [QuickfixListItem::new(
+                        Location {
+                            path: s.main_rs(),
+                            range: (CharIndex(4)..CharIndex(7)).into(),
+                        },
+                        None,
+                        None,
+                    )]
+                    .to_vec(),
+                ),
+            )),
+            App(OtherWindow),
+            Expect(CurrentComponentContent(
+                "
+src/main.rs
+    1:5  mod foo;
+"
+                .trim(),
+            )),
+            App(TerminalDimensionChanged(Dimension {
+                height: 20,
+                width: 50,
+            })),
+            // Expect "foo" is highlighted as search
+            Expect(RangeStyleKey(
+                "foo",
+                Some(StyleKey::UiIncrementalSearchMatch),
+            )),
+            // Expect that line excluding "foo" is highlighted as primary selection
+            Expect(RangeStyleKey(
+                "1:5  mod ",
+                Some(StyleKey::UiPrimarySelectionAnchors),
+            )),
+        ])
+    })
+}
+
+#[test]
 fn diagnostic_info() -> Result<(), anyhow::Error> {
     execute_test(|s| {
         Box::new([


### PR DESCRIPTION
## Before

<img width="1406" height="1020" alt="image" src="https://github.com/user-attachments/assets/4f337823-7675-4436-ba5a-a5460bbcf9ae" />


## After

<img width="1406" height="1020" alt="image" src="https://github.com/user-attachments/assets/7cbcad89-c7d9-439a-b0fa-58f56ed6f7b2" />
