### PR TITLE
docs(help): completely move to space forwardslash

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -476,8 +476,10 @@ impl<T: Frontend> App<T> {
                         StatusLineComponent::LastDispatch => self.last_action_description.clone(),
                         StatusLineComponent::LastSearchString => last_search_string.clone(),
                         StatusLineComponent::Help => {
-                            let key = self.keyboard_layout_kind().get_insert_key(&Meaning::SHelp);
-                            Some(format!("Help({key})"))
+                            let key = self
+                                .keyboard_layout_kind()
+                                .get_space_keymap(&Meaning::SHelp);
+                            Some(format!("Help(Space+{key})"))
                         }
                         StatusLineComponent::KeyboardLayout => {
                             Some(self.keyboard_layout_kind().display().to_string())

--- a/src/components/editor_keymap.rs
+++ b/src/components/editor_keymap.rs
@@ -49,7 +49,7 @@ pub(crate) const KEYMAP_META: [[Meaning; 10]; 3] = [
         _____, LineP, LineD, LineN, OpenM, /****/ DWrdP, MrkFP, ScrlD, MrkFN, SView,
     ],
     [
-        Undo_, _____, _____, WClse, MarkF, /****/ _____, SHelp, _____, _____, WSwth,
+        Undo_, _____, _____, WClse, MarkF, /****/ _____, _____, _____, _____, WSwth,
     ],
 ];
 

--- a/src/components/editor_keymap_legend.rs
+++ b/src/components/editor_keymap_legend.rs
@@ -583,14 +583,6 @@ impl Editor {
                 "Switch window".to_string(),
                 Dispatch::OtherWindow,
             ),
-            Keymap::new_extended(
-                context
-                    .keyboard_layout_kind()
-                    .get_insert_key(&Meaning::SHelp),
-                "Help".to_string(),
-                "Help".to_string(),
-                Dispatch::ToEditor(DispatchEditor::ShowHelp),
-            ),
             #[cfg(unix)]
             Keymap::new("ctrl+z", "Suspend".to_string(), Dispatch::Suspend),
         ]


### PR DESCRIPTION
Under universal key binds, alt+m did not have any doc to remove.