### PR TITLE
doc(submodes): fix key binding for entering Extend Mode

### DIFF
--- a/docs/docs/sub-modes/extend-mode.md
+++ b/docs/docs/sub-modes/extend-mode.md
@@ -9,7 +9,7 @@ import {KeymapFallback} from '@site/src/components/KeymapFallback';
 
 ## Intro
 
-This mode can be entered by pressing `f` (Qwerty), it is a short-lived mode where the next keypress
+This mode can be entered by pressing `g` (Qwerty), it is a short-lived mode where the next keypress
 leads to one of the following:
 
 1. Surround-related actions


### PR DESCRIPTION
[#Help > ✔ Keymap: How to do ... in Ki? @ 💬](https://ki-editor.zulipchat.com/#narrow/channel/538719-Help/topic/.E2.9C.94.20Keymap.3A.20How.20to.20do.20.2E.2E.2E.20in.20Ki.3F/near/563506081)