### PR TITLE
refactor(config): Use dedicated type for theme serde

### DIFF
--- a/src/themes/mod.rs
+++ b/src/themes/mod.rs
@@ -3,13 +3,10 @@ pub(crate) mod theme_descriptor;
 pub(crate) mod vscode_dark;
 pub(crate) mod vscode_light;
 use std::collections::HashMap;
-use std::{borrow::Cow, fmt};
 
 use itertools::Itertools;
 use my_proc_macros::hex;
 use once_cell::sync::OnceCell;
-use serde::{de, Serialize, Serializer};
-use serde::{de::Visitor, Deserialize, Deserializer};
 use strum::IntoEnumIterator as _;
 pub(crate) use vscode_dark::vscode_dark;
 pub(crate) use vscode_light::vscode_light;
@@ -26,71 +23,16 @@ pub(crate) struct Theme {
     pub(crate) git_gutter: GitGutterStyles,
 }
 
-use schemars::{JsonSchema, Schema, SchemaGenerator};
-
-impl Serialize for Theme {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_str(&self.name)
-    }
-}
-
-impl<'de> Deserialize<'de> for Theme {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        struct ThemeVisitor;
-
-        impl<'de> Visitor<'de> for ThemeVisitor {
-            type Value = Theme;
-
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("a valid theme name")
-            }
-
-            fn visit_str<E>(self, value: &str) -> Result<Theme, E>
-            where
-                E: de::Error,
-            {
-                let descriptors = crate::themes::theme_descriptor::all();
-                descriptors
-                    .iter()
-                    .find(|descriptor| descriptor.name() == value)
-                    .map(|descriptor| descriptor.to_theme())
-                    .ok_or_else(|| {
-                        let valid_themes: Vec<_> = descriptors.iter().map(|d| d.name()).collect();
-                        E::custom(format!(
-                            "'{value}' is not a valid theme. Available: {valid_themes:?}"
-                        ))
-                    })
-            }
-        }
-
-        deserializer.deserialize_str(ThemeVisitor)
-    }
-}
-
-impl JsonSchema for Theme {
-    fn schema_name() -> Cow<'static, str> {
-        "Theme".into()
-    }
-
-    fn json_schema(_gen: &mut SchemaGenerator) -> Schema {
-        let valid_themes: Vec<_> = crate::themes::theme_descriptor::all()
-            .into_iter()
-            .map(|descriptor| descriptor.name().to_string())
-            .collect();
-
-        serde_json::json!({
-            "type": "string",
-            "enum": valid_themes
+pub(crate) fn from_name(name: &str) -> Result<Theme, String> {
+    let descriptors = crate::themes::theme_descriptor::all();
+    descriptors
+        .iter()
+        .find(|descriptor| descriptor.name() == name)
+        .map(|descriptor| descriptor.to_theme())
+        .ok_or_else(|| {
+            let valid_themes: Vec<_> = descriptors.iter().map(|d| d.name()).collect();
+            format!("'{name}' is not a valid theme. Available: {valid_themes:?}")
         })
-        .try_into()
-        .unwrap()
-    }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]


### PR DESCRIPTION
Instead of implementing custom Serialize/Deserialize implementations on Theme, this change adds new types and makes use of serde attributes to deserialize/serialize with distinct types.

The reason for this change is to pave the way for custom themes, and to potentially allow embedding default themes, by having more correct serde derives on Theme itself.