### PR TITLE
fix(editor): possible matches highlight not showing ocassionally

### DIFF
--- a/src/components/editor.rs
+++ b/src/components/editor.rs
@@ -1700,6 +1700,7 @@ impl Editor {
         context: &Context,
         prior_change: Option<PriorChange>,
     ) -> anyhow::Result<Dispatches> {
+        self.clear_incremental_search_matches();
         self.handle_prior_change(prior_change);
         if self.mode == Mode::MultiCursor {
             let selection_set = self.selection_set.clone().set_mode(selection_mode.clone());


### PR DESCRIPTION
This is because the incremental search matches of the Editor are not cleared whenever the prompt is not closed normally.

So a simple solution to this, is to manually clear them whenever the selection mode changes.