### PR TITLE
fix(nix): fix error in flake.nix that prevented builds

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -147,7 +147,8 @@
                 filter = path: type:
                   (crossCraneLib.filterCargoSources path type)
                   || (builtins.match ".*contrib/emoji-icon-theme.json$" path != null)
-                  || (builtins.match ".*tree_sitter_quickfix/src/.*$" path != null);
+                  || (builtins.match ".*tree_sitter_quickfix/src/.*$" path != null)
+                  || (builtins.match ".*src/config_default.json$" path != null);
               };
 
               # Add a preBuild phase to create the VERSION file


### PR DESCRIPTION
I'm using Nix to grab the latest version of Ki and recently started seeing this error upon building Ki:

```
       > error: couldn't read `src/config_default.json`: No such file or directory (os error 2)
       >   --> src/config.rs:25:30
       >    |
       > 25 | const DEFAULT_CONFIG: &str = include_str!("config_default.json");
       >    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       >
       > error: could not compile `ki` (bin "ki") due to 1 previous error
```

This error can be reproduced by running `nix build` on the master branch of the project.

It turns out the problem is that Nix was not copying this `default.json` file into its sandboxed build directory. That's why the Nix build failed while the cargo one did not.

This change fixes the problem. Afterwards `nix build` succeeds again.