### PR TITLE
fix(quickfix_list): incorrect match highlight of LSP references

### DIFF
--- a/justfile
+++ b/justfile
@@ -142,6 +142,6 @@ vscode-build-binaries:
     ls -la ki-vscode/dist/bin/
     echo "Done!"
 
-profile:
+profile args="":
     cargo build --release
-    samply record ./target/release/ki
+    samply record ./target/release/ki {{args}}

--- a/src/app.rs
+++ b/src/app.rs
@@ -2190,7 +2190,7 @@ impl<T: Frontend> App<T> {
         self.current_component()
             .borrow_mut()
             .editor_mut()
-            .set_incremental_search_config(Default::default());
+            .initialize_incremental_search_matches();
 
         let key = prompt_config.prompt_history_key;
         let history = self.context.get_prompt_history(key);

--- a/src/components/editor.rs
+++ b/src/components/editor.rs
@@ -4123,9 +4123,16 @@ impl Editor {
 
     pub(crate) fn set_incremental_search_config(&mut self, config: LocalSearchConfig) {
         let content = self.content();
+        let search = config.search();
+        if search.is_empty() {
+            // Don't set incremental search matches if the search string is empty
+            // otherwise it will cause performance issue with rendering
+            // as empty string matches every character of the file.
+            return;
+        }
         let matches = match config.mode {
             LocalSearchConfigMode::Regex(regex_config) => regex_config
-                .to_regex(&config.search())
+                .to_regex(&search)
                 .map(|regex| {
                     regex
                         .find_iter(&content)
@@ -4133,13 +4140,11 @@ impl Editor {
                         .collect_vec()
                 })
                 .unwrap_or_default(),
-            LocalSearchConfigMode::AstGrep => {
-                ast_grep::AstGrep::new(&self.buffer(), &config.search())
-                    .map(|result| result.find_all().map(|m| m.range()).collect_vec())
-                    .unwrap_or_default()
-            }
+            LocalSearchConfigMode::AstGrep => ast_grep::AstGrep::new(&self.buffer(), &search)
+                .map(|result| result.find_all().map(|m| m.range()).collect_vec())
+                .unwrap_or_default(),
             LocalSearchConfigMode::NamingConventionAgnostic => {
-                NamingConventionAgnostic::new(config.search())
+                NamingConventionAgnostic::new(search)
                     .find_all(&content)
                     .into_iter()
                     .map(|(range, _)| range.range().clone())
@@ -4147,6 +4152,10 @@ impl Editor {
             }
         };
         self.incremental_search_matches = Some(matches)
+    }
+
+    pub(crate) fn initialize_incremental_search_matches(&mut self) {
+        self.incremental_search_matches = Some(Vec::new())
     }
 }
 


### PR DESCRIPTION
## Before

<img width="2812" height="1980" alt="image" src="https://github.com/user-attachments/assets/29ca8886-891d-492c-afb6-136377baba0e" />


## After

<img width="1406" height="990" alt="image" src="https://github.com/user-attachments/assets/e9febc5c-7ac3-4809-be00-eb2c87b3687e" />
