### PR TITLE
doc: simple cheatsheet

### DIFF
--- a/docs/docs/cheatsheet.md
+++ b/docs/docs/cheatsheet.md
@@ -1,0 +1,70 @@
+import {KeymapFallback} from '@site/src/components/KeymapFallback';
+
+# Cheatsheet
+
+This is a quick reference sheet for ki commands. For details on any given
+command, please consult the in-depth documentation on the side, or search for
+the command in the top right.
+
+## Normal Mode
+
+For a breakdown of keys by usecase, check out the Normal Mode section in the
+sidebar.
+
+<KeymapFallback filename="Normal"/>
+
+The following binds are non-positional:
+
+| Bind      | Action                        |
+| ----------| ----------------------------- |
+| Backspace | ← Select (previous selection) |
+| Tab       | Select → (next selection)     |
+
+### Space Menu
+
+<KeymapFallback filename="Space"/>
+
+#### Space Context Menu
+
+<KeymapFallback filename="Space Context"/>
+
+#### Space Editor Menu
+
+<KeymapFallback filename="Space Editor"/>
+
+#### Space Pick Menu
+
+<KeymapFallback filename="Space Pick"/>
+
+### Transform Menu
+
+<KeymapFallback filename="Transform"/>
+
+### Sub Modes
+
+These modes mirror normal mode except for the changed binds listed.
+
+#### Extend Submode
+
+<KeymapFallback filename="Extend"/>
+
+#### Multi-Cursor Submode
+
+<KeymapFallback filename="Multi-cursor"/>
+
+## Insert Mode
+
+<KeymapFallback filename="Insert"/>
+
+The following binds are non-positional:
+
+| Bind          | Action               |
+| ------------- | -------------------- |
+| Alt+Backspace | Delete Word Backward |
+
+### Completion Items
+
+For code completion popups.
+
+<KeymapFallback filename="Completion Items"/>
+


### PR DESCRIPTION
Gathers all Keymap Legends spread across the docs in a single page.

<img width="1165" height="950" alt="image" src="https://github.com/user-attachments/assets/b81c71d3-0604-4a10-b077-8466ded1e7ac" />


<!-- <img width="840" height="384" alt="image" src="https://github.com/user-attachments/assets/6a336768-b7e8-4a81-84ab-813f3d8b7e9d" /> -->
