### PR TITLE
style(linecolumn): fill padding 4 line 3 column

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -509,7 +509,7 @@ impl<T: Frontend> App<T> {
                             .ok()
                             .map(|position| {
                                 FlexLayoutComponent::Text(format!(
-                                    "{}:{}",
+                                    "{: >4}:{: <3}",
                                     position.line + 1,
                                     position.column + 1
                                 ))


### PR DESCRIPTION


https://github.com/user-attachments/assets/64bd69a4-024a-4992-9264-4b2f91547b3d



parent folder in the center should not jerk when "line:columns" changes its width

for most of the cases, we can pad the lines as 4 digits, and columns as 3 digits

This should be enough to cover most day to day coding experiences, assuming most files are well below 10,000 lines and 1000 columns

