### PR TITLE
keymap(editor): consistency semantic quit should use Delte

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -847,7 +847,6 @@ impl<T: Frontend> App<T> {
                 self.open_move_to_index_prompt(prior_change)?
             }
             Dispatch::QuitAll => self.quit_all()?,
-            Dispatch::SaveQuitAll => self.save_quit_all()?,
             Dispatch::RevealInExplorer(path) => self.reveal_path_in_explorer(&path)?,
             Dispatch::OpenMoveFilePrompt => self.open_move_file_prompt()?,
             Dispatch::OpenDuplicateFilePrompt => self.open_copy_file_prompt()?,
@@ -1759,12 +1758,6 @@ impl<T: Frontend> App<T> {
 
     pub(crate) fn sender(&self) -> Sender<AppMessage> {
         self.sender.clone()
-    }
-
-    fn save_quit_all(&mut self) -> anyhow::Result<()> {
-        self.save_all()?;
-        self.quit_all()?;
-        Ok(())
     }
 
     fn save_all(&self) -> anyhow::Result<()> {
@@ -3248,7 +3241,6 @@ pub(crate) enum Dispatch {
     GotoLocation(Location),
     OpenMoveToIndexPrompt(Option<PriorChange>),
     QuitAll,
-    SaveQuitAll,
     RevealInExplorer(CanonicalizedPath),
     OpenMoveFilePrompt,
     OpenDuplicateFilePrompt,

--- a/src/components/editor_keymap.rs
+++ b/src/components/editor_keymap.rs
@@ -130,13 +130,13 @@ pub(crate) const KEYMAP_SPACE: KeyboardMeaningLayout = [
 
 pub(crate) const KEYMAP_SPACE_EDITOR: KeyboardMeaningLayout = [
     [
-        QNSav, QSave, _____, _____, _____, /****/ _____, _____, _____, _____, _____,
+        _____, _____, _____, _____, _____, /****/ _____, _____, _____, _____, _____,
     ],
     [
-        _____, SaveA, RlBfr, Pipe_, _____, /****/ _____, _____, _____, _____, _____,
+        _____, _____, RlBfr, Pipe_, _____, /****/ _____, _____, _____, _____, _____,
     ],
     [
-        _____, RplcA, _____, _____, _____, /****/ _____, _____, _____, _____, _____,
+        _____, RplcA, SaveA, QNSav, _____, /****/ _____, _____, _____, _____, _____,
     ],
 ];
 
@@ -763,8 +763,6 @@ pub(crate) enum Meaning {
     SHelp,
     /// Quit No Save
     QNSav,
-    /// Quit Save
-    QSave,
     /// Save All
     SaveA,
     /// File Explorer

--- a/src/components/editor_keymap_legend.rs
+++ b/src/components/editor_keymap_legend.rs
@@ -1152,13 +1152,6 @@ impl Editor {
                 Keymap::new(
                     context
                         .keyboard_layout_kind()
-                        .get_space_editor_keymap(&Meaning::QSave),
-                    "Save All Quit".to_string(),
-                    Dispatch::SaveQuitAll,
-                ),
-                Keymap::new(
-                    context
-                        .keyboard_layout_kind()
                         .get_space_editor_keymap(&Meaning::QNSav),
                     "Quit No Save".to_string(),
                     Dispatch::QuitAll,


### PR DESCRIPTION
Removes `Save and Quit` as discussed in associated zulip topic.