### PR TITLE
Update nix command from install to add

### DIFF
--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -62,7 +62,7 @@ cargo install --locked --path .
   - with `nix profile`:
 
 ```sh
-nix profile install github:ki-editor/ki-editor
+nix profile add github:ki-editor/ki-editor
 ```
 
   - or as part of nix configuration, e.g.:


### PR DESCRIPTION
Reason:

$ nix profile install ...
warning: 'install' is a deprecated alias for 'add'