### PR TITLE
refactor(themes): embed compressed zed themes into the binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1390,7 +1390,6 @@ dependencies = [
  "scraper",
  "serde",
  "serde_json",
- "serde_json5",
  "serial_test",
  "shared",
  "similar",
@@ -1912,50 +1911,6 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
-
-[[package]]
-name = "pest"
-version = "2.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
-dependencies = [
- "memchr",
- "thiserror 2.0.12",
- "ucd-trie",
-]
-
-[[package]]
-name = "pest_derive"
-version = "2.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb056d9e8ea77922845ec74a1c4e8fb17e7c218cc4fc11a15c5d25e189aa40bc"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87e404e638f781eb3202dc82db6760c8ae8a1eeef7fb3fa8264b2ef280504966"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
-dependencies = [
- "pest",
- "sha2",
-]
 
 [[package]]
 name = "petgraph"
@@ -2514,13 +2469,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_json5"
-version = "0.1.0"
+name = "serde_json_lenient"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a6b754515e1a7bd79fc2edeaecee526fc80cb3a918607e5ca149225a3a9586"
+checksum = "0e033097bf0d2b59a62b42c18ebbb797503839b26afdda2c4e1415cb6c813540"
 dependencies = [
- "pest",
- "pest_derive",
+ "itoa",
+ "memchr",
+ "ryu",
  "serde",
 ]
 
@@ -2638,17 +2594,6 @@ name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -3490,12 +3435,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ucd-trie"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
-
-[[package]]
 name = "uncased"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4297,7 +4236,9 @@ dependencies = [
 name = "zed-theme"
 version = "0.1.0"
 dependencies = [
+ "miniz_oxide",
  "serde",
+ "serde_json_lenient",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,6 @@ strum = "0.26.2"
 strum_macros = "0.26.2"
 nonempty = "~0.11.0"
 base64 = "0.22.1"
-serde_json5 = "0.1.0"
 comfy-table = "7.1.3"
 chrono = "0.4.39"
 ki-protocol-types = { path = "ki-protocol-types" }

--- a/biome.json
+++ b/biome.json
@@ -14,7 +14,8 @@
             "src/protocol/types.ts",
             "target",
             "docs/static",
-            "docs/.docusaurus"
+            "docs/.docusaurus",
+            "themes"
         ]
     },
     "formatter": {

--- a/src/themes/from_zed_theme.rs
+++ b/src/themes/from_zed_theme.rs
@@ -1,129 +1,13 @@
-use super::{
-    theme_descriptor::ThemeDescriptor, Color, DiagnosticStyles, HighlightName, Theme, UiStyles,
-};
+use super::{Color, DiagnosticStyles, HighlightName, Theme, UiStyles};
 use crate::{
     style::Style,
     themes::{GitGutterStyles, SyntaxStyles},
 };
 use itertools::Itertools;
 use my_proc_macros::hex;
-use shared::download::cache_download;
 use zed_theme::*;
 
-const ZED_THEME_AYU_URL: &str =
-    "https://raw.githubusercontent.com/zed-industries/zed/main/assets/themes/ayu/ayu.json";
-const ZED_THEME_ALABASTER_URL: &str =
-    "https://raw.githubusercontent.com/tsimoshka/zed-theme-alabaster/refs/heads/main/themes/alabaster-color-theme.json";
-const ZED_THEME_APATHY_URL: &str =
-    "https://raw.githubusercontent.com/mqual/themes/refs/heads/main/apathy_ki.json";
-const ZED_THEME_CATPPUCCIN_URL: &str =
-    "https://raw.githubusercontent.com/catppuccin/zed/main/themes/catppuccin-mauve.json";
-const ZED_THEME_DRACULA_URL: &str =
-    "https://raw.githubusercontent.com/dracula/zed/refs/heads/main/themes/dracula.json";
-const ZED_THEME_GITHUB_URL: &str = "https://raw.githubusercontent.com/PyaeSoneAungRgn/github-zed-theme/refs/heads/main/themes/github_theme.json";
-const ZED_THEME_GRUBER_DARKER_URL: &str =
-    "https://raw.githubusercontent.com/mqual/themes/refs/heads/main/gruber_darker_zed.json";
-const ZED_THEME_GRUVBOX_URL: &str =
-    "https://raw.githubusercontent.com/zed-industries/zed/main/assets/themes/gruvbox/gruvbox.json";
-const ZED_THEME_ONE_URL: &str =
-    "https://raw.githubusercontent.com/zed-industries/zed/main/assets/themes/one/one.json";
-const ZED_THEME_MODUS_URL: &str = "https://raw.githubusercontent.com/vitallium/zed-modus-themes/refs/heads/main/themes/modus.json";
-const ZED_THEME_MONOKAI_ST3_URL: &str =
-    "https://raw.githubusercontent.com/epmoyer/Zed-Monokai-Theme/main/monokai_st3.json";
-const ZED_THEME_MONOKAI_URL: &str =
-    "https://raw.githubusercontent.com/epmoyer/Zed-Monokai-Theme/main/monokai.json";
-const ZED_THEME_MQUAL_BLUE_URL: &str =
-    "https://raw.githubusercontent.com/mqual/themes/main/mqual_blue_zed.json";
-const ZED_THEME_NORD_URL: &str =
-    "https://raw.githubusercontent.com/mikasius/zed-nord-theme/refs/heads/master/themes/nord.json";
-const ZED_THEME_ROSE_PINE_URL: &str =
-    "https://raw.githubusercontent.com/rose-pine/zed/refs/heads/main/themes/rose-pine.json";
-const ZED_THEME_SOLARIZED_URL: &str = "https://raw.githubusercontent.com/harmtemolder/Solarized.zed/refs/heads/main/themes/solarized.json";
-const ZED_THEME_TOKYO_NIGHT_URL: &str = "https://raw.githubusercontent.com/ssaunderss/zed-tokyo-night/refs/heads/main/themes/tokyo-night.json";
-
-#[derive(serde::Deserialize)]
-struct ZedThemeManiftest {
-    themes: Vec<ThemeContent>,
-}
-
-/// Get all known Zed themes as a `ThemeDescriptor`.
-pub(crate) fn theme_descriptors() -> Vec<ThemeDescriptor> {
-    [
-        ("Ayu Dark", ZED_THEME_AYU_URL),
-        ("Ayu Light", ZED_THEME_AYU_URL),
-        ("Ayu Mirage", ZED_THEME_AYU_URL),
-        ("Alabaster", ZED_THEME_ALABASTER_URL),
-        ("Alabaster Dark", ZED_THEME_ALABASTER_URL),
-        ("Alabaster Mono", ZED_THEME_ALABASTER_URL),
-        ("Alabaster Dark Mono", ZED_THEME_ALABASTER_URL),
-        ("Alabaster BG", ZED_THEME_ALABASTER_URL),
-        ("Apathy Dark", ZED_THEME_APATHY_URL),
-        ("Apathy Light", ZED_THEME_APATHY_URL),
-        ("Catppuccin Frappé", ZED_THEME_CATPPUCCIN_URL),
-        ("Catppuccin Latte", ZED_THEME_CATPPUCCIN_URL),
-        ("Catppuccin Macchiato", ZED_THEME_CATPPUCCIN_URL),
-        ("Catppuccin Mocha", ZED_THEME_CATPPUCCIN_URL),
-        ("Dracula", ZED_THEME_DRACULA_URL),
-        ("Github Dark Colorblind", ZED_THEME_GITHUB_URL),
-        ("Github Dark Dimmed", ZED_THEME_GITHUB_URL),
-        ("Github Dark High Contrast", ZED_THEME_GITHUB_URL),
-        ("Github Dark Tritanopia", ZED_THEME_GITHUB_URL),
-        ("Github Dark", ZED_THEME_GITHUB_URL),
-        ("Github Light Colorblind", ZED_THEME_GITHUB_URL),
-        ("Github Light High Contrast", ZED_THEME_GITHUB_URL),
-        ("Github Light Tritanopia", ZED_THEME_GITHUB_URL),
-        ("Github Light", ZED_THEME_GITHUB_URL),
-        ("Gruber Darker", ZED_THEME_GRUBER_DARKER_URL),
-        ("Gruvbox Dark Hard", ZED_THEME_GRUVBOX_URL),
-        ("Gruvbox Dark Soft", ZED_THEME_GRUVBOX_URL),
-        ("Gruvbox Dark", ZED_THEME_GRUVBOX_URL),
-        ("Gruvbox Light Hard", ZED_THEME_GRUVBOX_URL),
-        ("Gruvbox Light Soft", ZED_THEME_GRUVBOX_URL),
-        ("Gruvbox Light", ZED_THEME_GRUVBOX_URL),
-        ("Modus Operandi Tinted", ZED_THEME_MODUS_URL),
-        ("Modus Operandi", ZED_THEME_MODUS_URL),
-        ("Modus Vivendi Tinted", ZED_THEME_MODUS_URL),
-        ("Modus Vivendi", ZED_THEME_MODUS_URL),
-        ("Monokai", ZED_THEME_MONOKAI_URL),
-        ("Monokai-ST3", ZED_THEME_MONOKAI_ST3_URL),
-        ("Mqual Blue", ZED_THEME_MQUAL_BLUE_URL),
-        ("Nord", ZED_THEME_NORD_URL),
-        ("Nord Light", ZED_THEME_NORD_URL),
-        ("One Dark", ZED_THEME_ONE_URL),
-        ("One Light", ZED_THEME_ONE_URL),
-        ("Rosé Pine Dawn", ZED_THEME_ROSE_PINE_URL),
-        ("Rosé Pine Moon", ZED_THEME_ROSE_PINE_URL),
-        ("Rosé Pine", ZED_THEME_ROSE_PINE_URL),
-        ("Solarized Dark", ZED_THEME_SOLARIZED_URL),
-        ("Solarized Light", ZED_THEME_SOLARIZED_URL),
-        ("Tokyo Night Light", ZED_THEME_TOKYO_NIGHT_URL),
-        ("Tokyo Night Storm", ZED_THEME_TOKYO_NIGHT_URL),
-        ("Tokyo Night", ZED_THEME_TOKYO_NIGHT_URL),
-    ]
-    .iter()
-    .map(|(name, url)| ThemeDescriptor::ZedTheme(name, url))
-    .collect()
-}
-
-pub(crate) fn from_url(name: &'static str, url: &'static str) -> anyhow::Result<Theme> {
-    let path = std::path::PathBuf::from(url);
-    let file_name = path
-        .file_name()
-        .ok_or_else(|| anyhow::anyhow!("The url ({:?}) should contain a file name.", url))?
-        .to_string_lossy();
-    let json_str = cache_download(url, "zed-themes", &file_name)?;
-    let manifest: ZedThemeManiftest = serde_json5::from_str(&json_str).map_err(|error| {
-        anyhow::anyhow!("Cannot parse JSON downloaded from {url:?} due to:\n{error:#?}")
-    })?;
-
-    manifest
-        .themes
-        .iter()
-        .find_map(|theme| (theme.name == name).then(|| from_theme_content(theme.clone())))
-        .ok_or_else(|| anyhow::anyhow!("could not find theme '{}'", name))
-}
-
-fn from_theme_content(theme: ThemeContent) -> Theme {
+pub(super) fn from_theme_content(theme: ThemeContent) -> Theme {
     let background = theme
         .style
         .editor_background
@@ -293,20 +177,5 @@ fn from_theme_content(theme: ThemeContent) -> Theme {
             super::HunkStyles::dark()
         },
         git_gutter: GitGutterStyles::new(),
-    }
-}
-
-#[cfg(test)]
-mod test_from_zed_theme {
-    use crate::themes::Theme;
-
-    #[test]
-    fn ensure_all_zed_themes_parse() -> anyhow::Result<()> {
-        // Expect no failure
-        let _: Vec<Theme> = super::theme_descriptors()
-            .iter()
-            .map(|theme| (*theme).to_theme())
-            .collect();
-        Ok(())
     }
 }

--- a/src/themes/theme_descriptor.rs
+++ b/src/themes/theme_descriptor.rs
@@ -1,47 +1,56 @@
-use super::{from_zed_theme, vscode_dark, vscode_light, Theme};
-use itertools::Itertools;
+use std::{collections::HashMap, sync::LazyLock};
 
-pub(crate) type ThemeFn = fn() -> Theme;
+use super::{from_zed_theme, vscode_dark, vscode_light, Theme};
+use zed_theme::get_zed_themes;
 
 #[derive(Clone, Debug, PartialEq)]
-pub(crate) enum ThemeDescriptor {
-    ThemeFn(String, ThemeFn),
-    ZedTheme(&'static str, &'static str),
-}
+pub(crate) struct ThemeDescriptor(String);
 
 impl ThemeDescriptor {
     pub(crate) fn name(&self) -> &str {
-        match self {
-            ThemeDescriptor::ThemeFn(name, _) => name,
-            ThemeDescriptor::ZedTheme(name, _) => name,
-        }
+        &self.0
     }
 
     pub(crate) fn to_theme(&self) -> Theme {
-        match self {
-            ThemeDescriptor::ThemeFn(_, theme_fn) => theme_fn(),
-            ThemeDescriptor::ZedTheme(name, url) => {
-                from_zed_theme::from_url(name, url).unwrap_or_else(|_| vscode_light())
-            }
-        }
+        let theme_map = &*THEMES;
+        theme_map
+            .get(&self.0)
+            .expect("Theme descriptor had no matching theme?")
+            .clone()
     }
 }
 
 impl Default for ThemeDescriptor {
     fn default() -> Self {
-        ThemeDescriptor::ThemeFn("VS Code (Light)".to_string(), vscode_light)
+        Self("VS Code (Light)".to_string())
     }
 }
 
-pub(crate) fn all() -> Vec<ThemeDescriptor> {
-    let theme_descriptors: Vec<ThemeDescriptor> = [
-        ThemeDescriptor::ThemeFn("VS Code (Light)".to_string(), vscode_light),
-        ThemeDescriptor::ThemeFn("VS Code (Dark)".to_string(), vscode_dark),
-    ]
-    .into_iter()
-    .chain(from_zed_theme::theme_descriptors())
-    .sorted_by_key(|theme| theme.name().to_owned())
-    .collect();
+static THEMES: LazyLock<HashMap<String, Theme>> = LazyLock::new(|| {
+    let mut themes = HashMap::new();
 
-    theme_descriptors
+    // Non-zed builtin themes
+    themes.insert("VS Code (Light)".to_string(), vscode_light());
+    themes.insert("VS Code (Dark)".to_string(), vscode_dark());
+
+    // Zed builtin themes
+    for (name, theme) in get_zed_themes() {
+        themes.insert(name, from_zed_theme::from_theme_content(theme));
+    }
+
+    themes
+});
+
+pub(crate) fn all() -> Vec<ThemeDescriptor> {
+    THEMES.keys().cloned().map(ThemeDescriptor).collect()
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn test_all_themes_work() {
+        for theme_descriptor in super::all() {
+            theme_descriptor.to_theme();
+        }
+    }
 }

--- a/themes/alabaster-color-theme.json
+++ b/themes/alabaster-color-theme.json
@@ -1,0 +1,1343 @@
+{
+  "$schema": "https://zed.dev/schema/themes/v0.2.0.json",
+  "name": "Alabaster",
+  "author": "Vitali Tsimoshka (theme originally by Nikita Prokopov)",
+  "themes": [
+    {
+      "name": "Alabaster",
+      "appearance": "light",
+      "style": {
+        "accents": [
+          "#007accff",
+          "#cb9000ff",
+          "#7a3e9dff",
+          "#0083b2ff",
+          "#aa3731ff",
+          "#f05050ff",
+          "#60cb00ff"
+        ],
+        "border": "#d2d2d2ff",
+        "border.variant": "#dadadaff",
+        "border.focused": "#c8c8c8ff",
+        "border.selected": "#cbcdf6ff",
+        "border.transparent": "#00000000",
+        "border.disabled": "#d3d3d4ff",
+        "elevated_surface.background": "#e6e6e6ff",
+        "surface.background": "#e6e6e6ff",
+        "background": "#e6e6e6ff",
+        "element.background": "#e6e6e6ff",
+        "element.hover": "#dcdcdcff",
+        "element.active": "#dcdcdcff",
+        "element.selected": "#d2d2d2ff",
+        "element.disabled": "#f0f0f0ff",
+        "drop_target.background": "#7e808780",
+        "ghost_element.background": "#00000000",
+        "ghost_element.hover": "#dcdcdcff",
+        "ghost_element.active": "#d2d2d2ff",
+        "ghost_element.selected": "#d2d2d2ff",
+        "ghost_element.disabled": "#f0f0f0ff",
+        "text": "#000000ff",
+        "text.muted": "#474747ff",
+        "text.placeholder": "#7e8086ff",
+        "text.disabled": "#7e8086ff",
+        "text.accent": "#007accff",
+        "icon": "#000000ff",
+        "icon.muted": "#474747ff",
+        "icon.disabled": "#7e8086ff",
+        "icon.placeholder": "#474747ff",
+        "icon.accent": "#007accff",
+        "status_bar.background": "#dadadaff",
+        "title_bar.background": "#e6e6e6ff",
+        "title_bar.inactive_background": "#e6e6e6ff",
+        "toolbar.background": "#e6e6e6ff",
+        "tab_bar.background": "#e6e6e6ff",
+        "tab.inactive_background": "#e6e6e6ff",
+        "tab.active_background": "#f7f7f7ff",
+        "search.match_background": "#ffbc5dff",
+        "panel.background": "#e6e6e6ff",
+        "panel.focused_border": null,
+        "pane.focused_border": null,
+        "scrollbar.thumb.background": "#383a414c",
+        "scrollbar.thumb.hover_background": "#dfdfe0ff",
+        "scrollbar.thumb.border": "#dfdfe0ff",
+        "scrollbar.track.background": "#00000000",
+        "scrollbar.track.border": "#eeeeeeff",
+        "editor.foreground": "#000000ff",
+        "editor.background": "#f7f7f7ff",
+        "editor.gutter.background": "#f7f7f7ff",
+        "editor.subheader.background": "#e6e6e6ff",
+        "editor.active_line.background": "#f0f0f0ff",
+        "editor.highlighted_line.background": "#f0f0f0ff",
+        "editor.line_number": "#9da39aff",
+        "editor.active_line_number": "#44454b",
+        "editor.hover_line_number": "#61616b",
+        "editor.invisible": "#a3a3a4ff",
+        "editor.wrap_guide": "#383a410d",
+        "editor.active_wrap_guide": "#383a411a",
+        "editor.document_highlight.read_background": "#cfcfcf81",
+        "editor.document_highlight.write_background": "#cfcfcf81",
+        "terminal.background": "#f7f7f7ff",
+        "terminal.foreground": "#000000ff",
+        "terminal.bright_foreground": "#000000ff",
+        "terminal.dim_foreground": "#4d4d4dff",
+        "terminal.ansi.black": "#000000ff",
+        "terminal.ansi.bright_black": "#777777ff",
+        "terminal.ansi.dim_black": "#333333ff",
+        "terminal.ansi.red": "#aa3731ff",
+        "terminal.ansi.bright_red": "#f05050ff",
+        "terminal.ansi.dim_red": "#6b211dff",
+        "terminal.ansi.green": "#448c37ff",
+        "terminal.ansi.bright_green": "#60cb00ff",
+        "terminal.ansi.dim_green": "#2a5622ff",
+        "terminal.ansi.yellow": "#cb9000ff",
+        "terminal.ansi.bright_yellow": "#ffbc5dff",
+        "terminal.ansi.dim_yellow": "#7d5900ff",
+        "terminal.ansi.blue": "#325cc0ff",
+        "terminal.ansi.bright_blue": "#007accff",
+        "terminal.ansi.dim_blue": "#1f3976ff",
+        "terminal.ansi.magenta": "#7a3e9dff",
+        "terminal.ansi.bright_magenta": "#e64ce6ff",
+        "terminal.ansi.dim_magenta": "#4c2762ff",
+        "terminal.ansi.cyan": "#0083b2ff",
+        "terminal.ansi.bright_cyan": "#00aacbff",
+        "terminal.ansi.dim_cyan": "#00516eff",
+        "terminal.ansi.white": "#666666ff",
+        "terminal.ansi.bright_white": "#d4d4d4ff",
+        "terminal.ansi.dim_white": "#747474ff",
+        "link_text.hover": "#007accff",
+        "version_control.added": "#27a657ff",
+        "version_control.modified": "#d3b020ff",
+        "version_control.deleted": "#e06c76ff",
+        "conflict": "#a48819ff",
+        "conflict.background": "#faf2e6ff",
+        "conflict.border": "#f4e7d1ff",
+        "created": "#669f59ff",
+        "created.background": "#dfeadbff",
+        "created.border": "#c8dcc1ff",
+        "deleted": "#d36151ff",
+        "deleted.background": "#fbdfd9ff",
+        "deleted.border": "#f6c6bdff",
+        "error": "#d36151ff",
+        "error.background": "#fbdfd9ff",
+        "error.border": "#f6c6bdff",
+        "hidden": "#7e8086ff",
+        "hidden.background": "#dcdcddff",
+        "hidden.border": "#d3d3d4ff",
+        "hint": "#7274a7ff",
+        "hint.background": "#e2e2faff",
+        "hint.border": "#cbcdf6ff",
+        "ignored": "#7e8086ff",
+        "ignored.background": "#dcdcddff",
+        "ignored.border": "#c9c9caff",
+        "info": "#5c78e2ff",
+        "info.background": "#e2e2faff",
+        "info.border": "#cbcdf6ff",
+        "modified": "#a48819ff",
+        "modified.background": "#faf2e6ff",
+        "modified.border": "#f4e7d1ff",
+        "predictive": "#9b9ec6ff",
+        "predictive.background": "#dfeadbff",
+        "predictive.border": "#c8dcc1ff",
+        "renamed": "#5c78e2ff",
+        "renamed.background": "#e2e2faff",
+        "renamed.border": "#cbcdf6ff",
+        "success": "#669f59ff",
+        "success.background": "#dfeadbff",
+        "success.border": "#c8dcc1ff",
+        "unreachable": "#58585aff",
+        "unreachable.background": "#dcdcddff",
+        "unreachable.border": "#c9c9caff",
+        "warning": "#a48819ff",
+        "warning.background": "#faf2e6ff",
+        "warning.border": "#f4e7d1ff",
+        "players": [
+          {
+            "cursor": "#007accff",
+            "background": "#007accff",
+            "selection": "#007acc3d"
+          },
+
+          {
+            "cursor": "#cb9000ff",
+            "background": "#cb9000ff",
+            "selection": "#cb90003d"
+          },
+          {
+            "cursor": "#7a3e9dff",
+            "background": "#7a3e9dff",
+            "selection": "#7a3e9d3d"
+          },
+          {
+            "cursor": "#0083b2ff",
+            "background": "#0083b2ff",
+            "selection": "#0083b23d"
+          },
+          {
+            "cursor": "#aa3731ff",
+            "background": "#aa3731ff",
+            "selection": "#aa37313d"
+          },
+          {
+            "cursor": "#f05050ff",
+            "background": "#f05050ff",
+            "selection": "#f050503d"
+          },
+          {
+            "cursor": "#60cb00ff",
+            "background": "#60cb00ff",
+            "selection": "#60cb003d"
+          }
+        ],
+        "syntax": {
+          "comment": {
+            "color": "#AA3731ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#AA3731ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#448C27ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.doc": {
+            "color": "#AA3731ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#7A3E9Dff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.unit": {
+            "color": "#7A3E9Dff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#7A3E9Dff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#7A3E9Dff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#7A3E9Dff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.class.definition": {
+            "color": "#325CC0",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.definition": {
+            "color": "#325CC0",
+            "font_style": null,
+            "font_weight": null
+          },
+          "@function.special.definition": {
+            "color": "#325CC0",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#325CC0",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#325CC0",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#777777",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    },
+    {
+      "name": "Alabaster Dark",
+      "appearance": "dark",
+      "style": {
+        "accents": [
+          "#cd974b",
+          "#71ade7",
+          "#915caf",
+          "#23acdd",
+          "#e25d56",
+          "#73ca50",
+          "#e9bf57"
+        ],
+        "border": "#484e50ff",
+        "border.variant": "#3e4446ff",
+        "border.focused": "#5a6264ff",
+        "border.selected": "#293b5bff",
+        "border.transparent": "#00000000",
+        "border.disabled": "#2a2e2fff",
+        "elevated_surface.background": "#313738ff",
+        "surface.background": "#313738ff",
+        "background": "#313738ff",
+        "element.background": "#313738ff",
+        "element.hover": "#3a4042ff",
+        "element.active": "#3a4042ff",
+        "element.selected": "#3a4042ff",
+        "element.disabled": "#282c2dff",
+        "drop_target.background": "#cd974b80",
+        "ghost_element.background": "#00000000",
+        "ghost_element.hover": "#3a4042ff",
+        "ghost_element.active": "#3a4042ff",
+        "ghost_element.selected": "#3a4042ff",
+        "ghost_element.disabled": "#282c2dff",
+        "text": "#cecece",
+        "text.muted": "#999999",
+        "text.placeholder": "#708b8d",
+        "text.disabled": "#666666",
+        "text.accent": "#cd974b",
+        "icon": "#cecece",
+        "icon.muted": "#999999",
+        "icon.disabled": "#666666",
+        "icon.placeholder": "#708b8d",
+        "icon.accent": "#cd974b",
+        "status_bar.background": "#252829ff",
+        "title_bar.background": "#313738ff",
+        "title_bar.inactive_background": "#313738ff",
+        "toolbar.background": "#313738ff",
+        "tab_bar.background": "#313738ff",
+        "tab.inactive_background": "#313738ff",
+        "tab.active_background": "#0c1415ff",
+        "search.match_background": "#cd974bff",
+        "panel.background": "#313738ff",
+        "panel.focused_border": null,
+        "pane.focused_border": null,
+        "scrollbar.thumb.background": "#708b8d4c",
+        "scrollbar.thumb.hover_background": "#708b8d99",
+        "scrollbar.thumb.border": "#00000000",
+        "scrollbar.track.background": "#00000000",
+        "scrollbar.track.border": "#00000000",
+        "editor.foreground": "#cecece",
+        "editor.background": "#0c1415ff",
+        "editor.gutter.background": "#0c1415ff",
+        "editor.subheader.background": "#313738ff",
+        "editor.active_line.background": "#1a1f20ff",
+        "editor.highlighted_line.background": "#1a1f20ff",
+        "editor.line_number": "#708b8d",
+        "editor.active_line_number": "#cecece",
+        "editor.hover_line_number": "#999999",
+        "editor.invisible": "#444444",
+        "editor.wrap_guide": "#708b8d0d",
+        "editor.active_wrap_guide": "#708b8d1a",
+        "editor.document_highlight.read_background": "#29333481",
+        "editor.document_highlight.write_background": "#29333481",
+        "terminal.background": "#0c1415ff",
+        "terminal.foreground": "#cecece",
+        "terminal.bright_foreground": "#ffffff",
+        "terminal.dim_foreground": "#808080",
+        "terminal.ansi.black": "#000000",
+        "terminal.ansi.bright_black": "#777777",
+        "terminal.ansi.dim_black": "#333333",
+        "terminal.ansi.red": "#e25d56",
+        "terminal.ansi.bright_red": "#f36868",
+        "terminal.ansi.dim_red": "#8a3833",
+        "terminal.ansi.green": "#73ca50",
+        "terminal.ansi.bright_green": "#88db3f",
+        "terminal.ansi.dim_green": "#467d30",
+        "terminal.ansi.yellow": "#e9bf57",
+        "terminal.ansi.bright_yellow": "#f0bf7a",
+        "terminal.ansi.dim_yellow": "#8f7634",
+        "terminal.ansi.blue": "#4a88e4",
+        "terminal.ansi.bright_blue": "#6f8fdb",
+        "terminal.ansi.dim_blue": "#2d548b",
+        "terminal.ansi.magenta": "#915caf",
+        "terminal.ansi.bright_magenta": "#e987e9",
+        "terminal.ansi.dim_magenta": "#59386b",
+        "terminal.ansi.cyan": "#23acdd",
+        "terminal.ansi.bright_cyan": "#4ac9e2",
+        "terminal.ansi.dim_cyan": "#156988",
+        "terminal.ansi.white": "#cecece",
+        "terminal.ansi.bright_white": "#ffffff",
+        "terminal.ansi.dim_white": "#999999",
+        "link_text.hover": "#cd974b",
+        "version_control.added": "#73ca50",
+        "version_control.modified": "#e9bf57",
+        "version_control.deleted": "#e25d56",
+        "conflict": "#e9bf57",
+        "conflict.background": "#3d3a2fff",
+        "conflict.border": "#4f4b3fff",
+        "created": "#73ca50",
+        "created.background": "#273229ff",
+        "created.border": "#334335ff",
+        "deleted": "#e25d56",
+        "deleted.background": "#3a2729ff",
+        "deleted.border": "#4c3335ff",
+        "error": "#e25d56",
+        "error.background": "#3a2729ff",
+        "error.border": "#4c3335ff",
+        "hidden": "#708b8d",
+        "hidden.background": "#282c2dff",
+        "hidden.border": "#3a4042ff",
+        "hint": "#71ade7",
+        "hint.background": "#1f2b3dff",
+        "hint.border": "#293b5bff",
+        "ignored": "#708b8d",
+        "ignored.background": "#282c2dff",
+        "ignored.border": "#3a4042ff",
+        "info": "#71ade7",
+        "info.background": "#1f2b3dff",
+        "info.border": "#293b5bff",
+        "modified": "#e9bf57",
+        "modified.background": "#3d3a2fff",
+        "modified.border": "#4f4b3fff",
+        "predictive": "#915caf",
+        "predictive.background": "#2b233aff",
+        "predictive.border": "#3a2d4cff",
+        "renamed": "#71ade7",
+        "renamed.background": "#1f2b3dff",
+        "renamed.border": "#293b5bff",
+        "success": "#73ca50",
+        "success.background": "#273229ff",
+        "success.border": "#334335ff",
+        "unreachable": "#555555",
+        "unreachable.background": "#282c2dff",
+        "unreachable.border": "#3a4042ff",
+        "warning": "#e9bf57",
+        "warning.background": "#3d3a2fff",
+        "warning.border": "#4f4b3fff",
+        "players": [
+          {
+            "cursor": "#cd974b",
+            "background": "#cd974b",
+            "selection": "#cd974b3d"
+          },
+          {
+            "cursor": "#71ade7",
+            "background": "#71ade7",
+            "selection": "#71ade73d"
+          },
+          {
+            "cursor": "#915caf",
+            "background": "#915caf",
+            "selection": "#915caf3d"
+          },
+          {
+            "cursor": "#23acdd",
+            "background": "#23acdd",
+            "selection": "#23acdd3d"
+          },
+          {
+            "cursor": "#e25d56",
+            "background": "#e25d56",
+            "selection": "#e25d563d"
+          },
+          {
+            "cursor": "#73ca50",
+            "background": "#73ca50",
+            "selection": "#73ca503d"
+          },
+          {
+            "cursor": "#e9bf57",
+            "background": "#e9bf57",
+            "selection": "#e9bf573d"
+          }
+        ],
+        "syntax": {
+          "comment": {
+            "color": "#DFDF8E",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#DFDF8E",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#95CB82",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.doc": {
+            "color": "#DFDF8E",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#CC8BC9",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.unit": {
+            "color": "#CC8BC9",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#CC8BC9",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#CC8BC9",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#CC8BC9",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.class.definition": {
+            "color": "#71ADE7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.definition": {
+            "color": "#71ADE7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "@function.special.definition": {
+            "color": "#71ADE7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#71ADE7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#71ADE7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#708B8D",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    },
+    {
+      "name": "Alabaster Mono",
+      "appearance": "light",
+      "style": {
+        "border": "#d2d2d2ff",
+        "border.variant": "#dadadaff",
+        "border.focused": "#c8c8c8ff",
+        "border.selected": "#cbcdf6ff",
+        "border.transparent": "#00000000",
+        "border.disabled": "#d3d3d4ff",
+        "elevated_surface.background": "#e6e6e6ff",
+        "surface.background": "#e6e6e6ff",
+        "background": "#e6e6e6ff",
+        "element.background": "#e6e6e6ff",
+        "element.hover": "#dcdcdcff",
+        "element.active": "#dcdcdcff",
+        "element.selected": "#d2d2d2ff",
+        "element.disabled": "#f0f0f0ff",
+        "drop_target.background": "#7e808780",
+        "ghost_element.background": "#00000000",
+        "ghost_element.hover": "#dcdcdcff",
+        "ghost_element.active": "#d2d2d2ff",
+        "ghost_element.selected": "#d2d2d2ff",
+        "ghost_element.disabled": "#f0f0f0ff",
+        "text": "#000000",
+        "text.muted": "#474747ff",
+        "text.placeholder": "#7e8086ff",
+        "text.disabled": "#7e8086ff",
+        "text.accent": "#007accff",
+        "icon": "#000000",
+        "icon.muted": "#474747ff",
+        "icon.disabled": "#7e8086ff",
+        "icon.placeholder": "#474747ff",
+        "icon.accent": "#007accff",
+        "status_bar.background": "#dadadaff",
+        "title_bar.background": "#e6e6e6ff",
+        "title_bar.inactive_background": "#e6e6e6ff",
+        "toolbar.background": "#e6e6e6ff",
+        "tab_bar.background": "#e6e6e6ff",
+        "tab.inactive_background": "#e6e6e6ff",
+        "tab.active_background": "#f7f7f7ff",
+        "search.match_background": "#ffbc5dff",
+        "panel.background": "#e6e6e6ff",
+        "panel.focused_border": null,
+        "pane.focused_border": null,
+        "scrollbar.thumb.background": "#383a414c",
+        "scrollbar.thumb.hover_background": "#dfdfe0ff",
+        "scrollbar.thumb.border": "#dfdfe0ff",
+        "scrollbar.track.background": "#00000000",
+        "scrollbar.track.border": "#eeeeeeff",
+        "editor.foreground": "#000000",
+        "editor.background": "#ffffff",
+        "editor.gutter.background": "#f7f7f7ff",
+        "editor.subheader.background": "#e6e6e6ff",
+        "editor.active_line.background": "#f5f5f5ff",
+        "editor.highlighted_line.background": "#f5f5f5ff",
+        "editor.line_number": "#9da39aff",
+        "editor.active_line_number": "#44454b",
+        "editor.hover_line_number": "#61616b",
+        "editor.invisible": "#a3a3a4ff",
+        "editor.wrap_guide": "#383a410d",
+        "editor.active_wrap_guide": "#383a411a",
+        "editor.document_highlight.read_background": "#cfcfcf81",
+        "editor.document_highlight.write_background": "#cfcfcf81",
+        "terminal.background": "#f7f7f7ff",
+        "terminal.foreground": "#000000",
+        "terminal.bright_foreground": "#000000",
+        "terminal.dim_foreground": "#666666",
+        "terminal.ansi.black": "#000000",
+        "terminal.ansi.bright_black": "#777777",
+        "terminal.ansi.dim_black": "#333333",
+        "terminal.ansi.red": "#aa3731",
+        "terminal.ansi.bright_red": "#f05050",
+        "terminal.ansi.dim_red": "#6b211d",
+        "terminal.ansi.green": "#448c37",
+        "terminal.ansi.bright_green": "#60cb00",
+        "terminal.ansi.dim_green": "#2a5622",
+        "terminal.ansi.yellow": "#cb9000",
+        "terminal.ansi.bright_yellow": "#ffbc5d",
+        "terminal.ansi.dim_yellow": "#7d5900",
+        "terminal.ansi.blue": "#325cc0",
+        "terminal.ansi.bright_blue": "#007acc",
+        "terminal.ansi.dim_blue": "#1f3976",
+        "terminal.ansi.magenta": "#7a3e9d",
+        "terminal.ansi.bright_magenta": "#e64ce6",
+        "terminal.ansi.dim_magenta": "#4c2762",
+        "terminal.ansi.cyan": "#0083b2",
+        "terminal.ansi.bright_cyan": "#00aacb",
+        "terminal.ansi.dim_cyan": "#00516e",
+        "terminal.ansi.white": "#666666",
+        "terminal.ansi.bright_white": "#d4d4d4",
+        "terminal.ansi.dim_white": "#747474",
+        "link_text.hover": "#007accff",
+        "version_control.added": "#27a657",
+        "version_control.modified": "#d3b020",
+        "version_control.deleted": "#e06c76",
+        "conflict": "#d3b020",
+        "conflict.background": "#faf2e6ff",
+        "conflict.border": "#f4e7d1ff",
+        "created": "#27a657",
+        "created.background": "#dfeadbff",
+        "created.border": "#c8dcc1ff",
+        "deleted": "#e06c76",
+        "deleted.background": "#fbdfd9ff",
+        "deleted.border": "#f6c6bdff",
+        "error": "#e06c76",
+        "error.background": "#fbdfd9ff",
+        "error.border": "#f6c6bdff",
+        "hidden": "#7e8086ff",
+        "hidden.background": "#dcdcddff",
+        "hidden.border": "#d3d3d4ff",
+        "hint": "#7274a7ff",
+        "hint.background": "#e2e2faff",
+        "hint.border": "#cbcdf6ff",
+        "ignored": "#7e8086ff",
+        "ignored.background": "#dcdcddff",
+        "ignored.border": "#c9c9caff",
+        "info": "#5c78e2ff",
+        "info.background": "#e2e2faff",
+        "info.border": "#cbcdf6ff",
+        "modified": "#d3b020",
+        "modified.background": "#faf2e6ff",
+        "modified.border": "#f4e7d1ff",
+        "predictive": "#9b9ec6ff",
+        "predictive.background": "#dfeadbff",
+        "predictive.border": "#c8dcc1ff",
+        "renamed": "#5c78e2ff",
+        "renamed.background": "#e2e2faff",
+        "renamed.border": "#cbcdf6ff",
+        "success": "#27a657",
+        "success.background": "#dfeadbff",
+        "success.border": "#c8dcc1ff",
+        "unreachable": "#58585aff",
+        "unreachable.background": "#dcdcddff",
+        "unreachable.border": "#c9c9caff",
+        "warning": "#d3b020",
+        "warning.background": "#faf2e6ff",
+        "warning.border": "#f4e7d1ff",
+        "players": [
+          {
+            "cursor": "#16bdec",
+            "background": "#16bdec",
+            "selection": "#16bdec3d"
+          },
+          {
+            "cursor": "#cb9000",
+            "background": "#cb9000",
+            "selection": "#cb90003d"
+          },
+          {
+            "cursor": "#7a3e9d",
+            "background": "#7a3e9d",
+            "selection": "#7a3e9d3d"
+          },
+          {
+            "cursor": "#0083b2",
+            "background": "#0083b2",
+            "selection": "#0083b23d"
+          },
+          {
+            "cursor": "#aa3731",
+            "background": "#aa3731",
+            "selection": "#aa37313d"
+          },
+          {
+            "cursor": "#448c37",
+            "background": "#448c37",
+            "selection": "#448c373d"
+          },
+          {
+            "cursor": "#325cc0",
+            "background": "#325cc0",
+            "selection": "#325cc03d"
+          }
+        ],
+        "syntax": {
+          "comment": {
+            "color": "#999999",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#999999",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#000000",
+            "background_color": "#eeeeee",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.doc": {
+            "color": "#999999",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#000000",
+            "background_color": "#eeeeee",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.unit": {
+            "color": "#000000",
+            "background_color": "#eeeeee",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#000000",
+            "background_color": "#d9d9d9",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#000000",
+            "background_color": "#eeeeee",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#000000",
+            "background_color": "#eeeeee",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.class.definition": {
+            "color": "#000000",
+            "background_color": "#eeeeee",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.definition": {
+            "color": "#000000",
+            "background_color": "#eeeeee",
+            "font_style": null,
+            "font_weight": null
+          },
+          "@function.special.definition": {
+            "color": "#000000",
+            "background_color": "#eeeeee",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#000000",
+            "background_color": "#eeeeee",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#000000",
+            "background_color": "#eeeeee",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#999999",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    },
+    {
+      "name": "Alabaster Dark Mono",
+      "appearance": "dark",
+      "style": {
+        "accents": [
+          "#cd974b",
+          "#71ade7",
+          "#915caf",
+          "#23acdd",
+          "#e25d56",
+          "#73ca50",
+          "#e9bf57"
+        ],
+        "border": "#484e50ff",
+        "border.variant": "#3e4446ff",
+        "border.focused": "#5a6264ff",
+        "border.selected": "#293b5bff",
+        "border.transparent": "#00000000",
+        "border.disabled": "#2a2e2fff",
+        "elevated_surface.background": "#313738ff",
+        "surface.background": "#313738ff",
+        "background": "#313738ff",
+        "element.background": "#313738ff",
+        "element.hover": "#3a4042ff",
+        "element.active": "#3a4042ff",
+        "element.selected": "#3a4042ff",
+        "element.disabled": "#282c2dff",
+        "drop_target.background": "#cd974b80",
+        "ghost_element.background": "#00000000",
+        "ghost_element.hover": "#3a4042ff",
+        "ghost_element.active": "#3a4042ff",
+        "ghost_element.selected": "#3a4042ff",
+        "ghost_element.disabled": "#282c2dff",
+        "text": "#cecece",
+        "text.muted": "#999999",
+        "text.placeholder": "#708b8d",
+        "text.disabled": "#666666",
+        "text.accent": "#cd974b",
+        "icon": "#cecece",
+        "icon.muted": "#999999",
+        "icon.disabled": "#666666",
+        "icon.placeholder": "#708b8d",
+        "icon.accent": "#cd974b",
+        "status_bar.background": "#252829ff",
+        "title_bar.background": "#313738ff",
+        "title_bar.inactive_background": "#313738ff",
+        "toolbar.background": "#313738ff",
+        "tab_bar.background": "#313738ff",
+        "tab.inactive_background": "#313738ff",
+        "tab.active_background": "#111111",
+        "search.match_background": "#cd974bff",
+        "panel.background": "#313738ff",
+        "panel.focused_border": null,
+        "pane.focused_border": null,
+        "scrollbar.thumb.background": "#708b8d4c",
+        "scrollbar.thumb.hover_background": "#708b8d99",
+        "scrollbar.thumb.border": "#00000000",
+        "scrollbar.track.background": "#00000000",
+        "scrollbar.track.border": "#00000000",
+        "editor.foreground": "#cecece",
+        "editor.background": "#111111",
+        "editor.gutter.background": "#111111",
+        "editor.subheader.background": "#313738ff",
+        "editor.active_line.background": "#1a1f20ff",
+        "editor.highlighted_line.background": "#1a1f20ff",
+        "editor.line_number": "#708b8d",
+        "editor.active_line_number": "#cecece",
+        "editor.hover_line_number": "#999999",
+        "editor.invisible": "#444444",
+        "editor.wrap_guide": "#708b8d0d",
+        "editor.active_wrap_guide": "#708b8d1a",
+        "editor.document_highlight.read_background": "#29333481",
+        "editor.document_highlight.write_background": "#29333481",
+        "terminal.background": "#0c1415ff",
+        "terminal.foreground": "#cecece",
+        "terminal.bright_foreground": "#ffffff",
+        "terminal.dim_foreground": "#808080",
+        "terminal.ansi.black": "#000000",
+        "terminal.ansi.bright_black": "#777777",
+        "terminal.ansi.dim_black": "#333333",
+        "terminal.ansi.red": "#e25d56",
+        "terminal.ansi.bright_red": "#f36868",
+        "terminal.ansi.dim_red": "#8a3833",
+        "terminal.ansi.green": "#73ca50",
+        "terminal.ansi.bright_green": "#88db3f",
+        "terminal.ansi.dim_green": "#467d30",
+        "terminal.ansi.yellow": "#e9bf57",
+        "terminal.ansi.bright_yellow": "#f0bf7a",
+        "terminal.ansi.dim_yellow": "#8f7634",
+        "terminal.ansi.blue": "#4a88e4",
+        "terminal.ansi.bright_blue": "#6f8fdb",
+        "terminal.ansi.dim_blue": "#2d548b",
+        "terminal.ansi.magenta": "#915caf",
+        "terminal.ansi.bright_magenta": "#e987e9",
+        "terminal.ansi.dim_magenta": "#59386b",
+        "terminal.ansi.cyan": "#23acdd",
+        "terminal.ansi.bright_cyan": "#4ac9e2",
+        "terminal.ansi.dim_cyan": "#156988",
+        "terminal.ansi.white": "#cecece",
+        "terminal.ansi.bright_white": "#ffffff",
+        "terminal.ansi.dim_white": "#999999",
+        "link_text.hover": "#cd974b",
+        "version_control.added": "#73ca50",
+        "version_control.modified": "#e9bf57",
+        "version_control.deleted": "#e25d56",
+        "conflict": "#e9bf57",
+        "conflict.background": "#3d3a2fff",
+        "conflict.border": "#4f4b3fff",
+        "created": "#73ca50",
+        "created.background": "#273229ff",
+        "created.border": "#334335ff",
+        "deleted": "#e25d56",
+        "deleted.background": "#3a2729ff",
+        "deleted.border": "#4c3335ff",
+        "error": "#e25d56",
+        "error.background": "#3a2729ff",
+        "error.border": "#4c3335ff",
+        "hidden": "#708b8d",
+        "hidden.background": "#282c2dff",
+        "hidden.border": "#3a4042ff",
+        "hint": "#71ade7",
+        "hint.background": "#1f2b3dff",
+        "hint.border": "#293b5bff",
+        "ignored": "#708b8d",
+        "ignored.background": "#282c2dff",
+        "ignored.border": "#3a4042ff",
+        "info": "#71ade7",
+        "info.background": "#1f2b3dff",
+        "info.border": "#293b5bff",
+        "modified": "#e9bf57",
+        "modified.background": "#3d3a2fff",
+        "modified.border": "#4f4b3fff",
+        "predictive": "#915caf",
+        "predictive.background": "#2b233aff",
+        "predictive.border": "#3a2d4cff",
+        "renamed": "#71ade7",
+        "renamed.background": "#1f2b3dff",
+        "renamed.border": "#293b5bff",
+        "success": "#73ca50",
+        "success.background": "#273229ff",
+        "success.border": "#334335ff",
+        "unreachable": "#555555",
+        "unreachable.background": "#282c2dff",
+        "unreachable.border": "#3a4042ff",
+        "warning": "#e9bf57",
+        "warning.background": "#3d3a2fff",
+        "warning.border": "#4f4b3fff",
+        "players": [
+          {
+            "cursor": "#cd974b",
+            "background": "#cd974b",
+            "selection": "#cd974b3d"
+          },
+          {
+            "cursor": "#71ade7",
+            "background": "#71ade7",
+            "selection": "#71ade73d"
+          },
+          {
+            "cursor": "#915caf",
+            "background": "#915caf",
+            "selection": "#915caf3d"
+          },
+          {
+            "cursor": "#23acdd",
+            "background": "#23acdd",
+            "selection": "#23acdd3d"
+          },
+          {
+            "cursor": "#e25d56",
+            "background": "#e25d56",
+            "selection": "#e25d563d"
+          },
+          {
+            "cursor": "#73ca50",
+            "background": "#73ca50",
+            "selection": "#73ca503d"
+          },
+          {
+            "cursor": "#e9bf57",
+            "background": "#e9bf57",
+            "selection": "#e9bf573d"
+          }
+        ],
+        "syntax": {
+          "comment": {
+            "color": "#999999",
+            "background_color": "#333333",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#999999",
+            "background_color": "#333333",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#eeeeee",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.doc": {
+            "color": "#999999",
+            "background_color": "#333333",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#eeeeee",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.unit": {
+            "color": "#eeeeee",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#eeeeee",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#eeeeee",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#eeeeee",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.class.definition": {
+            "color": "#eeeeee",
+            "background_color": "#333333",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.definition": {
+            "color": "#eeeeee",
+            "background_color": "#333333",
+            "font_style": null,
+            "font_weight": null
+          },
+          "@function.special.definition": {
+            "color": "#eeeeee",
+            "background_color": "#333333",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#eeeeee",
+            "background_color": "#333333",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#eeeeee",
+            "background_color": "#333333",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#999999",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    },
+    {
+      "name": "Alabaster BG",
+      "appearance": "light",
+      "style": {
+        "accents": [
+          "#007accff",
+          "#cb9000ff",
+          "#7a3e9dff",
+          "#0083b2ff",
+          "#aa3731ff",
+          "#f05050ff",
+          "#60cb00ff"
+        ],
+        "border": "#d2d2d2ff",
+        "border.variant": "#dadadaff",
+        "border.focused": "#c8c8c8ff",
+        "border.selected": "#cbcdf6ff",
+        "border.transparent": "#00000000",
+        "border.disabled": "#d3d3d4ff",
+        "elevated_surface.background": "#e6e6e6ff",
+        "surface.background": "#e6e6e6ff",
+        "background": "#e6e6e6ff",
+        "element.background": "#e6e6e6ff",
+        "element.hover": "#dcdcdcff",
+        "element.active": "#dcdcdcff",
+        "element.selected": "#d2d2d2ff",
+        "element.disabled": "#f0f0f0ff",
+        "drop_target.background": "#7e808780",
+        "ghost_element.background": "#00000000",
+        "ghost_element.hover": "#dcdcdcff",
+        "ghost_element.active": "#d2d2d2ff",
+        "ghost_element.selected": "#d2d2d2ff",
+        "ghost_element.disabled": "#f0f0f0ff",
+        "text": "#000000",
+        "text.muted": "#666666",
+        "text.placeholder": "#999999",
+        "text.disabled": "#999999",
+        "text.accent": "#007acc",
+        "icon": "#000000",
+        "icon.muted": "#666666",
+        "icon.disabled": "#999999",
+        "icon.placeholder": "#666666",
+        "icon.accent": "#007acc",
+        "status_bar.background": "#dadadaff",
+        "title_bar.background": "#e6e6e6ff",
+        "title_bar.inactive_background": "#e6e6e6ff",
+        "toolbar.background": "#e6e6e6ff",
+        "tab_bar.background": "#e6e6e6ff",
+        "tab.inactive_background": "#e6e6e6ff",
+        "tab.active_background": "#f7f7f7ff",
+        "search.match_background": "#ffbc5dff",
+        "panel.background": "#e6e6e6ff",
+        "panel.focused_border": null,
+        "pane.focused_border": null,
+        "scrollbar.thumb.background": "#383a414c",
+        "scrollbar.thumb.hover_background": "#dfdfe0ff",
+        "scrollbar.thumb.border": "#dfdfe0ff",
+        "scrollbar.track.background": "#00000000",
+        "scrollbar.track.border": "#eeeeeeff",
+        "editor.foreground": "#000000",
+        "editor.background": "#ffffff",
+        "editor.gutter.background": "#f7f7f7ff",
+        "editor.subheader.background": "#e6e6e6ff",
+        "editor.active_line.background": "#f5f5f5ff",
+        "editor.highlighted_line.background": "#f5f5f5ff",
+        "editor.line_number": "#9da39aff",
+        "editor.active_line_number": "#44454b",
+        "editor.hover_line_number": "#999999",
+        "editor.invisible": "#cccccc",
+        "editor.wrap_guide": "#383a410d",
+        "editor.active_wrap_guide": "#383a411a",
+        "editor.document_highlight.read_background": "#cfcfcf81",
+        "editor.document_highlight.write_background": "#cfcfcf81",
+        "terminal.background": "#f7f7f7ff",
+        "terminal.foreground": "#000000",
+        "terminal.bright_foreground": "#000000",
+        "terminal.dim_foreground": "#666666",
+        "terminal.ansi.black": "#000000",
+        "terminal.ansi.bright_black": "#777777",
+        "terminal.ansi.dim_black": "#333333",
+        "terminal.ansi.red": "#aa3731",
+        "terminal.ansi.bright_red": "#f05050",
+        "terminal.ansi.dim_red": "#6b211d",
+        "terminal.ansi.green": "#448c37",
+        "terminal.ansi.bright_green": "#60cb00",
+        "terminal.ansi.dim_green": "#2a5622",
+        "terminal.ansi.yellow": "#cb9000",
+        "terminal.ansi.bright_yellow": "#ffbc5d",
+        "terminal.ansi.dim_yellow": "#7d5900",
+        "terminal.ansi.blue": "#325cc0",
+        "terminal.ansi.bright_blue": "#007acc",
+        "terminal.ansi.dim_blue": "#1f3976",
+        "terminal.ansi.magenta": "#7a3e9d",
+        "terminal.ansi.bright_magenta": "#e64ce6",
+        "terminal.ansi.dim_magenta": "#4c2762",
+        "terminal.ansi.cyan": "#0083b2",
+        "terminal.ansi.bright_cyan": "#00aacb",
+        "terminal.ansi.dim_cyan": "#00516e",
+        "terminal.ansi.white": "#666666",
+        "terminal.ansi.bright_white": "#d4d4d4",
+        "terminal.ansi.dim_white": "#747474",
+        "link_text.hover": "#007acc",
+        "version_control.added": "#27a657",
+        "version_control.modified": "#d3b020",
+        "version_control.deleted": "#e06c76",
+        "conflict": "#d3b020",
+        "conflict.background": "#faf2e6ff",
+        "conflict.border": "#f4e7d1ff",
+        "created": "#27a657",
+        "created.background": "#dfeadbff",
+        "created.border": "#c8dcc1ff",
+        "deleted": "#e06c76",
+        "deleted.background": "#fbdfd9ff",
+        "deleted.border": "#f6c6bdff",
+        "error": "#e06c76",
+        "error.background": "#ffe0e0",
+        "error.border": "#ffcccc",
+        "hidden": "#7e8086ff",
+        "hidden.background": "#dcdcddff",
+        "hidden.border": "#d3d3d4ff",
+        "hint": "#007acc",
+        "hint.background": "#e6f3ff",
+        "hint.border": "#b4d8fd",
+        "ignored": "#7e8086ff",
+        "ignored.background": "#dcdcddff",
+        "ignored.border": "#c9c9caff",
+        "info": "#007acc",
+        "info.background": "#e6f3ff",
+        "info.border": "#b4d8fd",
+        "modified": "#d3b020",
+        "modified.background": "#faf2e6ff",
+        "modified.border": "#f4e7d1ff",
+        "predictive": "#9b9ec6ff",
+        "predictive.background": "#dfeadbff",
+        "predictive.border": "#c8dcc1ff",
+        "renamed": "#007acc",
+        "renamed.background": "#e6f3ff",
+        "renamed.border": "#b4d8fd",
+        "success": "#27a657",
+        "success.background": "#dfeadbff",
+        "success.border": "#c8dcc1ff",
+        "unreachable": "#58585aff",
+        "unreachable.background": "#dcdcddff",
+        "unreachable.border": "#c9c9caff",
+        "warning": "#d3b020",
+        "warning.background": "#faf2e6ff",
+        "warning.border": "#f4e7d1ff",
+        "players": [
+          {
+            "cursor": "#007acc",
+            "background": "#007acc",
+            "selection": "#007acc3d"
+          },
+          {
+            "cursor": "#cb9000",
+            "background": "#cb9000",
+            "selection": "#cb90003d"
+          },
+          {
+            "cursor": "#7a3e9d",
+            "background": "#7a3e9d",
+            "selection": "#7a3e9d3d"
+          },
+          {
+            "cursor": "#0083b2",
+            "background": "#0083b2",
+            "selection": "#0083b23d"
+          },
+          {
+            "cursor": "#aa3731",
+            "background": "#aa3731",
+            "selection": "#aa37313d"
+          },
+          {
+            "cursor": "#448c37",
+            "background": "#448c37",
+            "selection": "#448c373d"
+          },
+          {
+            "cursor": "#325cc0",
+            "background": "#325cc0",
+            "selection": "#325cc03d"
+          }
+        ],
+        "syntax": {
+          "comment": {
+            "color": "#000000",
+            "background_color": "#fffabc",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#000000",
+            "background_color": "#fffabc",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#000000",
+            "background_color": "#f1fadf",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.doc": {
+            "color": "#000000",
+            "background_color": "#fffabc",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#7a3e9d",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.unit": {
+            "color": "#7a3e9d",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#000000",
+            "background_color": "#dbecb6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#7a3e9d",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#7a3e9d",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.class.definition": {
+            "color": "#000000",
+            "background_color": "#dbf1ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.definition": {
+            "color": "#000000",
+            "background_color": "#dbf1ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "@function.special.definition": {
+            "color": "#000000",
+            "background_color": "#dbf1ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#000000",
+            "background_color": "#dbf1ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#000000",
+            "background_color": "#dbf1ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#000000e6",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    }
+  ]
+}

--- a/themes/apathy_ki.json
+++ b/themes/apathy_ki.json
@@ -1,0 +1,106 @@
+{
+    "name": "Apathy",
+    "author": "ported by Vishal (@haxfn)",
+    "themes": [
+        {
+            "name": "Apathy Dark",
+            "appearance": "dark",
+            "style": {
+                "background": "#031a16",
+                "editor.background": "#031a16",
+                "text": "#d2e7e4",
+                "text.accent": "#96883e",
+                "text.muted": "#2b685e",
+                "status_bar.background": "#96883e",
+                "tab_bar.background": "#96883e",
+                "tab.inactive_background": "#96883e",
+                "editor.line_number": "#2b685e",
+                "border": "#2b685e",
+                "conflict.background": "#963e4c",
+                "search.match_background": "#184e45",
+                "error": "#3e4c96",
+                "warning": "#3e4c96",
+                "info": "#96883e",
+                "hint": "#96883e",
+                "players": [
+                    {
+                        "cursor": "#81b5ac",
+                        "selection": "#08352b"
+                    }
+                ],
+                "syntax": {
+                    "boolean": { "color": "#4c963e" },
+                    "comment": { "color": "#2b685e" },
+                    "comment.documentation": { "color": "#2b685e" },
+                    "constant": { "color": "#4c963e" },
+                    "function": { "color": "#2b685e" },
+                    "keyword": { "color": "#4c963e" },
+                    "link_uri": { "color": "#883e96" },
+                    "tag": { "color": "#3e4c96" },
+                    "number": { "color": "#3e4c96" },
+                    "attribute": { "color": "#3e4c96" },
+                    "variable": { "color": "#81b5ac" },
+                    "type": { "color": "#81b5ac" },
+                    "operator": { "color": "#4c963e" },
+                    "string": { "color": "#4c963e" },
+                    "string.escape": { "color": "#4c963e" },
+                    "string.regex": { "color": "#4c963e" },
+                    "string.special": { "color": "#4c963e" },
+                    "punctuation.bracket": { "color": "#81b5ac" },
+                    "punctuation.delimiter": { "color": "#81b5ac" },
+                    "punctuation.special": { "color": "#81b5ac" }
+                }
+            }
+        },
+        {
+            "name": "Apathy Light",
+            "appearance": "light",
+            "style": {
+                "background": "#d2e7e4",
+                "editor.background": "#d2e7e4",
+                "text": "#184e45",
+                "text.accent": "#96883e",
+                "text.muted": "#81b5ac",
+                "status_bar.background": "#81b5ac",
+                "tab_bar.background": "#d2e7e4",
+                "tab.inactive_background": "#d2e7e4",
+                "editor.line_number": "#81b5ac",
+                "border": "#81b5ac",
+                "conflict.background": "#ed80a1",
+                "search.match_background": "#81b5ac",
+                "error": "#3e9688",
+                "warning": "#3e4c96",
+                "info": "#96883e",
+                "hint": "#96883e",
+                "players": [
+                    {
+                        "cursor": "#184e45",
+                        "selection": "#81b5ac"
+                    }
+                ],
+                "syntax": {
+                    "boolean": { "color": "#4c963e" },
+                    "comment": { "color": "#81b5ac" },
+                    "comment.documentation": { "color": "#81b5ac" },
+                    "constant": { "color": "#4c963e" },
+                    "function": { "color": "#96883e" },
+                    "keyword": { "color": "#4c963e" },
+                    "link_uri": { "color": "#96883e" },
+                    "tag": { "color": "#96883e" },
+                    "number": { "color": "#3e4c96" },
+                    "attribute": { "color": "#96883e" },
+                    "variable": { "color": "#184e45" },
+                    "type": { "color": "#883e96" },
+                    "operator": { "color": "#4c963e" },
+                    "string": { "color": "#883e96" },
+                    "string.escape": { "color": "#96883e" },
+                    "string.regex": { "color": "#963e4c" },
+                    "string.special": { "color": "#96883e" },
+                    "punctuation.bracket": { "color": "#184e45" },
+                    "punctuation.delimiter": { "color": "#184e45" },
+                    "punctuation.special": { "color": "#184e45" }
+                }
+            }
+        }
+    ]
+}

--- a/themes/ayu.json
+++ b/themes/ayu.json
@@ -1,0 +1,1183 @@
+{
+  "$schema": "https://zed.dev/schema/themes/v0.2.0.json",
+  "name": "Ayu",
+  "author": "Zed Industries",
+  "themes": [
+    {
+      "name": "Ayu Dark",
+      "appearance": "dark",
+      "style": {
+        "border": "#3f4043ff",
+        "border.variant": "#2d2f34ff",
+        "border.focused": "#1b4a6eff",
+        "border.selected": "#1b4a6eff",
+        "border.transparent": "#00000000",
+        "border.disabled": "#383a3eff",
+        "elevated_surface.background": "#1f2127ff",
+        "surface.background": "#1f2127ff",
+        "background": "#313337ff",
+        "element.background": "#1f2127ff",
+        "element.hover": "#2d2f34ff",
+        "element.active": "#3e4043ff",
+        "element.selected": "#3e4043ff",
+        "element.disabled": "#1f2127ff",
+        "drop_target.background": "#8a898680",
+        "ghost_element.background": "#00000000",
+        "ghost_element.hover": "#2d2f34ff",
+        "ghost_element.active": "#3e4043ff",
+        "ghost_element.selected": "#3e4043ff",
+        "ghost_element.disabled": "#1f2127ff",
+        "text": "#bfbdb6ff",
+        "text.muted": "#8a8986ff",
+        "text.placeholder": "#696a6aff",
+        "text.disabled": "#696a6aff",
+        "text.accent": "#5ac1feff",
+        "icon": "#bfbdb6ff",
+        "icon.muted": "#8a8986ff",
+        "icon.disabled": "#696a6aff",
+        "icon.placeholder": "#8a8986ff",
+        "icon.accent": "#5ac1feff",
+        "status_bar.background": "#313337ff",
+        "title_bar.background": "#313337ff",
+        "title_bar.inactive_background": "#1f2127ff",
+        "toolbar.background": "#0d1016ff",
+        "tab_bar.background": "#1f2127ff",
+        "tab.inactive_background": "#1f2127ff",
+        "tab.active_background": "#0d1016ff",
+        "search.match_background": "#5ac2fe66",
+        "search.active_match_background": "#ea570166",
+        "panel.background": "#1f2127ff",
+        "panel.focused_border": "#5ac1feff",
+        "pane.focused_border": null,
+        "scrollbar.thumb.background": "#bfbdb64c",
+        "scrollbar.thumb.hover_background": "#2d2f34ff",
+        "scrollbar.thumb.border": "#2d2f34ff",
+        "scrollbar.track.background": "#00000000",
+        "scrollbar.track.border": "#1b1e24ff",
+        "editor.foreground": "#bfbdb6ff",
+        "editor.background": "#0d1016ff",
+        "editor.gutter.background": "#0d1016ff",
+        "editor.subheader.background": "#1f2127ff",
+        "editor.active_line.background": "#1f2127bf",
+        "editor.highlighted_line.background": "#1f2127ff",
+        "editor.line_number": "#4b4c4e",
+        "editor.active_line_number": "#cbcccd",
+        "editor.hover_line_number": "#a1a2a5",
+        "editor.invisible": "#666767ff",
+        "editor.wrap_guide": "#bfbdb60d",
+        "editor.active_wrap_guide": "#bfbdb61a",
+        "editor.document_highlight.read_background": "#5ac1fe1a",
+        "editor.document_highlight.write_background": "#66676766",
+        "terminal.background": "#0d1016ff",
+        "terminal.foreground": "#bfbdb6ff",
+        "terminal.bright_foreground": "#bfbdb6ff",
+        "terminal.dim_foreground": "#0d1016ff",
+        "terminal.ansi.black": "#0d1016ff",
+        "terminal.ansi.bright_black": "#545557ff",
+        "terminal.ansi.dim_black": "#bfbdb6ff",
+        "terminal.ansi.red": "#ef7177ff",
+        "terminal.ansi.bright_red": "#83353bff",
+        "terminal.ansi.dim_red": "#febab9ff",
+        "terminal.ansi.green": "#aad84cff",
+        "terminal.ansi.bright_green": "#567627ff",
+        "terminal.ansi.dim_green": "#d8eca8ff",
+        "terminal.ansi.yellow": "#feb454ff",
+        "terminal.ansi.bright_yellow": "#92582bff",
+        "terminal.ansi.dim_yellow": "#ffd9aaff",
+        "terminal.ansi.blue": "#5ac1feff",
+        "terminal.ansi.bright_blue": "#27618cff",
+        "terminal.ansi.dim_blue": "#b7dffeff",
+        "terminal.ansi.magenta": "#39bae5ff",
+        "terminal.ansi.bright_magenta": "#205a78ff",
+        "terminal.ansi.dim_magenta": "#addcf3ff",
+        "terminal.ansi.cyan": "#95e5cbff",
+        "terminal.ansi.bright_cyan": "#4c806fff",
+        "terminal.ansi.dim_cyan": "#cbf2e4ff",
+        "terminal.ansi.white": "#bfbdb6ff",
+        "terminal.ansi.bright_white": "#fafafaff",
+        "terminal.ansi.dim_white": "#787876ff",
+        "link_text.hover": "#5ac1feff",
+        "conflict": "#feb454ff",
+        "conflict.background": "#572815ff",
+        "conflict.border": "#754221ff",
+        "created": "#aad84cff",
+        "created.background": "#294113ff",
+        "created.border": "#405c1cff",
+        "deleted": "#ef7177ff",
+        "deleted.background": "#48161bff",
+        "deleted.border": "#66272dff",
+        "error": "#ef7177ff",
+        "error.background": "#48161bff",
+        "error.border": "#66272dff",
+        "hidden": "#696a6aff",
+        "hidden.background": "#313337ff",
+        "hidden.border": "#383a3eff",
+        "hint": "#628b80ff",
+        "hint.background": "#0d2f4eff",
+        "hint.border": "#1b4a6eff",
+        "ignored": "#696a6aff",
+        "ignored.background": "#313337ff",
+        "ignored.border": "#3f4043ff",
+        "info": "#5ac1feff",
+        "info.background": "#0d2f4eff",
+        "info.border": "#1b4a6eff",
+        "modified": "#feb454ff",
+        "modified.background": "#572815ff",
+        "modified.border": "#754221ff",
+        "predictive": "#5a728bff",
+        "predictive.background": "#294113ff",
+        "predictive.border": "#405c1cff",
+        "renamed": "#5ac1feff",
+        "renamed.background": "#0d2f4eff",
+        "renamed.border": "#1b4a6eff",
+        "success": "#aad84cff",
+        "success.background": "#294113ff",
+        "success.border": "#405c1cff",
+        "unreachable": "#8a8986ff",
+        "unreachable.background": "#313337ff",
+        "unreachable.border": "#3f4043ff",
+        "warning": "#feb454ff",
+        "warning.background": "#572815ff",
+        "warning.border": "#754221ff",
+        "players": [
+          {
+            "cursor": "#5ac1feff",
+            "background": "#5ac1feff",
+            "selection": "#5ac1fe3d"
+          },
+          {
+            "cursor": "#39bae5ff",
+            "background": "#39bae5ff",
+            "selection": "#39bae53d"
+          },
+          {
+            "cursor": "#fe8f40ff",
+            "background": "#fe8f40ff",
+            "selection": "#fe8f403d"
+          },
+          {
+            "cursor": "#d2a6feff",
+            "background": "#d2a6feff",
+            "selection": "#d2a6fe3d"
+          },
+          {
+            "cursor": "#95e5cbff",
+            "background": "#95e5cbff",
+            "selection": "#95e5cb3d"
+          },
+          {
+            "cursor": "#ef7177ff",
+            "background": "#ef7177ff",
+            "selection": "#ef71773d"
+          },
+          {
+            "cursor": "#feb454ff",
+            "background": "#feb454ff",
+            "selection": "#feb4543d"
+          },
+          {
+            "cursor": "#aad84cff",
+            "background": "#aad84cff",
+            "selection": "#aad84c3d"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": "#5ac1feff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#d2a6ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#5c6773ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#8c8b88ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#d2a6ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#5ac1feff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#bfbdb6ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": "#5ac1feff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": "#5ac1feff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "enum": {
+            "color": "#fe8f40ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function": {
+            "color": "#ffb353ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "hint": {
+            "color": "#628b80ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword": {
+            "color": "#ff8f3fff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#5ac1feff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#fe8f40ff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#aad84cff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#bfbdb6ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#d2a6ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#f29668ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predictive": {
+            "color": "#5a728bff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#bfbdb6ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "#bfbdb6ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#5ac1feff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#a6a5a0ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#a6a5a0ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#a6a5a0ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#a6a5a0ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.markup": {
+            "color": "#a6a5a0ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#d2a6ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector": {
+            "color": "#d2a6ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector.pseudo": {
+            "color": "#5ac1feff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#a9d94bff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#8c8b88ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#95e6cbff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#e5b572ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#fe8f40ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#5ac1feff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#fe8f40ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#bfbdb6ff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "type": {
+            "color": "#59c2ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#bfbdb6ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variant": {
+            "color": "#5ac1feff",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    },
+    {
+      "name": "Ayu Light",
+      "appearance": "light",
+      "style": {
+        "border": "#cfd1d2ff",
+        "border.variant": "#dfe0e1ff",
+        "border.focused": "#c4daf6ff",
+        "border.selected": "#c4daf6ff",
+        "border.transparent": "#00000000",
+        "border.disabled": "#d5d6d8ff",
+        "elevated_surface.background": "#ececedff",
+        "surface.background": "#ececedff",
+        "background": "#dcdddeff",
+        "element.background": "#ececedff",
+        "element.hover": "#dfe0e1ff",
+        "element.active": "#cfd0d2ff",
+        "element.selected": "#cfd0d2ff",
+        "element.disabled": "#ececedff",
+        "drop_target.background": "#8b8e9280",
+        "ghost_element.background": "#00000000",
+        "ghost_element.hover": "#dfe0e1ff",
+        "ghost_element.active": "#cfd0d2ff",
+        "ghost_element.selected": "#cfd0d2ff",
+        "ghost_element.disabled": "#ececedff",
+        "text": "#5c6166ff",
+        "text.muted": "#8b8e92ff",
+        "text.placeholder": "#a9acaeff",
+        "text.disabled": "#a9acaeff",
+        "text.accent": "#3b9ee5ff",
+        "icon": "#5c6166ff",
+        "icon.muted": "#8b8e92ff",
+        "icon.disabled": "#a9acaeff",
+        "icon.placeholder": "#8b8e92ff",
+        "icon.accent": "#3b9ee5ff",
+        "status_bar.background": "#dcdddeff",
+        "title_bar.background": "#dcdddeff",
+        "title_bar.inactive_background": "#ececedff",
+        "toolbar.background": "#fcfcfcff",
+        "tab_bar.background": "#ececedff",
+        "tab.inactive_background": "#ececedff",
+        "tab.active_background": "#fcfcfcff",
+        "search.match_background": "#3b9ee566",
+        "search.active_match_background": "#f88b3666",
+        "panel.background": "#ececedff",
+        "panel.focused_border": "#3b9ee5ff",
+        "pane.focused_border": null,
+        "scrollbar.thumb.background": "#5c61664c",
+        "scrollbar.thumb.hover_background": "#dfe0e1ff",
+        "scrollbar.thumb.border": "#dfe0e1ff",
+        "scrollbar.track.background": "#00000000",
+        "scrollbar.track.border": "#efeff0ff",
+        "editor.foreground": "#5c6166ff",
+        "editor.background": "#fcfcfcff",
+        "editor.gutter.background": "#fcfcfcff",
+        "editor.subheader.background": "#ececedff",
+        "editor.active_line.background": "#ececedbf",
+        "editor.highlighted_line.background": "#ececedff",
+        "editor.line_number": "#b0b3b5",
+        "editor.active_line_number": "#313435",
+        "editor.hover_line_number": "#62686a",
+        "editor.invisible": "#acafb1ff",
+        "editor.wrap_guide": "#5c61660d",
+        "editor.active_wrap_guide": "#5c61661a",
+        "editor.document_highlight.read_background": "#3b9ee51a",
+        "editor.document_highlight.write_background": "#acafb166",
+        "terminal.background": "#fcfcfcff",
+        "terminal.foreground": "#5c6166ff",
+        "terminal.bright_foreground": "#5c6166ff",
+        "terminal.dim_foreground": "#fcfcfcff",
+        "terminal.ansi.black": "#5c6166ff",
+        "terminal.ansi.bright_black": "#3b9ee5ff",
+        "terminal.ansi.dim_black": "#9c9fa2ff",
+        "terminal.ansi.red": "#ef7271ff",
+        "terminal.ansi.bright_red": "#febab6ff",
+        "terminal.ansi.dim_red": "#833538ff",
+        "terminal.ansi.green": "#85b304ff",
+        "terminal.ansi.bright_green": "#c7d98fff",
+        "terminal.ansi.dim_green": "#445613ff",
+        "terminal.ansi.yellow": "#f1ad49ff",
+        "terminal.ansi.bright_yellow": "#fed5a3ff",
+        "terminal.ansi.dim_yellow": "#8a5227ff",
+        "terminal.ansi.blue": "#3b9ee5ff",
+        "terminal.ansi.bright_blue": "#abcdf2ff",
+        "terminal.ansi.dim_blue": "#214c76ff",
+        "terminal.ansi.magenta": "#55b4d3ff",
+        "terminal.ansi.bright_magenta": "#b1d8e8ff",
+        "terminal.ansi.dim_magenta": "#2f5669ff",
+        "terminal.ansi.cyan": "#4dbf99ff",
+        "terminal.ansi.bright_cyan": "#ace0cbff",
+        "terminal.ansi.dim_cyan": "#2a5f4aff",
+        "terminal.ansi.white": "#fcfcfcff",
+        "terminal.ansi.bright_white": "#ffffffff",
+        "terminal.ansi.dim_white": "#bcbec0ff",
+        "link_text.hover": "#3b9ee5ff",
+        "conflict": "#f1ad49ff",
+        "conflict.background": "#ffeedaff",
+        "conflict.border": "#ffe1beff",
+        "created": "#85b304ff",
+        "created.background": "#e9efd2ff",
+        "created.border": "#d7e3aeff",
+        "deleted": "#ef7271ff",
+        "deleted.background": "#ffe3e1ff",
+        "deleted.border": "#ffcdcaff",
+        "error": "#ef7271ff",
+        "error.background": "#ffe3e1ff",
+        "error.border": "#ffcdcaff",
+        "hidden": "#a9acaeff",
+        "hidden.background": "#dcdddeff",
+        "hidden.border": "#d5d6d8ff",
+        "hint": "#8ca7c2ff",
+        "hint.background": "#deebfaff",
+        "hint.border": "#c4daf6ff",
+        "ignored": "#a9acaeff",
+        "ignored.background": "#dcdddeff",
+        "ignored.border": "#cfd1d2ff",
+        "info": "#3b9ee5ff",
+        "info.background": "#deebfaff",
+        "info.border": "#c4daf6ff",
+        "modified": "#f1ad49ff",
+        "modified.background": "#ffeedaff",
+        "modified.border": "#ffe1beff",
+        "predictive": "#9eb9d3ff",
+        "predictive.background": "#e9efd2ff",
+        "predictive.border": "#d7e3aeff",
+        "renamed": "#3b9ee5ff",
+        "renamed.background": "#deebfaff",
+        "renamed.border": "#c4daf6ff",
+        "success": "#85b304ff",
+        "success.background": "#e9efd2ff",
+        "success.border": "#d7e3aeff",
+        "unreachable": "#8b8e92ff",
+        "unreachable.background": "#dcdddeff",
+        "unreachable.border": "#cfd1d2ff",
+        "warning": "#f1ad49ff",
+        "warning.background": "#ffeedaff",
+        "warning.border": "#ffe1beff",
+        "players": [
+          {
+            "cursor": "#3b9ee5ff",
+            "background": "#3b9ee5ff",
+            "selection": "#3b9ee53d"
+          },
+          {
+            "cursor": "#55b4d3ff",
+            "background": "#55b4d3ff",
+            "selection": "#55b4d33d"
+          },
+          {
+            "cursor": "#f98d3fff",
+            "background": "#f98d3fff",
+            "selection": "#f98d3f3d"
+          },
+          {
+            "cursor": "#a37accff",
+            "background": "#a37accff",
+            "selection": "#a37acc3d"
+          },
+          {
+            "cursor": "#4dbf99ff",
+            "background": "#4dbf99ff",
+            "selection": "#4dbf993d"
+          },
+          {
+            "cursor": "#ef7271ff",
+            "background": "#ef7271ff",
+            "selection": "#ef72713d"
+          },
+          {
+            "cursor": "#f1ad49ff",
+            "background": "#f1ad49ff",
+            "selection": "#f1ad493d"
+          },
+          {
+            "cursor": "#85b304ff",
+            "background": "#85b304ff",
+            "selection": "#85b3043d"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": "#3b9ee5ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#a37accff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#abb0b6ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#898d90ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#a37accff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#3b9ee5ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#5c6166ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": "#3b9ee5ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": "#3b9ee5ff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "enum": {
+            "color": "#f98d3fff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function": {
+            "color": "#f2ad48ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "hint": {
+            "color": "#8ca7c2ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword": {
+            "color": "#fa8d3eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#3b9ee5ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#f98d3fff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#85b304ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#5c6166ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#a37accff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#ed9365ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predictive": {
+            "color": "#9eb9d3ff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#5c6166ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "#5c6166ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#3b9ee5ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#73777bff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#73777bff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#73777bff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#73777bff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.markup": {
+            "color": "#73777bff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#a37accff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector": {
+            "color": "#a37accff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector.pseudo": {
+            "color": "#3b9ee5ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#86b300ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#898d90ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#4bbf98ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#e6ba7eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#f98d3fff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#3b9ee5ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#f98d3fff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#5c6166ff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "type": {
+            "color": "#389ee6ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#5c6166ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variant": {
+            "color": "#3b9ee5ff",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    },
+    {
+      "name": "Ayu Mirage",
+      "appearance": "dark",
+      "style": {
+        "border": "#53565dff",
+        "border.variant": "#43464fff",
+        "border.focused": "#24556fff",
+        "border.selected": "#24556fff",
+        "border.transparent": "#00000000",
+        "border.disabled": "#4d5058ff",
+        "elevated_surface.background": "#353944ff",
+        "surface.background": "#353944ff",
+        "background": "#464a52ff",
+        "element.background": "#353944ff",
+        "element.hover": "#43464fff",
+        "element.active": "#53565dff",
+        "element.selected": "#53565dff",
+        "element.disabled": "#353944ff",
+        "drop_target.background": "#9a9a9880",
+        "ghost_element.background": "#00000000",
+        "ghost_element.hover": "#43464fff",
+        "ghost_element.active": "#53565dff",
+        "ghost_element.selected": "#53565dff",
+        "ghost_element.disabled": "#353944ff",
+        "text": "#cccac2ff",
+        "text.muted": "#9a9a98ff",
+        "text.placeholder": "#7b7d7fff",
+        "text.disabled": "#7b7d7fff",
+        "text.accent": "#72cffeff",
+        "icon": "#cccac2ff",
+        "icon.muted": "#9a9a98ff",
+        "icon.disabled": "#7b7d7fff",
+        "icon.placeholder": "#9a9a98ff",
+        "icon.accent": "#72cffeff",
+        "status_bar.background": "#464a52ff",
+        "title_bar.background": "#464a52ff",
+        "title_bar.inactive_background": "#353944ff",
+        "toolbar.background": "#242835ff",
+        "tab_bar.background": "#353944ff",
+        "tab.inactive_background": "#353944ff",
+        "tab.active_background": "#242835ff",
+        "search.match_background": "#73cffe66",
+        "search.active_match_background": "#fd722b66",
+        "panel.background": "#353944ff",
+        "panel.focused_border": null,
+        "pane.focused_border": null,
+        "scrollbar.thumb.background": "#cccac24c",
+        "scrollbar.thumb.hover_background": "#43464fff",
+        "scrollbar.thumb.border": "#43464fff",
+        "scrollbar.track.background": "#00000000",
+        "scrollbar.track.border": "#323641ff",
+        "editor.foreground": "#cccac2ff",
+        "editor.background": "#242835ff",
+        "editor.gutter.background": "#242835ff",
+        "editor.subheader.background": "#353944ff",
+        "editor.active_line.background": "#353944bf",
+        "editor.highlighted_line.background": "#353944ff",
+        "editor.line_number": "#575c6b",
+        "editor.active_line_number": "#e1e3ea",
+        "editor.hover_line_number": "#b2b6c8",
+        "editor.invisible": "#787a7cff",
+        "editor.wrap_guide": "#cccac20d",
+        "editor.active_wrap_guide": "#cccac21a",
+        "editor.document_highlight.read_background": "#72cffe1a",
+        "editor.document_highlight.write_background": "#787a7c66",
+        "terminal.background": "#242835ff",
+        "terminal.foreground": "#cccac2ff",
+        "terminal.bright_foreground": "#cccac2ff",
+        "terminal.dim_foreground": "#242835ff",
+        "terminal.ansi.black": "#242835ff",
+        "terminal.ansi.bright_black": "#67696eff",
+        "terminal.ansi.dim_black": "#cccac2ff",
+        "terminal.ansi.red": "#f18779ff",
+        "terminal.ansi.bright_red": "#833f3cff",
+        "terminal.ansi.dim_red": "#fec4baff",
+        "terminal.ansi.green": "#d5fe80ff",
+        "terminal.ansi.bright_green": "#75993cff",
+        "terminal.ansi.dim_green": "#ecffc1ff",
+        "terminal.ansi.yellow": "#fecf72ff",
+        "terminal.ansi.bright_yellow": "#937237ff",
+        "terminal.ansi.dim_yellow": "#ffe7b9ff",
+        "terminal.ansi.blue": "#72cffeff",
+        "terminal.ansi.bright_blue": "#336d8dff",
+        "terminal.ansi.dim_blue": "#c1e7ffff",
+        "terminal.ansi.magenta": "#5bcde5ff",
+        "terminal.ansi.bright_magenta": "#2b6c7bff",
+        "terminal.ansi.dim_magenta": "#b7e7f2ff",
+        "terminal.ansi.cyan": "#95e5cbff",
+        "terminal.ansi.bright_cyan": "#4c806fff",
+        "terminal.ansi.dim_cyan": "#cbf2e4ff",
+        "terminal.ansi.white": "#cccac2ff",
+        "terminal.ansi.bright_white": "#fafafaff",
+        "terminal.ansi.dim_white": "#898a8aff",
+        "link_text.hover": "#72cffeff",
+        "conflict": "#fecf72ff",
+        "conflict.background": "#574018ff",
+        "conflict.border": "#765a29ff",
+        "created": "#d5fe80ff",
+        "created.background": "#426117ff",
+        "created.border": "#5d7e2cff",
+        "deleted": "#f18779ff",
+        "deleted.background": "#481a1bff",
+        "deleted.border": "#662e2dff",
+        "error": "#f18779ff",
+        "error.background": "#481a1bff",
+        "error.border": "#662e2dff",
+        "hidden": "#7b7d7fff",
+        "hidden.background": "#464a52ff",
+        "hidden.border": "#4d5058ff",
+        "hint": "#7399a3ff",
+        "hint.background": "#123950ff",
+        "hint.border": "#24556fff",
+        "ignored": "#7b7d7fff",
+        "ignored.background": "#464a52ff",
+        "ignored.border": "#53565dff",
+        "info": "#72cffeff",
+        "info.background": "#123950ff",
+        "info.border": "#24556fff",
+        "modified": "#fecf72ff",
+        "modified.background": "#574018ff",
+        "modified.border": "#765a29ff",
+        "predictive": "#6d839bff",
+        "predictive.background": "#426117ff",
+        "predictive.border": "#5d7e2cff",
+        "renamed": "#72cffeff",
+        "renamed.background": "#123950ff",
+        "renamed.border": "#24556fff",
+        "success": "#d5fe80ff",
+        "success.background": "#426117ff",
+        "success.border": "#5d7e2cff",
+        "unreachable": "#9a9a98ff",
+        "unreachable.background": "#464a52ff",
+        "unreachable.border": "#53565dff",
+        "warning": "#fecf72ff",
+        "warning.background": "#574018ff",
+        "warning.border": "#765a29ff",
+        "players": [
+          {
+            "cursor": "#72cffeff",
+            "background": "#72cffeff",
+            "selection": "#72cffe3d"
+          },
+          {
+            "cursor": "#5bcde5ff",
+            "background": "#5bcde5ff",
+            "selection": "#5bcde53d"
+          },
+          {
+            "cursor": "#fead66ff",
+            "background": "#fead66ff",
+            "selection": "#fead663d"
+          },
+          {
+            "cursor": "#debffeff",
+            "background": "#debffeff",
+            "selection": "#debffe3d"
+          },
+          {
+            "cursor": "#95e5cbff",
+            "background": "#95e5cbff",
+            "selection": "#95e5cb3d"
+          },
+          {
+            "cursor": "#f18779ff",
+            "background": "#f18779ff",
+            "selection": "#f187793d"
+          },
+          {
+            "cursor": "#fecf72ff",
+            "background": "#fecf72ff",
+            "selection": "#fecf723d"
+          },
+          {
+            "cursor": "#d5fe80ff",
+            "background": "#d5fe80ff",
+            "selection": "#d5fe803d"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": "#72cffeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#dfbfffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#5c6773ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#9b9b99ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#dfbfffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#72cffeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#cccac2ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": "#72cffeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": "#72cffeff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "enum": {
+            "color": "#fead66ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function": {
+            "color": "#ffd173ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "hint": {
+            "color": "#7399a3ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword": {
+            "color": "#ffad65ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#72cffeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#fead66ff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#d5fe80ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#cccac2ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#dfbfffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#f29e74ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predictive": {
+            "color": "#6d839bff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#cccac2ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "#cccac2ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#72cffeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#b4b3aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#b4b3aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#b4b3aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#b4b3aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.markup": {
+            "color": "#b4b3aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#dfbfffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector": {
+            "color": "#dfbfffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector.pseudo": {
+            "color": "#72cffeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#d4fe7fff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#9b9b99ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#95e6cbff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#ffdfb3ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#fead66ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#72cffeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#fead66ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#cccac2ff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "type": {
+            "color": "#73cfffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#cccac2ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variant": {
+            "color": "#72cffeff",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    }
+  ]
+}

--- a/themes/catppuccin-mauve.json
+++ b/themes/catppuccin-mauve.json
@@ -1,0 +1,2883 @@
+{
+    "$schema": "https://zed.dev/schema/themes/v0.2.0.json",
+    "name": "Catppuccin",
+    "author": "Catppuccin <releases@catppuccin.com>",
+    "themes": [
+        {
+            "name": "Catppuccin Latte",
+            "appearance": "light",
+            "style": {
+                "accents": [
+                    "#7c3ed466",
+                    "#6a7cdf66",
+                    "#298fa666",
+                    "#42903766",
+                    "#c1822c66",
+                    "#da601e66",
+                    "#b71c4366"
+                ],
+                "vim.mode.text": "#dce0e8",
+                "vim.normal.background": "#dc8a78",
+                "vim.helix_normal.background": "#dc8a78",
+                "vim.visual.background": "#7287fd",
+                "vim.helix_select.background": "#7287fd",
+                "vim.insert.background": "#40a02b",
+                "vim.visual_line.background": "#7287fd",
+                "vim.visual_block.background": "#8839ef",
+                "vim.replace.background": "#e64553",
+                "background.appearance": "opaque",
+                "border": "#ccd0da",
+                "border.variant": "#9658eb",
+                "border.focused": "#7287fd",
+                "border.selected": "#8839ef",
+                "border.transparent": "#40a02b",
+                "border.disabled": "#9ca0b0",
+                "elevated_surface.background": "#e6e9ef",
+                "surface.background": "#e6e9ef",
+                "background": "#d7dce5",
+                "element.background": "#dce0e8",
+                "element.hover": "#ccd0da",
+                "element.active": "#acb0be4d",
+                "element.selected": "#ccd0da4d",
+                "element.disabled": "#9ca0b0",
+                "drop_target.background": "#ccd0da66",
+                "ghost_element.background": "#00000000",
+                "ghost_element.hover": "#bcc0cc4d",
+                "ghost_element.active": "#acb0be99",
+                "ghost_element.selected": "#8f94a766",
+                "ghost_element.disabled": "#9ca0b0",
+                "text": "#4c4f69",
+                "text.muted": "#5c5f77",
+                "text.placeholder": "#acb0be",
+                "text.disabled": "#bcc0cc",
+                "text.accent": "#8839ef",
+                "icon": "#4c4f69",
+                "icon.muted": "#8c8fa1",
+                "icon.disabled": "#9ca0b0",
+                "icon.placeholder": "#acb0be",
+                "icon.accent": "#8839ef",
+                "status_bar.background": "#dce0e8",
+                "title_bar.background": "#dce0e8",
+                "title_bar.inactive_background": "#e6e9ee",
+                "toolbar.background": "#eff1f5",
+                "tab_bar.background": "#dce0e8",
+                "tab.inactive_background": "#d2d7e2",
+                "tab.active_background": "#eff1f5",
+                "search.match_background": "#17929933",
+                "panel.background": "#e6e9ef",
+                "panel.focused_border": "#4c4f69",
+                "panel.indent_guide": "#ccd0da99",
+                "panel.indent_guide_active": "#acb0be",
+                "panel.indent_guide_hover": "#8839ef",
+                "panel.overlay_background": "#dce0e8",
+                "pane.focused_border": "#4c4f69",
+                "pane_group.border": "#ccd0da",
+                "scrollbar.thumb.background": "#acb0be80",
+                "scrollbar.thumb.hover_background": "#9ca0b0",
+                "scrollbar.thumb.active_background": null,
+                "scrollbar.thumb.border": null,
+                "scrollbar.track.background": "#dce0e8",
+                "scrollbar.track.border": "#4c4f6912",
+                "minimap.thumb.background": "#8839ef33",
+                "minimap.thumb.hover_background": "#8839ef66",
+                "minimap.thumb.active_background": "#8839ef99",
+                "minimap.thumb.border": null,
+                "editor.foreground": "#4c4f69",
+                "editor.background": "#eff1f5",
+                "editor.gutter.background": "#eff1f5",
+                "editor.subheader.background": "#e6e9ef",
+                "editor.active_line.background": "#4c4f6912",
+                "editor.highlighted_line.background": null,
+                "editor.line_number": "#8c8fa1",
+                "editor.active_line_number": "#8839ef",
+                "editor.invisible": "#7c7f9366",
+                "editor.wrap_guide": "#acb0be",
+                "editor.active_wrap_guide": "#acb0be",
+                "editor.document_highlight.bracket_background": "#8839ef17",
+                "editor.document_highlight.read_background": "#6c6f8529",
+                "editor.document_highlight.write_background": "#6c6f8529",
+                "editor.indent_guide": "#ccd0da99",
+                "editor.indent_guide_active": "#acb0be",
+                "terminal.background": "#eff1f5",
+                "terminal.ansi.background": "#eff1f5",
+                "terminal.foreground": "#4c4f69",
+                "terminal.dim_foreground": "#8c8fa1",
+                "terminal.bright_foreground": "#4c4f69",
+                "terminal.ansi.black": "#5c5f77",
+                "terminal.ansi.white": "#acb0be",
+                "terminal.ansi.red": "#d20f39",
+                "terminal.ansi.green": "#40a02b",
+                "terminal.ansi.yellow": "#df8e1d",
+                "terminal.ansi.blue": "#1e66f5",
+                "terminal.ansi.magenta": "#ea76cb",
+                "terminal.ansi.cyan": "#179299",
+                "terminal.ansi.bright_black": "#6c6f85",
+                "terminal.ansi.bright_white": "#bcc0cc",
+                "terminal.ansi.bright_red": "#de293e",
+                "terminal.ansi.bright_green": "#49af3d",
+                "terminal.ansi.bright_yellow": "#eea02d",
+                "terminal.ansi.bright_blue": "#456eff",
+                "terminal.ansi.bright_magenta": "#fe85d8",
+                "terminal.ansi.bright_cyan": "#2d9fa8",
+                "terminal.ansi.dim_black": "#5c5f77",
+                "terminal.ansi.dim_white": "#acb0be",
+                "terminal.ansi.dim_red": "#d20f39",
+                "terminal.ansi.dim_green": "#40a02b",
+                "terminal.ansi.dim_yellow": "#df8e1d",
+                "terminal.ansi.dim_blue": "#1e66f5",
+                "terminal.ansi.dim_magenta": "#ea76cb",
+                "terminal.ansi.dim_cyan": "#179299",
+                "link_text.hover": "#04a5e5",
+                "conflict": "#fe640b",
+                "conflict.border": "#fe640b",
+                "conflict.background": "#fe640b26",
+                "created": "#40a02b",
+                "created.border": "#40a02b",
+                "created.background": "#40a02b26",
+                "deleted": "#d20f39",
+                "deleted.border": "#d20f39",
+                "deleted.background": "#d20f3926",
+                "hidden": "#9ca0b0",
+                "hidden.border": "#9ca0b0",
+                "hidden.background": "#e6e9ef",
+                "hint": "#acb0be",
+                "hint.border": "#acb0be",
+                "hint.background": "#e6e9ef",
+                "ignored": "#9ca0b0",
+                "ignored.border": "#9ca0b0",
+                "ignored.background": "#9ca0b026",
+                "modified": "#df8e1d",
+                "modified.border": "#df8e1d",
+                "modified.background": "#df8e1d26",
+                "predictive": "#9ca0b0",
+                "predictive.border": "#7287fd",
+                "predictive.background": "#e6e9ef",
+                "renamed": "#209fb5",
+                "renamed.border": "#209fb5",
+                "renamed.background": "#209fb526",
+                "info": "#179299",
+                "info.border": "#179299",
+                "info.background": "#7c7f9333",
+                "warning": "#df8e1d",
+                "warning.border": "#df8e1d",
+                "warning.background": "#df8e1d1f",
+                "error": "#d20f39",
+                "error.border": "#d20f39",
+                "error.background": "#d20f391f",
+                "success": "#40a02b",
+                "success.border": "#40a02b",
+                "success.background": "#40a02b1f",
+                "unreachable": "#d20f39",
+                "unreachable.border": "#d20f39",
+                "unreachable.background": "#d20f391f",
+                "players": [
+                    {
+                        "cursor": "#dc8a78",
+                        "selection": "#7c7f934d",
+                        "background": "#dc8a78"
+                    },
+                    {
+                        "cursor": "#7c3ed4",
+                        "selection": "#7c3ed44d",
+                        "background": "#7c3ed4"
+                    },
+                    {
+                        "cursor": "#6a7cdf",
+                        "selection": "#6a7cdf4d",
+                        "background": "#6a7cdf"
+                    },
+                    {
+                        "cursor": "#298fa6",
+                        "selection": "#298fa64d",
+                        "background": "#298fa6"
+                    },
+                    {
+                        "cursor": "#429037",
+                        "selection": "#4290374d",
+                        "background": "#429037"
+                    },
+                    {
+                        "cursor": "#c1822c",
+                        "selection": "#c1822c4d",
+                        "background": "#c1822c"
+                    },
+                    {
+                        "cursor": "#da601e",
+                        "selection": "#da601e4d",
+                        "background": "#da601e"
+                    },
+                    {
+                        "cursor": "#b71c43",
+                        "selection": "#b71c434d",
+                        "background": "#b71c43"
+                    }
+                ],
+                "version_control.added": "#40a02b",
+                "version_control.deleted": "#d20f39",
+                "version_control.modified": "#df8e1d",
+                "version_control.renamed": "#209fb5",
+                "version_control.conflict": "#fe640b",
+                "version_control.conflict_marker.ours": "#40a02b33",
+                "version_control.conflict_marker.theirs": "#1e66f533",
+                "version_control.ignored": "#9ca0b0",
+                "debugger.accent": "#d20f39",
+                "editor.debugger_active_line.background": "#fe640b12",
+                "syntax": {
+                    "variable": {
+                        "color": "#4c4f69",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "variable.builtin": {
+                        "color": "#d20f39",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "variable.parameter": {
+                        "color": "#e64553",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "variable.member": {
+                        "color": "#1e66f5",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "variable.special": {
+                        "color": "#d20f39",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "constant": {
+                        "color": "#fe640b",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "constant.builtin": {
+                        "color": "#fe640b",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "constant.macro": {
+                        "color": "#8839ef",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "module": {
+                        "color": "#df8e1d",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "label": {
+                        "color": "#209fb5",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "string": {
+                        "color": "#40a02b",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "string.documentation": {
+                        "color": "#179299",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "string.regexp": {
+                        "color": "#fe640b",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "string.escape": {
+                        "color": "#ea76cb",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "string.special": {
+                        "color": "#ea76cb",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "string.special.path": {
+                        "color": "#ea76cb",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "string.special.symbol": {
+                        "color": "#dd7878",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "string.special.url": {
+                        "color": "#dc8a78",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "character": {
+                        "color": "#179299",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "character.special": {
+                        "color": "#ea76cb",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "boolean": {
+                        "color": "#fe640b",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "number": {
+                        "color": "#fe640b",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "number.float": {
+                        "color": "#fe640b",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "type": {
+                        "color": "#df8e1d",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "type.builtin": {
+                        "color": "#8839ef",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "type.definition": {
+                        "color": "#df8e1d",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "type.interface": {
+                        "color": "#df8e1d",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "type.super": {
+                        "color": "#df8e1d",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "attribute": {
+                        "color": "#fe640b",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "property": {
+                        "color": "#1e66f5",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "function": {
+                        "color": "#1e66f5",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "function.builtin": {
+                        "color": "#fe640b",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "function.call": {
+                        "color": "#1e66f5",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "function.macro": {
+                        "color": "#179299",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "function.method": {
+                        "color": "#1e66f5",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "function.method.call": {
+                        "color": "#1e66f5",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "constructor": {
+                        "color": "#dd7878",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "operator": {
+                        "color": "#04a5e5",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword": {
+                        "color": "#8839ef",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.modifier": {
+                        "color": "#8839ef",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.type": {
+                        "color": "#8839ef",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.coroutine": {
+                        "color": "#8839ef",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.function": {
+                        "color": "#8839ef",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.operator": {
+                        "color": "#8839ef",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.import": {
+                        "color": "#8839ef",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.repeat": {
+                        "color": "#8839ef",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.return": {
+                        "color": "#8839ef",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.debug": {
+                        "color": "#8839ef",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.exception": {
+                        "color": "#8839ef",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.conditional": {
+                        "color": "#8839ef",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.conditional.ternary": {
+                        "color": "#8839ef",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.directive": {
+                        "color": "#ea76cb",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.directive.define": {
+                        "color": "#ea76cb",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.export": {
+                        "color": "#04a5e5",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "punctuation": {
+                        "color": "#7c7f93",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "punctuation.delimiter": {
+                        "color": "#7c7f93",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "punctuation.bracket": {
+                        "color": "#7c7f93",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "punctuation.special": {
+                        "color": "#ea76cb",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "punctuation.special.symbol": {
+                        "color": "#dd7878",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "punctuation.list_marker": {
+                        "color": "#179299",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "comment": {
+                        "color": "#7c7f93",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "comment.doc": {
+                        "color": "#7c7f93",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "comment.documentation": {
+                        "color": "#7c7f93",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "comment.error": {
+                        "color": "#d20f39",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "comment.warning": {
+                        "color": "#df8e1d",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "comment.hint": {
+                        "color": "#1e66f5",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "comment.todo": {
+                        "color": "#dd7878",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "comment.note": {
+                        "color": "#dc8a78",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "diff.plus": {
+                        "color": "#40a02b",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "diff.minus": {
+                        "color": "#d20f39",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "tag": {
+                        "color": "#1e66f5",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "tag.attribute": {
+                        "color": "#df8e1d",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "tag.delimiter": {
+                        "color": "#179299",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "parameter": {
+                        "color": "#e64553",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "field": {
+                        "color": "#7287fd",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "namespace": {
+                        "color": "#df8e1d",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "float": {
+                        "color": "#fe640b",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "symbol": {
+                        "color": "#ea76cb",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "string.regex": {
+                        "color": "#fe640b",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "text": {
+                        "color": "#4c4f69",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "emphasis.strong": {
+                        "color": "#e64553",
+                        "font_style": null,
+                        "font_weight": 700
+                    },
+                    "emphasis": {
+                        "color": "#e64553",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "embedded": {
+                        "color": "#e64553",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "text.literal": {
+                        "color": "#40a02b",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "concept": {
+                        "color": "#209fb5",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "enum": {
+                        "color": "#179299",
+                        "font_style": null,
+                        "font_weight": 700
+                    },
+                    "function.decorator": {
+                        "color": "#fe640b",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "type.class.definition": {
+                        "color": "#df8e1d",
+                        "font_style": null,
+                        "font_weight": 700
+                    },
+
+                    "hint": {
+                        "color": "#8c8fa1",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "link_text": {
+                        "color": "#7287fd",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "link_uri": {
+                        "color": "#1e66f5",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "parent": {
+                        "color": "#fe640b",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "predictive": {
+                        "color": "#9ca0b0",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "predoc": {
+                        "color": "#d20f39",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "primary": {
+                        "color": "#e64553",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "tag.doctype": {
+                        "color": "#8839ef",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "string.doc": {
+                      "color": "#179299",
+                      "font_style": "italic",
+                      "font_weight": null
+                    },
+                    "title": {
+                        "color": "#4c4f69",
+                        "font_style": null,
+                        "font_weight": 800
+                    },
+                    "variant": {
+                        "color": "#d20f39",
+                        "font_style": null,
+                        "font_weight": null
+                    }
+                }
+            }
+        },
+        {
+            "name": "Catppuccin Frappé",
+            "appearance": "dark",
+            "style": {
+                "accents": [
+                    "#caa8e966",
+                    "#bdc0f266",
+                    "#92c4e166",
+                    "#add19f66",
+                    "#dfcaa466",
+                    "#e7a98f66",
+                    "#e1929b66"
+                ],
+                "vim.mode.text": "#232634",
+                "vim.normal.background": "#f2d5cf",
+                "vim.helix_normal.background": "#f2d5cf",
+                "vim.visual.background": "#babbf1",
+                "vim.helix_select.background": "#babbf1",
+                "vim.insert.background": "#a6d189",
+                "vim.visual_line.background": "#babbf1",
+                "vim.visual_block.background": "#ca9ee6",
+                "vim.replace.background": "#ea999c",
+                "background.appearance": "opaque",
+                "border": "#414559",
+                "border.variant": "#af8cca",
+                "border.focused": "#babbf1",
+                "border.selected": "#ca9ee6",
+                "border.transparent": "#a6d189",
+                "border.disabled": "#737994",
+                "elevated_surface.background": "#292c3c",
+                "surface.background": "#292c3c",
+                "background": "#383c52",
+                "element.background": "#232634",
+                "element.hover": "#414559",
+                "element.active": "#6268804d",
+                "element.selected": "#4145594d",
+                "element.disabled": "#737994",
+                "drop_target.background": "#41455966",
+                "ghost_element.background": "#00000000",
+                "ghost_element.hover": "#51576d4d",
+                "ghost_element.active": "#62688099",
+                "ghost_element.selected": "#7c829a66",
+                "ghost_element.disabled": "#737994",
+                "text": "#c6d0f5",
+                "text.muted": "#b5bfe2",
+                "text.placeholder": "#626880",
+                "text.disabled": "#51576d",
+                "text.accent": "#ca9ee6",
+                "icon": "#c6d0f5",
+                "icon.muted": "#838ba7",
+                "icon.disabled": "#737994",
+                "icon.placeholder": "#626880",
+                "icon.accent": "#ca9ee6",
+                "status_bar.background": "#232634",
+                "title_bar.background": "#232634",
+                "title_bar.inactive_background": "#2a2e3e",
+                "toolbar.background": "#303446",
+                "tab_bar.background": "#232634",
+                "tab.inactive_background": "#1d202b",
+                "tab.active_background": "#303446",
+                "search.match_background": "#81c8be33",
+                "panel.background": "#292c3c",
+                "panel.focused_border": "#c6d0f5",
+                "panel.indent_guide": "#41455999",
+                "panel.indent_guide_active": "#626880",
+                "panel.indent_guide_hover": "#ca9ee6",
+                "panel.overlay_background": "#232634",
+                "pane.focused_border": "#c6d0f5",
+                "pane_group.border": "#414559",
+                "scrollbar.thumb.background": "#62688080",
+                "scrollbar.thumb.hover_background": "#737994",
+                "scrollbar.thumb.active_background": null,
+                "scrollbar.thumb.border": null,
+                "scrollbar.track.background": "#232634",
+                "scrollbar.track.border": "#c6d0f512",
+                "minimap.thumb.background": "#ca9ee633",
+                "minimap.thumb.hover_background": "#ca9ee666",
+                "minimap.thumb.active_background": "#ca9ee699",
+                "minimap.thumb.border": null,
+                "editor.foreground": "#c6d0f5",
+                "editor.background": "#303446",
+                "editor.gutter.background": "#303446",
+                "editor.subheader.background": "#292c3c",
+                "editor.active_line.background": "#c6d0f512",
+                "editor.highlighted_line.background": null,
+                "editor.line_number": "#838ba7",
+                "editor.active_line_number": "#ca9ee6",
+                "editor.invisible": "#949cbb66",
+                "editor.wrap_guide": "#626880",
+                "editor.active_wrap_guide": "#626880",
+                "editor.document_highlight.bracket_background": "#ca9ee617",
+                "editor.document_highlight.read_background": "#a5adce29",
+                "editor.document_highlight.write_background": "#a5adce29",
+                "editor.indent_guide": "#41455999",
+                "editor.indent_guide_active": "#626880",
+                "terminal.background": "#303446",
+                "terminal.ansi.background": "#303446",
+                "terminal.foreground": "#c6d0f5",
+                "terminal.dim_foreground": "#838ba7",
+                "terminal.bright_foreground": "#c6d0f5",
+                "terminal.ansi.black": "#51576d",
+                "terminal.ansi.white": "#a5adce",
+                "terminal.ansi.red": "#e78284",
+                "terminal.ansi.green": "#a6d189",
+                "terminal.ansi.yellow": "#e5c890",
+                "terminal.ansi.blue": "#8caaee",
+                "terminal.ansi.magenta": "#f4b8e4",
+                "terminal.ansi.cyan": "#81c8be",
+                "terminal.ansi.bright_black": "#626880",
+                "terminal.ansi.bright_white": "#b5bfe2",
+                "terminal.ansi.bright_red": "#e67172",
+                "terminal.ansi.bright_green": "#8ec772",
+                "terminal.ansi.bright_yellow": "#d9ba73",
+                "terminal.ansi.bright_blue": "#7b9ef0",
+                "terminal.ansi.bright_magenta": "#f4b8e4",
+                "terminal.ansi.bright_cyan": "#5abfb5",
+                "terminal.ansi.dim_black": "#51576d",
+                "terminal.ansi.dim_white": "#a5adce",
+                "terminal.ansi.dim_red": "#e78284",
+                "terminal.ansi.dim_green": "#a6d189",
+                "terminal.ansi.dim_yellow": "#e5c890",
+                "terminal.ansi.dim_blue": "#8caaee",
+                "terminal.ansi.dim_magenta": "#f4b8e4",
+                "terminal.ansi.dim_cyan": "#81c8be",
+                "link_text.hover": "#99d1db",
+                "conflict": "#ef9f76",
+                "conflict.border": "#ef9f76",
+                "conflict.background": "#ef9f7626",
+                "created": "#a6d189",
+                "created.border": "#a6d189",
+                "created.background": "#a6d18926",
+                "deleted": "#e78284",
+                "deleted.border": "#e78284",
+                "deleted.background": "#e7828426",
+                "hidden": "#737994",
+                "hidden.border": "#737994",
+                "hidden.background": "#292c3c",
+                "hint": "#626880",
+                "hint.border": "#626880",
+                "hint.background": "#292c3c",
+                "ignored": "#737994",
+                "ignored.border": "#737994",
+                "ignored.background": "#73799426",
+                "modified": "#e5c890",
+                "modified.border": "#e5c890",
+                "modified.background": "#e5c89026",
+                "predictive": "#737994",
+                "predictive.border": "#babbf1",
+                "predictive.background": "#292c3c",
+                "renamed": "#85c1dc",
+                "renamed.border": "#85c1dc",
+                "renamed.background": "#85c1dc26",
+                "info": "#81c8be",
+                "info.border": "#81c8be",
+                "info.background": "#949cbb33",
+                "warning": "#e5c890",
+                "warning.border": "#e5c890",
+                "warning.background": "#e5c8901f",
+                "error": "#e78284",
+                "error.border": "#e78284",
+                "error.background": "#e782841f",
+                "success": "#a6d189",
+                "success.border": "#a6d189",
+                "success.background": "#a6d1891f",
+                "unreachable": "#e78284",
+                "unreachable.border": "#e78284",
+                "unreachable.background": "#e782841f",
+                "players": [
+                    {
+                        "cursor": "#f2d5cf",
+                        "selection": "#949cbb40",
+                        "background": "#f2d5cf"
+                    },
+                    {
+                        "cursor": "#caa8e9",
+                        "selection": "#caa8e940",
+                        "background": "#caa8e9"
+                    },
+                    {
+                        "cursor": "#bdc0f2",
+                        "selection": "#bdc0f240",
+                        "background": "#bdc0f2"
+                    },
+                    {
+                        "cursor": "#92c4e1",
+                        "selection": "#92c4e140",
+                        "background": "#92c4e1"
+                    },
+                    {
+                        "cursor": "#add19f",
+                        "selection": "#add19f40",
+                        "background": "#add19f"
+                    },
+                    {
+                        "cursor": "#dfcaa4",
+                        "selection": "#dfcaa440",
+                        "background": "#dfcaa4"
+                    },
+                    {
+                        "cursor": "#e7a98f",
+                        "selection": "#e7a98f40",
+                        "background": "#e7a98f"
+                    },
+                    {
+                        "cursor": "#e1929b",
+                        "selection": "#e1929b40",
+                        "background": "#e1929b"
+                    }
+                ],
+                "version_control.added": "#a6d189",
+                "version_control.deleted": "#e78284",
+                "version_control.modified": "#e5c890",
+                "version_control.renamed": "#85c1dc",
+                "version_control.conflict": "#ef9f76",
+                "version_control.conflict_marker.ours": "#a6d18933",
+                "version_control.conflict_marker.theirs": "#8caaee33",
+                "version_control.ignored": "#737994",
+                "debugger.accent": "#e78284",
+                "editor.debugger_active_line.background": "#ef9f7612",
+                "syntax": {
+                    "variable": {
+                        "color": "#c6d0f5",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "variable.builtin": {
+                        "color": "#e78284",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "variable.parameter": {
+                        "color": "#ea999c",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "variable.member": {
+                        "color": "#8caaee",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "variable.special": {
+                        "color": "#e78284",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "constant": {
+                        "color": "#ef9f76",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "constant.builtin": {
+                        "color": "#ef9f76",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "constant.macro": {
+                        "color": "#ca9ee6",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "module": {
+                        "color": "#e5c890",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "label": {
+                        "color": "#85c1dc",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "string": {
+                        "color": "#a6d189",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "string.documentation": {
+                        "color": "#81c8be",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "string.regexp": {
+                        "color": "#ef9f76",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "string.escape": {
+                        "color": "#f4b8e4",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "string.special": {
+                        "color": "#f4b8e4",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "string.special.path": {
+                        "color": "#f4b8e4",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "string.special.symbol": {
+                        "color": "#eebebe",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "string.special.url": {
+                        "color": "#f2d5cf",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "character": {
+                        "color": "#81c8be",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "character.special": {
+                        "color": "#f4b8e4",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "boolean": {
+                        "color": "#ef9f76",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "number": {
+                        "color": "#ef9f76",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "number.float": {
+                        "color": "#ef9f76",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "type": {
+                        "color": "#e5c890",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "type.builtin": {
+                        "color": "#ca9ee6",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "type.definition": {
+                        "color": "#e5c890",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "type.interface": {
+                        "color": "#e5c890",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "type.super": {
+                        "color": "#e5c890",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "attribute": {
+                        "color": "#ef9f76",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "property": {
+                        "color": "#8caaee",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "function": {
+                        "color": "#8caaee",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "function.builtin": {
+                        "color": "#ef9f76",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "function.call": {
+                        "color": "#8caaee",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "function.macro": {
+                        "color": "#81c8be",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "function.method": {
+                        "color": "#8caaee",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "function.method.call": {
+                        "color": "#8caaee",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "constructor": {
+                        "color": "#eebebe",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "operator": {
+                        "color": "#99d1db",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword": {
+                        "color": "#ca9ee6",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.modifier": {
+                        "color": "#ca9ee6",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.type": {
+                        "color": "#ca9ee6",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.coroutine": {
+                        "color": "#ca9ee6",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.function": {
+                        "color": "#ca9ee6",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.operator": {
+                        "color": "#ca9ee6",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.import": {
+                        "color": "#ca9ee6",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.repeat": {
+                        "color": "#ca9ee6",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.return": {
+                        "color": "#ca9ee6",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.debug": {
+                        "color": "#ca9ee6",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.exception": {
+                        "color": "#ca9ee6",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.conditional": {
+                        "color": "#ca9ee6",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.conditional.ternary": {
+                        "color": "#ca9ee6",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.directive": {
+                        "color": "#f4b8e4",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.directive.define": {
+                        "color": "#f4b8e4",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.export": {
+                        "color": "#99d1db",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "punctuation": {
+                        "color": "#949cbb",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "punctuation.delimiter": {
+                        "color": "#949cbb",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "punctuation.bracket": {
+                        "color": "#949cbb",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "punctuation.special": {
+                        "color": "#f4b8e4",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "punctuation.special.symbol": {
+                        "color": "#eebebe",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "punctuation.list_marker": {
+                        "color": "#81c8be",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "comment": {
+                        "color": "#949cbb",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "comment.doc": {
+                        "color": "#949cbb",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "comment.documentation": {
+                        "color": "#949cbb",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "comment.error": {
+                        "color": "#e78284",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "comment.warning": {
+                        "color": "#e5c890",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "comment.hint": {
+                        "color": "#8caaee",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "comment.todo": {
+                        "color": "#eebebe",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "comment.note": {
+                        "color": "#f2d5cf",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "diff.plus": {
+                        "color": "#a6d189",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "diff.minus": {
+                        "color": "#e78284",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "tag": {
+                        "color": "#8caaee",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "tag.attribute": {
+                        "color": "#e5c890",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "tag.delimiter": {
+                        "color": "#81c8be",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "parameter": {
+                        "color": "#ea999c",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "field": {
+                        "color": "#babbf1",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "namespace": {
+                        "color": "#e5c890",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "float": {
+                        "color": "#ef9f76",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "symbol": {
+                        "color": "#f4b8e4",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "string.regex": {
+                        "color": "#ef9f76",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "text": {
+                        "color": "#c6d0f5",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "emphasis.strong": {
+                        "color": "#ea999c",
+                        "font_style": null,
+                        "font_weight": 700
+                    },
+                    "emphasis": {
+                        "color": "#ea999c",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "embedded": {
+                        "color": "#ea999c",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "text.literal": {
+                        "color": "#a6d189",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "concept": {
+                        "color": "#85c1dc",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "enum": {
+                        "color": "#81c8be",
+                        "font_style": null,
+                        "font_weight": 700
+                    },
+                    "function.decorator": {
+                        "color": "#ef9f76",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "type.class.definition": {
+                        "color": "#e5c890",
+                        "font_style": null,
+                        "font_weight": 700
+                    },
+
+                    "hint": {
+                        "color": "#838ba7",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "link_text": {
+                        "color": "#babbf1",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "link_uri": {
+                        "color": "#8caaee",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "parent": {
+                        "color": "#ef9f76",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "predictive": {
+                        "color": "#737994",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "predoc": {
+                        "color": "#e78284",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "primary": {
+                        "color": "#ea999c",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "tag.doctype": {
+                        "color": "#ca9ee6",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "string.doc": {
+                      "color": "#81c8be",
+                      "font_style": "italic",
+                      "font_weight": null
+                    },
+                    "title": {
+                        "color": "#c6d0f5",
+                        "font_style": null,
+                        "font_weight": 800
+                    },
+                    "variant": {
+                        "color": "#e78284",
+                        "font_style": null,
+                        "font_weight": null
+                    }
+                }
+            }
+        },
+        {
+            "name": "Catppuccin Macchiato",
+            "appearance": "dark",
+            "style": {
+                "accents": [
+                    "#c6aaf666",
+                    "#bac1f766",
+                    "#8cc7e766",
+                    "#add8a866",
+                    "#e6d4b066",
+                    "#ecb19766",
+                    "#e696a966"
+                ],
+                "vim.mode.text": "#181926",
+                "vim.normal.background": "#f4dbd6",
+                "vim.helix_normal.background": "#f4dbd6",
+                "vim.visual.background": "#b7bdf8",
+                "vim.helix_select.background": "#b7bdf8",
+                "vim.insert.background": "#a6da95",
+                "vim.visual_line.background": "#b7bdf8",
+                "vim.visual_block.background": "#c6a0f6",
+                "vim.replace.background": "#ee99a0",
+                "background.appearance": "opaque",
+                "border": "#363a4f",
+                "border.variant": "#a98cd5",
+                "border.focused": "#b7bdf8",
+                "border.selected": "#c6a0f6",
+                "border.transparent": "#a6da95",
+                "border.disabled": "#6e738d",
+                "elevated_surface.background": "#1e2030",
+                "surface.background": "#1e2030",
+                "background": "#2c2f46",
+                "element.background": "#181926",
+                "element.hover": "#363a4f",
+                "element.active": "#5b60784d",
+                "element.selected": "#363a4f4d",
+                "element.disabled": "#6e738d",
+                "drop_target.background": "#363a4f66",
+                "ghost_element.background": "#00000000",
+                "ghost_element.hover": "#494d644d",
+                "ghost_element.active": "#5b607899",
+                "ghost_element.selected": "#73799566",
+                "ghost_element.disabled": "#6e738d",
+                "text": "#cad3f5",
+                "text.muted": "#b8c0e0",
+                "text.placeholder": "#5b6078",
+                "text.disabled": "#494d64",
+                "text.accent": "#c6a0f6",
+                "icon": "#cad3f5",
+                "icon.muted": "#8087a2",
+                "icon.disabled": "#6e738d",
+                "icon.placeholder": "#5b6078",
+                "icon.accent": "#c6a0f6",
+                "status_bar.background": "#181926",
+                "title_bar.background": "#181926",
+                "title_bar.inactive_background": "#1e1f30",
+                "toolbar.background": "#24273a",
+                "tab_bar.background": "#181926",
+                "tab.inactive_background": "#12121c",
+                "tab.active_background": "#24273a",
+                "search.match_background": "#8bd5ca33",
+                "panel.background": "#1e2030",
+                "panel.focused_border": "#cad3f5",
+                "panel.indent_guide": "#363a4f99",
+                "panel.indent_guide_active": "#5b6078",
+                "panel.indent_guide_hover": "#c6a0f6",
+                "panel.overlay_background": "#181926",
+                "pane.focused_border": "#cad3f5",
+                "pane_group.border": "#363a4f",
+                "scrollbar.thumb.background": "#5b607880",
+                "scrollbar.thumb.hover_background": "#6e738d",
+                "scrollbar.thumb.active_background": null,
+                "scrollbar.thumb.border": null,
+                "scrollbar.track.background": "#181926",
+                "scrollbar.track.border": "#cad3f512",
+                "minimap.thumb.background": "#c6a0f633",
+                "minimap.thumb.hover_background": "#c6a0f666",
+                "minimap.thumb.active_background": "#c6a0f699",
+                "minimap.thumb.border": null,
+                "editor.foreground": "#cad3f5",
+                "editor.background": "#24273a",
+                "editor.gutter.background": "#24273a",
+                "editor.subheader.background": "#1e2030",
+                "editor.active_line.background": "#cad3f512",
+                "editor.highlighted_line.background": null,
+                "editor.line_number": "#8087a2",
+                "editor.active_line_number": "#c6a0f6",
+                "editor.invisible": "#939ab766",
+                "editor.wrap_guide": "#5b6078",
+                "editor.active_wrap_guide": "#5b6078",
+                "editor.document_highlight.bracket_background": "#c6a0f617",
+                "editor.document_highlight.read_background": "#a5adcb29",
+                "editor.document_highlight.write_background": "#a5adcb29",
+                "editor.indent_guide": "#363a4f99",
+                "editor.indent_guide_active": "#5b6078",
+                "terminal.background": "#24273a",
+                "terminal.ansi.background": "#24273a",
+                "terminal.foreground": "#cad3f5",
+                "terminal.dim_foreground": "#8087a2",
+                "terminal.bright_foreground": "#cad3f5",
+                "terminal.ansi.black": "#494d64",
+                "terminal.ansi.white": "#a5adcb",
+                "terminal.ansi.red": "#ed8796",
+                "terminal.ansi.green": "#a6da95",
+                "terminal.ansi.yellow": "#eed49f",
+                "terminal.ansi.blue": "#8aadf4",
+                "terminal.ansi.magenta": "#f5bde6",
+                "terminal.ansi.cyan": "#8bd5ca",
+                "terminal.ansi.bright_black": "#5b6078",
+                "terminal.ansi.bright_white": "#b8c0e0",
+                "terminal.ansi.bright_red": "#ec7486",
+                "terminal.ansi.bright_green": "#8ccf7f",
+                "terminal.ansi.bright_yellow": "#e1c682",
+                "terminal.ansi.bright_blue": "#78a1f6",
+                "terminal.ansi.bright_magenta": "#f2a9dd",
+                "terminal.ansi.bright_cyan": "#63cbc0",
+                "terminal.ansi.dim_black": "#494d64",
+                "terminal.ansi.dim_white": "#a5adcb",
+                "terminal.ansi.dim_red": "#ed8796",
+                "terminal.ansi.dim_green": "#a6da95",
+                "terminal.ansi.dim_yellow": "#eed49f",
+                "terminal.ansi.dim_blue": "#8aadf4",
+                "terminal.ansi.dim_magenta": "#f5bde6",
+                "terminal.ansi.dim_cyan": "#8bd5ca",
+                "link_text.hover": "#91d7e3",
+                "conflict": "#f5a97f",
+                "conflict.border": "#f5a97f",
+                "conflict.background": "#f5a97f26",
+                "created": "#a6da95",
+                "created.border": "#a6da95",
+                "created.background": "#a6da9526",
+                "deleted": "#ed8796",
+                "deleted.border": "#ed8796",
+                "deleted.background": "#ed879626",
+                "hidden": "#6e738d",
+                "hidden.border": "#6e738d",
+                "hidden.background": "#1e2030",
+                "hint": "#5b6078",
+                "hint.border": "#5b6078",
+                "hint.background": "#1e2030",
+                "ignored": "#6e738d",
+                "ignored.border": "#6e738d",
+                "ignored.background": "#6e738d26",
+                "modified": "#eed49f",
+                "modified.border": "#eed49f",
+                "modified.background": "#eed49f26",
+                "predictive": "#6e738d",
+                "predictive.border": "#b7bdf8",
+                "predictive.background": "#1e2030",
+                "renamed": "#7dc4e4",
+                "renamed.border": "#7dc4e4",
+                "renamed.background": "#7dc4e426",
+                "info": "#8bd5ca",
+                "info.border": "#8bd5ca",
+                "info.background": "#939ab733",
+                "warning": "#eed49f",
+                "warning.border": "#eed49f",
+                "warning.background": "#eed49f1f",
+                "error": "#ed8796",
+                "error.border": "#ed8796",
+                "error.background": "#ed87961f",
+                "success": "#a6da95",
+                "success.border": "#a6da95",
+                "success.background": "#a6da951f",
+                "unreachable": "#ed8796",
+                "unreachable.border": "#ed8796",
+                "unreachable.background": "#ed87961f",
+                "players": [
+                    {
+                        "cursor": "#f4dbd6",
+                        "selection": "#939ab740",
+                        "background": "#f4dbd6"
+                    },
+                    {
+                        "cursor": "#c6aaf6",
+                        "selection": "#c6aaf640",
+                        "background": "#c6aaf6"
+                    },
+                    {
+                        "cursor": "#bac1f7",
+                        "selection": "#bac1f740",
+                        "background": "#bac1f7"
+                    },
+                    {
+                        "cursor": "#8cc7e7",
+                        "selection": "#8cc7e740",
+                        "background": "#8cc7e7"
+                    },
+                    {
+                        "cursor": "#add8a8",
+                        "selection": "#add8a840",
+                        "background": "#add8a8"
+                    },
+                    {
+                        "cursor": "#e6d4b0",
+                        "selection": "#e6d4b040",
+                        "background": "#e6d4b0"
+                    },
+                    {
+                        "cursor": "#ecb197",
+                        "selection": "#ecb19740",
+                        "background": "#ecb197"
+                    },
+                    {
+                        "cursor": "#e696a9",
+                        "selection": "#e696a940",
+                        "background": "#e696a9"
+                    }
+                ],
+                "version_control.added": "#a6da95",
+                "version_control.deleted": "#ed8796",
+                "version_control.modified": "#eed49f",
+                "version_control.renamed": "#7dc4e4",
+                "version_control.conflict": "#f5a97f",
+                "version_control.conflict_marker.ours": "#a6da9533",
+                "version_control.conflict_marker.theirs": "#8aadf433",
+                "version_control.ignored": "#6e738d",
+                "debugger.accent": "#ed8796",
+                "editor.debugger_active_line.background": "#f5a97f12",
+                "syntax": {
+                    "variable": {
+                        "color": "#cad3f5",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "variable.builtin": {
+                        "color": "#ed8796",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "variable.parameter": {
+                        "color": "#ee99a0",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "variable.member": {
+                        "color": "#8aadf4",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "variable.special": {
+                        "color": "#ed8796",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "constant": {
+                        "color": "#f5a97f",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "constant.builtin": {
+                        "color": "#f5a97f",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "constant.macro": {
+                        "color": "#c6a0f6",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "module": {
+                        "color": "#eed49f",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "label": {
+                        "color": "#7dc4e4",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "string": {
+                        "color": "#a6da95",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "string.documentation": {
+                        "color": "#8bd5ca",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "string.regexp": {
+                        "color": "#f5a97f",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "string.escape": {
+                        "color": "#f5bde6",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "string.special": {
+                        "color": "#f5bde6",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "string.special.path": {
+                        "color": "#f5bde6",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "string.special.symbol": {
+                        "color": "#f0c6c6",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "string.special.url": {
+                        "color": "#f4dbd6",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "character": {
+                        "color": "#8bd5ca",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "character.special": {
+                        "color": "#f5bde6",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "boolean": {
+                        "color": "#f5a97f",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "number": {
+                        "color": "#f5a97f",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "number.float": {
+                        "color": "#f5a97f",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "type": {
+                        "color": "#eed49f",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "type.builtin": {
+                        "color": "#c6a0f6",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "type.definition": {
+                        "color": "#eed49f",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "type.interface": {
+                        "color": "#eed49f",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "type.super": {
+                        "color": "#eed49f",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "attribute": {
+                        "color": "#f5a97f",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "property": {
+                        "color": "#8aadf4",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "function": {
+                        "color": "#8aadf4",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "function.builtin": {
+                        "color": "#f5a97f",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "function.call": {
+                        "color": "#8aadf4",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "function.macro": {
+                        "color": "#8bd5ca",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "function.method": {
+                        "color": "#8aadf4",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "function.method.call": {
+                        "color": "#8aadf4",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "constructor": {
+                        "color": "#f0c6c6",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "operator": {
+                        "color": "#91d7e3",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword": {
+                        "color": "#c6a0f6",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.modifier": {
+                        "color": "#c6a0f6",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.type": {
+                        "color": "#c6a0f6",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.coroutine": {
+                        "color": "#c6a0f6",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.function": {
+                        "color": "#c6a0f6",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.operator": {
+                        "color": "#c6a0f6",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.import": {
+                        "color": "#c6a0f6",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.repeat": {
+                        "color": "#c6a0f6",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.return": {
+                        "color": "#c6a0f6",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.debug": {
+                        "color": "#c6a0f6",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.exception": {
+                        "color": "#c6a0f6",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.conditional": {
+                        "color": "#c6a0f6",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.conditional.ternary": {
+                        "color": "#c6a0f6",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.directive": {
+                        "color": "#f5bde6",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.directive.define": {
+                        "color": "#f5bde6",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.export": {
+                        "color": "#91d7e3",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "punctuation": {
+                        "color": "#939ab7",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "punctuation.delimiter": {
+                        "color": "#939ab7",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "punctuation.bracket": {
+                        "color": "#939ab7",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "punctuation.special": {
+                        "color": "#f5bde6",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "punctuation.special.symbol": {
+                        "color": "#f0c6c6",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "punctuation.list_marker": {
+                        "color": "#8bd5ca",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "comment": {
+                        "color": "#939ab7",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "comment.doc": {
+                        "color": "#939ab7",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "comment.documentation": {
+                        "color": "#939ab7",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "comment.error": {
+                        "color": "#ed8796",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "comment.warning": {
+                        "color": "#eed49f",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "comment.hint": {
+                        "color": "#8aadf4",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "comment.todo": {
+                        "color": "#f0c6c6",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "comment.note": {
+                        "color": "#f4dbd6",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "diff.plus": {
+                        "color": "#a6da95",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "diff.minus": {
+                        "color": "#ed8796",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "tag": {
+                        "color": "#8aadf4",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "tag.attribute": {
+                        "color": "#eed49f",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "tag.delimiter": {
+                        "color": "#8bd5ca",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "parameter": {
+                        "color": "#ee99a0",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "field": {
+                        "color": "#b7bdf8",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "namespace": {
+                        "color": "#eed49f",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "float": {
+                        "color": "#f5a97f",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "symbol": {
+                        "color": "#f5bde6",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "string.regex": {
+                        "color": "#f5a97f",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "text": {
+                        "color": "#cad3f5",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "emphasis.strong": {
+                        "color": "#ee99a0",
+                        "font_style": null,
+                        "font_weight": 700
+                    },
+                    "emphasis": {
+                        "color": "#ee99a0",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "embedded": {
+                        "color": "#ee99a0",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "text.literal": {
+                        "color": "#a6da95",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "concept": {
+                        "color": "#7dc4e4",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "enum": {
+                        "color": "#8bd5ca",
+                        "font_style": null,
+                        "font_weight": 700
+                    },
+                    "function.decorator": {
+                        "color": "#f5a97f",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "type.class.definition": {
+                        "color": "#eed49f",
+                        "font_style": null,
+                        "font_weight": 700
+                    },
+
+                    "hint": {
+                        "color": "#8087a2",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "link_text": {
+                        "color": "#b7bdf8",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "link_uri": {
+                        "color": "#8aadf4",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "parent": {
+                        "color": "#f5a97f",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "predictive": {
+                        "color": "#6e738d",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "predoc": {
+                        "color": "#ed8796",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "primary": {
+                        "color": "#ee99a0",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "tag.doctype": {
+                        "color": "#c6a0f6",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "string.doc": {
+                      "color": "#8bd5ca",
+                      "font_style": "italic",
+                      "font_weight": null
+                    },
+                    "title": {
+                        "color": "#cad3f5",
+                        "font_style": null,
+                        "font_weight": 800
+                    },
+                    "variant": {
+                        "color": "#ed8796",
+                        "font_style": null,
+                        "font_weight": null
+                    }
+                }
+            }
+        },
+        {
+            "name": "Catppuccin Mocha",
+            "appearance": "dark",
+            "style": {
+                "accents": [
+                    "#cbb0f766",
+                    "#b9c3fc66",
+                    "#86caee66",
+                    "#aee1b266",
+                    "#f0e0bd66",
+                    "#f1ba9d66",
+                    "#eb9ab766"
+                ],
+                "vim.mode.text": "#11111b",
+                "vim.normal.background": "#f5e0dc",
+                "vim.helix_normal.background": "#f5e0dc",
+                "vim.visual.background": "#b4befe",
+                "vim.helix_select.background": "#b4befe",
+                "vim.insert.background": "#a6e3a1",
+                "vim.visual_line.background": "#b4befe",
+                "vim.visual_block.background": "#cba6f7",
+                "vim.replace.background": "#eba0ac",
+                "background.appearance": "opaque",
+                "border": "#313244",
+                "border.variant": "#ac8fd4",
+                "border.focused": "#b4befe",
+                "border.selected": "#cba6f7",
+                "border.transparent": "#a6e3a1",
+                "border.disabled": "#6c7086",
+                "elevated_surface.background": "#181825",
+                "surface.background": "#181825",
+                "background": "#27273b",
+                "element.background": "#11111b",
+                "element.hover": "#313244",
+                "element.active": "#585b704d",
+                "element.selected": "#3132444d",
+                "element.disabled": "#6c7086",
+                "drop_target.background": "#31324466",
+                "ghost_element.background": "#00000000",
+                "ghost_element.hover": "#45475a4d",
+                "ghost_element.active": "#585b7099",
+                "ghost_element.selected": "#6f728d66",
+                "ghost_element.disabled": "#6c7086",
+                "text": "#cdd6f4",
+                "text.muted": "#bac2de",
+                "text.placeholder": "#585b70",
+                "text.disabled": "#45475a",
+                "text.accent": "#cba6f7",
+                "icon": "#cdd6f4",
+                "icon.muted": "#7f849c",
+                "icon.disabled": "#6c7086",
+                "icon.placeholder": "#585b70",
+                "icon.accent": "#cba6f7",
+                "status_bar.background": "#11111b",
+                "title_bar.background": "#11111b",
+                "title_bar.inactive_background": "#171725",
+                "toolbar.background": "#1e1e2e",
+                "tab_bar.background": "#11111b",
+                "tab.inactive_background": "#0b0b11",
+                "tab.active_background": "#1e1e2e",
+                "search.match_background": "#94e2d533",
+                "panel.background": "#181825",
+                "panel.focused_border": "#cdd6f4",
+                "panel.indent_guide": "#31324499",
+                "panel.indent_guide_active": "#585b70",
+                "panel.indent_guide_hover": "#cba6f7",
+                "panel.overlay_background": "#11111b",
+                "pane.focused_border": "#cdd6f4",
+                "pane_group.border": "#313244",
+                "scrollbar.thumb.background": "#585b7080",
+                "scrollbar.thumb.hover_background": "#6c7086",
+                "scrollbar.thumb.active_background": null,
+                "scrollbar.thumb.border": null,
+                "scrollbar.track.background": "#11111b",
+                "scrollbar.track.border": "#cdd6f412",
+                "minimap.thumb.background": "#cba6f733",
+                "minimap.thumb.hover_background": "#cba6f766",
+                "minimap.thumb.active_background": "#cba6f799",
+                "minimap.thumb.border": null,
+                "editor.foreground": "#cdd6f4",
+                "editor.background": "#1e1e2e",
+                "editor.gutter.background": "#1e1e2e",
+                "editor.subheader.background": "#181825",
+                "editor.active_line.background": "#cdd6f412",
+                "editor.highlighted_line.background": null,
+                "editor.line_number": "#7f849c",
+                "editor.active_line_number": "#cba6f7",
+                "editor.invisible": "#9399b266",
+                "editor.wrap_guide": "#585b70",
+                "editor.active_wrap_guide": "#585b70",
+                "editor.document_highlight.bracket_background": "#cba6f717",
+                "editor.document_highlight.read_background": "#a6adc829",
+                "editor.document_highlight.write_background": "#a6adc829",
+                "editor.indent_guide": "#31324499",
+                "editor.indent_guide_active": "#585b70",
+                "terminal.background": "#1e1e2e",
+                "terminal.ansi.background": "#1e1e2e",
+                "terminal.foreground": "#cdd6f4",
+                "terminal.dim_foreground": "#7f849c",
+                "terminal.bright_foreground": "#cdd6f4",
+                "terminal.ansi.black": "#45475a",
+                "terminal.ansi.white": "#a6adc8",
+                "terminal.ansi.red": "#f38ba8",
+                "terminal.ansi.green": "#a6e3a1",
+                "terminal.ansi.yellow": "#f9e2af",
+                "terminal.ansi.blue": "#89b4fa",
+                "terminal.ansi.magenta": "#f5c2e7",
+                "terminal.ansi.cyan": "#94e2d5",
+                "terminal.ansi.bright_black": "#585b70",
+                "terminal.ansi.bright_white": "#bac2de",
+                "terminal.ansi.bright_red": "#f37799",
+                "terminal.ansi.bright_green": "#89d88b",
+                "terminal.ansi.bright_yellow": "#ebd391",
+                "terminal.ansi.bright_blue": "#74a8fc",
+                "terminal.ansi.bright_magenta": "#f2aede",
+                "terminal.ansi.bright_cyan": "#6bd7ca",
+                "terminal.ansi.dim_black": "#45475a",
+                "terminal.ansi.dim_white": "#a6adc8",
+                "terminal.ansi.dim_red": "#f38ba8",
+                "terminal.ansi.dim_green": "#a6e3a1",
+                "terminal.ansi.dim_yellow": "#f9e2af",
+                "terminal.ansi.dim_blue": "#89b4fa",
+                "terminal.ansi.dim_magenta": "#f5c2e7",
+                "terminal.ansi.dim_cyan": "#94e2d5",
+                "link_text.hover": "#89dceb",
+                "conflict": "#fab387",
+                "conflict.border": "#fab387",
+                "conflict.background": "#fab38726",
+                "created": "#a6e3a1",
+                "created.border": "#a6e3a1",
+                "created.background": "#a6e3a126",
+                "deleted": "#f38ba8",
+                "deleted.border": "#f38ba8",
+                "deleted.background": "#f38ba826",
+                "hidden": "#6c7086",
+                "hidden.border": "#6c7086",
+                "hidden.background": "#181825",
+                "hint": "#585b70",
+                "hint.border": "#585b70",
+                "hint.background": "#181825",
+                "ignored": "#6c7086",
+                "ignored.border": "#6c7086",
+                "ignored.background": "#6c708626",
+                "modified": "#f9e2af",
+                "modified.border": "#f9e2af",
+                "modified.background": "#f9e2af26",
+                "predictive": "#6c7086",
+                "predictive.border": "#b4befe",
+                "predictive.background": "#181825",
+                "renamed": "#74c7ec",
+                "renamed.border": "#74c7ec",
+                "renamed.background": "#74c7ec26",
+                "info": "#94e2d5",
+                "info.border": "#94e2d5",
+                "info.background": "#9399b233",
+                "warning": "#f9e2af",
+                "warning.border": "#f9e2af",
+                "warning.background": "#f9e2af1f",
+                "error": "#f38ba8",
+                "error.border": "#f38ba8",
+                "error.background": "#f38ba81f",
+                "success": "#a6e3a1",
+                "success.border": "#a6e3a1",
+                "success.background": "#a6e3a11f",
+                "unreachable": "#f38ba8",
+                "unreachable.border": "#f38ba8",
+                "unreachable.background": "#f38ba81f",
+                "players": [
+                    {
+                        "cursor": "#f5e0dc",
+                        "selection": "#9399b240",
+                        "background": "#f5e0dc"
+                    },
+                    {
+                        "cursor": "#cbb0f7",
+                        "selection": "#cbb0f740",
+                        "background": "#cbb0f7"
+                    },
+                    {
+                        "cursor": "#b9c3fc",
+                        "selection": "#b9c3fc40",
+                        "background": "#b9c3fc"
+                    },
+                    {
+                        "cursor": "#86caee",
+                        "selection": "#86caee40",
+                        "background": "#86caee"
+                    },
+                    {
+                        "cursor": "#aee1b2",
+                        "selection": "#aee1b240",
+                        "background": "#aee1b2"
+                    },
+                    {
+                        "cursor": "#f0e0bd",
+                        "selection": "#f0e0bd40",
+                        "background": "#f0e0bd"
+                    },
+                    {
+                        "cursor": "#f1ba9d",
+                        "selection": "#f1ba9d40",
+                        "background": "#f1ba9d"
+                    },
+                    {
+                        "cursor": "#eb9ab7",
+                        "selection": "#eb9ab740",
+                        "background": "#eb9ab7"
+                    }
+                ],
+                "version_control.added": "#a6e3a1",
+                "version_control.deleted": "#f38ba8",
+                "version_control.modified": "#f9e2af",
+                "version_control.renamed": "#74c7ec",
+                "version_control.conflict": "#fab387",
+                "version_control.conflict_marker.ours": "#a6e3a133",
+                "version_control.conflict_marker.theirs": "#89b4fa33",
+                "version_control.ignored": "#6c7086",
+                "debugger.accent": "#f38ba8",
+                "editor.debugger_active_line.background": "#fab38712",
+                "syntax": {
+                    "variable": {
+                        "color": "#cdd6f4",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "variable.builtin": {
+                        "color": "#f38ba8",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "variable.parameter": {
+                        "color": "#eba0ac",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "variable.member": {
+                        "color": "#89b4fa",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "variable.special": {
+                        "color": "#f38ba8",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "constant": {
+                        "color": "#fab387",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "constant.builtin": {
+                        "color": "#fab387",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "constant.macro": {
+                        "color": "#cba6f7",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "module": {
+                        "color": "#f9e2af",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "label": {
+                        "color": "#74c7ec",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "string": {
+                        "color": "#a6e3a1",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "string.documentation": {
+                        "color": "#94e2d5",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "string.regexp": {
+                        "color": "#fab387",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "string.escape": {
+                        "color": "#f5c2e7",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "string.special": {
+                        "color": "#f5c2e7",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "string.special.path": {
+                        "color": "#f5c2e7",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "string.special.symbol": {
+                        "color": "#f2cdcd",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "string.special.url": {
+                        "color": "#f5e0dc",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "character": {
+                        "color": "#94e2d5",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "character.special": {
+                        "color": "#f5c2e7",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "boolean": {
+                        "color": "#fab387",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "number": {
+                        "color": "#fab387",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "number.float": {
+                        "color": "#fab387",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "type": {
+                        "color": "#f9e2af",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "type.builtin": {
+                        "color": "#cba6f7",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "type.definition": {
+                        "color": "#f9e2af",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "type.interface": {
+                        "color": "#f9e2af",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "type.super": {
+                        "color": "#f9e2af",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "attribute": {
+                        "color": "#fab387",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "property": {
+                        "color": "#89b4fa",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "function": {
+                        "color": "#89b4fa",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "function.builtin": {
+                        "color": "#fab387",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "function.call": {
+                        "color": "#89b4fa",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "function.macro": {
+                        "color": "#94e2d5",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "function.method": {
+                        "color": "#89b4fa",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "function.method.call": {
+                        "color": "#89b4fa",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "constructor": {
+                        "color": "#f2cdcd",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "operator": {
+                        "color": "#89dceb",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword": {
+                        "color": "#cba6f7",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.modifier": {
+                        "color": "#cba6f7",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.type": {
+                        "color": "#cba6f7",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.coroutine": {
+                        "color": "#cba6f7",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.function": {
+                        "color": "#cba6f7",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.operator": {
+                        "color": "#cba6f7",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.import": {
+                        "color": "#cba6f7",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.repeat": {
+                        "color": "#cba6f7",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.return": {
+                        "color": "#cba6f7",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.debug": {
+                        "color": "#cba6f7",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.exception": {
+                        "color": "#cba6f7",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.conditional": {
+                        "color": "#cba6f7",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.conditional.ternary": {
+                        "color": "#cba6f7",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.directive": {
+                        "color": "#f5c2e7",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.directive.define": {
+                        "color": "#f5c2e7",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword.export": {
+                        "color": "#89dceb",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "punctuation": {
+                        "color": "#9399b2",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "punctuation.delimiter": {
+                        "color": "#9399b2",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "punctuation.bracket": {
+                        "color": "#9399b2",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "punctuation.special": {
+                        "color": "#f5c2e7",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "punctuation.special.symbol": {
+                        "color": "#f2cdcd",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "punctuation.list_marker": {
+                        "color": "#94e2d5",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "comment": {
+                        "color": "#9399b2",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "comment.doc": {
+                        "color": "#9399b2",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "comment.documentation": {
+                        "color": "#9399b2",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "comment.error": {
+                        "color": "#f38ba8",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "comment.warning": {
+                        "color": "#f9e2af",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "comment.hint": {
+                        "color": "#89b4fa",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "comment.todo": {
+                        "color": "#f2cdcd",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "comment.note": {
+                        "color": "#f5e0dc",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "diff.plus": {
+                        "color": "#a6e3a1",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "diff.minus": {
+                        "color": "#f38ba8",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "tag": {
+                        "color": "#89b4fa",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "tag.attribute": {
+                        "color": "#f9e2af",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "tag.delimiter": {
+                        "color": "#94e2d5",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "parameter": {
+                        "color": "#eba0ac",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "field": {
+                        "color": "#b4befe",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "namespace": {
+                        "color": "#f9e2af",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "float": {
+                        "color": "#fab387",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "symbol": {
+                        "color": "#f5c2e7",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "string.regex": {
+                        "color": "#fab387",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "text": {
+                        "color": "#cdd6f4",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "emphasis.strong": {
+                        "color": "#eba0ac",
+                        "font_style": null,
+                        "font_weight": 700
+                    },
+                    "emphasis": {
+                        "color": "#eba0ac",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "embedded": {
+                        "color": "#eba0ac",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "text.literal": {
+                        "color": "#a6e3a1",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "concept": {
+                        "color": "#74c7ec",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "enum": {
+                        "color": "#94e2d5",
+                        "font_style": null,
+                        "font_weight": 700
+                    },
+                    "function.decorator": {
+                        "color": "#fab387",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "type.class.definition": {
+                        "color": "#f9e2af",
+                        "font_style": null,
+                        "font_weight": 700
+                    },
+
+                    "hint": {
+                        "color": "#7f849c",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "link_text": {
+                        "color": "#b4befe",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "link_uri": {
+                        "color": "#89b4fa",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "parent": {
+                        "color": "#fab387",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "predictive": {
+                        "color": "#6c7086",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "predoc": {
+                        "color": "#f38ba8",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "primary": {
+                        "color": "#eba0ac",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "tag.doctype": {
+                        "color": "#cba6f7",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "string.doc": {
+                      "color": "#94e2d5",
+                      "font_style": "italic",
+                      "font_weight": null
+                    },
+                    "title": {
+                        "color": "#cdd6f4",
+                        "font_style": null,
+                        "font_weight": 800
+                    },
+                    "variant": {
+                        "color": "#f38ba8",
+                        "font_style": null,
+                        "font_weight": null
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/themes/dracula.json
+++ b/themes/dracula.json
@@ -1,0 +1,1247 @@
+{
+  "$schema": "https://zed.dev/schema/themes/v0.2.0.json",
+  "name": "Dracula",
+  "author": "Ben Hamment",
+  "themes": [
+    {
+      "name": "Dracula",
+      "appearance": "dark",
+      "style": {
+        "accents": [
+          "#bd93f9ff",
+          "#ff79c6ff",
+          "#8be9fdff",
+          "#50fa7bff",
+          "#ffb86cff",
+          "#f1fa8cff",
+          "#ff5555ff"
+        ],
+        "background.appearance": "blurred",
+        "border": "#3c324bcc",
+        "border.variant": "#C9A8F933",
+        "border.focused": "#C9A8F977",
+        "border.selected": "#C9A8F9bb",
+        "border.transparent": "#00000000",
+        "border.disabled": null,
+        "elevated_surface.background": "#1e1925ff",
+        "surface.background": "#242631ee",
+        "background": "#b597e033",
+        "element.background": "#1c1d26ff",
+        "element.hover": "#504364ff",
+        "element.active": "#796595ff",
+        "element.selected": "#65547dff",
+        "element.disabled": "#e9dbfdff",
+        "drop_target.background": "#504364ff",
+        "ghost_element.background": "#00000000",
+        "ghost_element.hover": "#C9A8F935",
+        "ghost_element.active": "#C9A8F950",
+        "ghost_element.selected": "#C9A8F925",
+        "ghost_element.disabled": "#ff5555ff",
+        "text": "#f8f8f2ff",
+        "text.muted": "#a186c7ff",
+        "text.placeholder": "#C9A8F980",
+        "text.disabled": "#C9A8F950",
+        "text.accent": "#C9A8F9FF",
+        "icon": "#f8f8f2ff",
+        "icon.muted": "#f8f8f270",
+        "icon.disabled": "#f8f8f240",
+        "icon.placeholder": "#f8f8f250",
+        "icon.accent": "#C9A8F9FF",
+        "status_bar.background": "#141119bb",
+        "title_bar.background": "#141119bb",
+        "title_bar.inactive_background": "#0a080cbb",
+        "toolbar.background": "#282a36ff",
+        "tab_bar.background": "#282232bb",
+        "tab.inactive_background": "#1c1d26ff",
+        "tab.active_background": "#282a36ff",
+        "search.match_background": "#50fa7b50",
+        "panel.background": "#16121bff",
+        "panel.focused_border": "#C9A8F9FF",
+        "panel.indent_guide": "#f8f8f220",
+        "panel.indent_guide_active": "#C9A8F950",
+        "panel.indent_guide_hover": "#C9A8F935",
+        "pane.focused_border": "#C9A8F9FF",
+        "pane_group.border": "#3c324bcc",
+        "scrollbar.thumb.background": "#C9A8F977",
+        "scrollbar.thumb.hover_background": "#C9A8F9FF",
+        "scrollbar.thumb.border": "#00000000",
+        "scrollbar.track.background": "#141119ff",
+        "scrollbar.track.border": "#C9A8F944",
+        "editor.foreground": "#f8f8f2ff",
+        "editor.background": "#282a36ff",
+        "editor.gutter.background": "#282a36ff",
+        "editor.subheader.background": "#1e1925ff",
+        "editor.active_line.background": "#C9A8F933",
+        "editor.highlighted_line.background": "#44475aff",
+        "editor.line_number": "#f8f8f250",
+        "editor.active_line_number": "#C9A8F9FF",
+        "editor.invisible": "#f8f8f230",
+        "editor.wrap_guide": "#f8f8f228",
+        "editor.active_wrap_guide": "#bd93f965",
+        "editor.document_highlight.read_background": "#C9A8F940",
+        "editor.document_highlight.write_background": "#44475aff",
+        "editor.document_highlight.bracket_background": "#bd93f935",
+        "editor.indent_guide": "#f8f8f220",
+        "editor.indent_guide_active": "#bd93f950",
+        "link_text.hover": "#8be9fdff",
+        "conflict": "#dec184ff",
+        "conflict.background": "#dec18433",
+        "conflict.border": "#5d4c2fff",
+        "created": "#73fb95ff",
+        "created.background": "#222e1dff",
+        "created.border": "#38482fff",
+        "deleted": "#ff5555ff",
+        "deleted.background": "#301b1bff",
+        "deleted.border": "#4c2b2cff",
+        "error": "#e67373ff",
+        "error.background": "#242631ee",
+        "error.border": "#e67373ff",
+        "hidden": "#414754ff",
+        "hidden.background": "#242631ee",
+        "hidden.border": "#414754ff",
+        "hint": "#6272a4ff",
+        "hint.background": "#242631ee",
+        "hint.border": "#6272a4ff",
+        "ignored": "#C9A8F950",
+        "ignored.background": "#3c324bff",
+        "ignored.border": "#C9A8F950",
+        "info": "#73ece5ff",
+        "info.background": "#242631ee",
+        "info.border": "#73ece5ff",
+        "modified": "#a2edfdff",
+        "modified.background": "#242631ee",
+        "modified.border": "#a2edfdff",
+        "predictive": "#c6c6c2ff",
+        "predictive.background": "#242631ee",
+        "predictive.border": "#c6c6c2ff",
+        "renamed": "#8be9fdff",
+        "renamed.background": "#242631ee",
+        "renamed.border": "#8be9fdff",
+        "success": "#79e96dff",
+        "success.background": "#242631ee",
+        "success.border": "#79e96dff",
+        "unreachable": "#959591ff",
+        "unreachable.border": "#959591ff",
+        "warning": "#e6e373ff",
+        "warning.background": "#242631ee",
+        "warning.border": "#e6e373ff",
+        "players": [
+          {
+            "cursor": "#bd93f9ff",
+            "background": "#bd93f9ff",
+            "selection": "#bd93f933"
+          },
+          {
+            "cursor": "#50fa7bff",
+            "background": "#50fa7bff",
+            "selection": "#50fa7b33"
+          },
+          {
+            "cursor": "#ff79c6ff",
+            "background": "#ff79c6ff",
+            "selection": "#ff79c633"
+          },
+          {
+            "cursor": "#f1fa8cff",
+            "background": "#f1fa8cff",
+            "selection": "#f1fa8c33"
+          },
+          {
+            "cursor": "#8be9fdff",
+            "background": "#8be9fdff",
+            "selection": "#8be9fd33"
+          },
+          {
+            "cursor": "#ffb86cff",
+            "background": "#ffb86cff",
+            "selection": "#ffb86c33"
+          },
+          {
+            "cursor": "#ff5555ff",
+            "background": "#ff5555ff",
+            "selection": "#ff555533"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": "#ff79c6ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#ff79c6ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#6272a4ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#ff79c6ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#bd93f9ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#ff79c6ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#f8f8f2ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": "#f1fa8cff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": "#ffb86cff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "enum": {
+            "color": "#bd93f9ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function": {
+            "color": "#50fa7bff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "hint": {
+            "color": "#bd93f9ff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "keyword": {
+            "color": "#ff79c6ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#f8f8f2ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#ff79c6ff",
+            "font_style": "normal",
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#8be9fdff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#bd93f9ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#ff79c6ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predictive": {
+            "color": "#c6c6c2ff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#6272a4ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "#f8f8f2ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#8be9fdff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#ff79c6ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#f8f8f2ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#ff79c6ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#8be9fdff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#ff79c6ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#f1fa8cff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#ff79c6ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#ff5555ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#ff79c6ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#bd93f9ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#ff79c6ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#50fa7bff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#bd93f9ff",
+            "font_style": null,
+            "font_weight": 600
+          },
+          "type": {
+            "color": "#8be9fdff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.interface": {
+            "color": "#8be9fdff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "type.super": {
+            "color": "#8be9fdff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#f8f8f2ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.member": {
+            "color": "#f8f8f2ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.parameter": {
+            "color": "#ffb86cff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#bd93f9ff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "variant": {
+            "color": "#bd93f9ff",
+            "font_style": null,
+            "font_weight": null
+          }
+        },
+        "terminal.background": "#14151bff",
+        "terminal.foreground": "#f8f8f2ff",
+        "terminal.bright_foreground": "#f9f9f5ff",
+        "terminal.dim_foreground": "#c6c6c2ff",
+        "terminal.ansi.background": "#14151bff",
+        "terminal.ansi.black": "#21222cff",
+        "terminal.ansi.bright_black": "#919cbfff",
+        "terminal.ansi.dim_black": "#1a1b23ff",
+        "terminal.ansi.red": "#ff5555ff",
+        "terminal.ansi.bright_red": "#FF6E6Eff",
+        "terminal.ansi.dim_red": "#cc4444ff",
+        "terminal.ansi.green": "#50fa7bff",
+        "terminal.ansi.bright_green": "#69FF94ff",
+        "terminal.ansi.dim_green": "#40c862ff",
+        "terminal.ansi.yellow": "#f1fa8cff",
+        "terminal.ansi.bright_yellow": "#FFFFA5ff",
+        "terminal.ansi.dim_yellow": "#c1c870ff",
+        "terminal.ansi.blue": "#9580ffff",
+        "terminal.ansi.bright_blue": "#D6ACFFff",
+        "terminal.ansi.dim_blue": "#7766ccff",
+        "terminal.ansi.magenta": "#ff79c6ff",
+        "terminal.ansi.bright_magenta": "#FF92DFff",
+        "terminal.ansi.dim_magenta": "#cc619eff",
+        "terminal.ansi.cyan": "#8be9fdff",
+        "terminal.ansi.bright_cyan": "#A4FFFFff",
+        "terminal.ansi.dim_cyan": "#6fbacaff",
+        "terminal.ansi.white": "#f8f8f2ff",
+        "terminal.ansi.bright_white": "ffffffff",
+        "terminal.ansi.dim_white": "#c6c6c2ff",
+        "vim.normal.background": "#8be9fdff",
+        "vim.insert.background": "#50fa7bff",
+        "vim.replace.background": "#ff5555ff",
+        "vim.visual.background": "#bd93f9ff",
+        "vim.visual_line.background": "#bd93f9ff",
+        "vim.visual_block.background": "#bd93f9ff",
+        "vim.helix_normal.background": "#8be9fdff",
+        "vim.helix_select.background": "#50fa7bff",
+        "vim.mode.text": "#282a36ff"
+      }
+    },
+    {
+      "name": "Dracula Solid",
+      "appearance": "dark",
+      "style": {
+        "accents": [
+          "#bd93f9ff",
+          "#ff79c6ff",
+          "#8be9fdff",
+          "#50fa7bff",
+          "#ffb86cff",
+          "#f1fa8cff",
+          "#ff5555ff"
+        ],
+        "background.appearance": "opaque",
+        "border": "#3c324bff",
+        "border.variant": "#504364ff",
+        "border.focused": "#C9A8F9FF",
+        "border.selected": "#d4b9faff",
+        "border.transparent": "#282a36ff",
+        "border.disabled": "#6272a4ff",
+        "elevated_surface.background": "#1e1925ff",
+        "surface.background": "#242631ff",
+        "background": "#282a36ff",
+        "element.background": "#1c1d26ff",
+        "element.hover": "#504364ff",
+        "element.active": "#796595ff",
+        "element.selected": "#65547dff",
+        "element.disabled": "#e9dbfdff",
+        "drop_target.background": "#504364ff",
+        "ghost_element.background": "#22222211",
+        "ghost_element.hover": "#463b57ff",
+        "ghost_element.active": "#65547dff",
+        "ghost_element.selected": "#322a3eff",
+        "ghost_element.disabled": "#ff5555ff",
+        "text": "#f8f8f2ff",
+        "text.muted": "#a186c7ff",
+        "text.placeholder": "#a186c7ff",
+        "text.disabled": "#65547dff",
+        "text.accent": "#C9A8F9FF",
+        "icon": "#f8f8f2ff",
+        "icon.muted": "#aeaea9ff",
+        "icon.disabled": "#636361ff",
+        "icon.placeholder": "#7c7c79ff",
+        "icon.accent": "#C9A8F9FF",
+        "status_bar.background": "#141119ff",
+        "title_bar.background": "#141119ff",
+        "title_bar.inactive_background": "#0a080cff",
+        "toolbar.background": "#282a36ff",
+        "tab_bar.background": "#282232ff",
+        "tab.inactive_background": "#1c1d26ff",
+        "tab.active_background": "#282a36ff",
+        "search.match_background": "#287d3eff",
+        "panel.background": "#0a080cff",
+        "panel.focused_border": "#C9A8F9FF",
+        "panel.indent_guide": "#323230ff",
+        "panel.indent_guide_active": "#5f4a7dff",
+        "panel.indent_guide_hover": "#423357ff",
+        "pane.focused_border": "#C9A8F9FF",
+        "pane_group.border": "#3c324bff",
+        "scrollbar.thumb.background": "#C9A8F977",
+        "scrollbar.thumb.hover_background": "#d4b9faff",
+        "scrollbar.thumb.border": "#282a36ff",
+        "scrollbar.track.background": "#141119ff",
+        "scrollbar.track.border": "#584a6eff",
+        "editor.foreground": "#f8f8f2ff",
+        "editor.background": "#282a36ff",
+        "editor.gutter.background": "#282a36ff",
+        "editor.subheader.background": "#1e1925ff",
+        "editor.active_line.background": "#44475aff",
+        "editor.highlighted_line.background": "#44475aff",
+        "editor.line_number": "#7c7c79ff",
+        "editor.active_line_number": "#C9A8F9FF",
+        "editor.invisible": "#4a4a49ff",
+        "editor.wrap_guide": "#454544ff",
+        "editor.active_wrap_guide": "#7b60a2ff",
+        "editor.document_highlight.read_background": "#504364ff",
+        "editor.document_highlight.write_background": "#44475aff",
+        "editor.document_highlight.bracket_background": "#423357ff",
+        "editor.indent_guide": "#323230ff",
+        "editor.indent_guide_active": "#5f4a7dff",
+        "link_text.hover": "#8be9fdff",
+        "conflict": "#dec184ff",
+        "conflict.background": "#dec18433",
+        "conflict.border": "#5d4c2fff",
+        "created": "#73fb95ff",
+        "created.background": "#222e1dff",
+        "created.border": "#38482fff",
+        "deleted": "#ff5555ff",
+        "deleted.background": "#301b1bff",
+        "deleted.border": "#4c2b2cff",
+        "error": "#e67373ff",
+        "error.background": "#242631ff",
+        "error.border": "#e67373ff",
+        "hidden": "#414754ff",
+        "hidden.background": "#242631ff",
+        "hidden.border": "#414754ff",
+        "hint": "#6272a4ff",
+        "hint.background": "#242631ff",
+        "hint.border": "#6272a4ff",
+        "ignored": "#65547dff",
+        "ignored.background": "#3c324bff",
+        "ignored.border": "#65547dff",
+        "info": "#73ece5ff",
+        "info.background": "#242631ff",
+        "info.border": "#73ece5ff",
+        "modified": "#a2edfdff",
+        "modified.background": "#242631ff",
+        "modified.border": "#a2edfdff",
+        "predictive": "#c6c6c2ff",
+        "predictive.background": "#242631ff",
+        "predictive.border": "#c6c6c2ff",
+        "renamed": "#8be9fdff",
+        "renamed.background": "#242631ff",
+        "renamed.border": "#8be9fdff",
+        "success": "#79e96dff",
+        "success.background": "#242631ff",
+        "success.border": "#79e96dff",
+        "unreachable": "#959591ff",
+        "unreachable.border": "#959591ff",
+        "warning": "#e6e373ff",
+        "warning.background": "#242631ff",
+        "warning.border": "#e6e373ff",
+        "players": [
+          {
+            "cursor": "#bd93f9ff",
+            "background": "#bd93f9ff",
+            "selection": "#bd93f933"
+          },
+          {
+            "cursor": "#50fa7bff",
+            "background": "#50fa7bff",
+            "selection": "#50fa7b33"
+          },
+          {
+            "cursor": "#ff79c6ff",
+            "background": "#ff79c6ff",
+            "selection": "#ff79c633"
+          },
+          {
+            "cursor": "#f1fa8cff",
+            "background": "#f1fa8cff",
+            "selection": "#f1fa8c33"
+          },
+          {
+            "cursor": "#8be9fdff",
+            "background": "#8be9fdff",
+            "selection": "#8be9fd33"
+          },
+          {
+            "cursor": "#ffb86cff",
+            "background": "#ffb86cff",
+            "selection": "#ffb86c33"
+          },
+          {
+            "cursor": "#ff5555ff",
+            "background": "#ff5555ff",
+            "selection": "#ff555533"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": "#ff79c6ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#ff79c6ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#6272a4ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#ff79c6ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#bd93f9ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#ff79c6ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#f8f8f2ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": "#f1fa8cff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": "#ffb86cff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "enum": {
+            "color": "#bd93f9ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function": {
+            "color": "#50fa7bff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "hint": {
+            "color": "#bd93f9ff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "keyword": {
+            "color": "#ff79c6ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#f8f8f2ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#ff79c6ff",
+            "font_style": "normal",
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#8be9fdff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#bd93f9ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#ff79c6ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predictive": {
+            "color": "#c6c6c2ff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#6272a4ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "#f8f8f2ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#8be9fdff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#ff79c6ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#f8f8f2ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#ff79c6ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#8be9fdff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#ff79c6ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#f1fa8cff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#ff79c6ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#ff5555ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#ff79c6ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#bd93f9ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#ff79c6ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#50fa7bff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#bd93f9ff",
+            "font_style": null,
+            "font_weight": 600
+          },
+          "type": {
+            "color": "#8be9fdff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.interface": {
+            "color": "#8be9fdff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "type.super": {
+            "color": "#8be9fdff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#f8f8f2ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.member": {
+            "color": "#f8f8f2ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.parameter": {
+            "color": "#ffb86cff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#bd93f9ff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "variant": {
+            "color": "#bd93f9ff",
+            "font_style": null,
+            "font_weight": null
+          }
+        },
+        "terminal.background": "#14151bff",
+        "terminal.foreground": "#f8f8f2ff",
+        "terminal.bright_foreground": "#f9f9f5ff",
+        "terminal.dim_foreground": "#c6c6c2ff",
+        "terminal.ansi.background": "#14151bff",
+        "terminal.ansi.black": "#21222cff",
+        "terminal.ansi.bright_black": "#919cbfff",
+        "terminal.ansi.dim_black": "#1a1b23ff",
+        "terminal.ansi.red": "#ff5555ff",
+        "terminal.ansi.bright_red": "#FF6E6Eff",
+        "terminal.ansi.dim_red": "#cc4444ff",
+        "terminal.ansi.green": "#50fa7bff",
+        "terminal.ansi.bright_green": "#69FF94ff",
+        "terminal.ansi.dim_green": "#40c862ff",
+        "terminal.ansi.yellow": "#f1fa8cff",
+        "terminal.ansi.bright_yellow": "#FFFFA5ff",
+        "terminal.ansi.dim_yellow": "#c1c870ff",
+        "terminal.ansi.blue": "#9580ffff",
+        "terminal.ansi.bright_blue": "#D6ACFFff",
+        "terminal.ansi.dim_blue": "#7766ccff",
+        "terminal.ansi.magenta": "#ff79c6ff",
+        "terminal.ansi.bright_magenta": "#FF92DFff",
+        "terminal.ansi.dim_magenta": "#cc619eff",
+        "terminal.ansi.cyan": "#8be9fdff",
+        "terminal.ansi.bright_cyan": "#A4FFFFff",
+        "terminal.ansi.dim_cyan": "#6fbacaff",
+        "terminal.ansi.white": "#f8f8f2ff",
+        "terminal.ansi.bright_white": "ffffffff",
+        "terminal.ansi.dim_white": "#c6c6c2ff"
+      }
+    },
+    {
+      "name": "Dracula Light (Alucard)",
+      "appearance": "light",
+      "style": {
+        "accents": [
+          "#644AC9",
+          "#A3144D",
+          "#036A96",
+          "#14710A",
+          "#A34D14",
+          "#846E15",
+          "#CB3A2A"
+        ],
+        "background.appearance": "opaque",
+        "border": "#d1c9efff",
+        "border.variant": "#e4e4e4ff",
+        "border.focused": "#F5F5F577",
+        "border.selected": "#F5F5F5bb",
+        "border.transparent": null,
+        "border.disabled": null,
+        "elevated_surface.background": "#f6f6f6ff",
+        "surface.background": "#ddddddee",
+        "background": "#F5F5F5",
+        "element.background": "#dce0e8ff",
+        "element.hover": "#ccd0daff",
+        "element.active": "#d6d9e1ff",
+        "element.selected": "#CFCFDE",
+        "element.disabled": "#fbfbfbff",
+        "drop_target.background": "#ACB0BE42",
+        "ghost_element.background": null,
+        "ghost_element.hover": "#ccd0daff",
+        "ghost_element.active": "#d6d9e1ff",
+        "ghost_element.selected": "#dce0e8ff",
+        "ghost_element.disabled": "#CB3A2A",
+        "text": "#1F1F1F",
+        "text.muted": "#353535ff",
+        "text.placeholder": "#1F1F1F80",
+        "text.disabled": "#1F1F1F70",
+        "text.accent": "#836ed4ff",
+        "icon": "#1F1F1F",
+        "icon.muted": "#1F1F1F70",
+        "icon.disabled": "#1F1F1F40",
+        "icon.placeholder": "#1F1F1F50",
+        "icon.accent": "#836ed4ff",
+        "status_bar.background": "#FEFEFEff",
+        "title_bar.background": "#FEFEFEff",
+        "title_bar.inactive_background": "#F0F0F0ff",
+        "toolbar.background": "#F5F5F570",
+        "tab_bar.background": "#D5DAE4ff",
+        "tab.inactive_background": "#EDEFF4ff",
+        "tab.active_background": "#F5F5F5",
+        "search.match_background": "#14710A30",
+        "panel.background": "#EDEFF4ff",
+        "panel.focused_border": "#644AC9",
+        "panel.indent_guide": "#1F1F1F30",
+        "panel.indent_guide_active": "#644AC960",
+        "panel.indent_guide_hover": "#644AC945",
+        "pane.focused_border": "#644AC9",
+        "pane_group.border": "#d1c9efff",
+        "scrollbar.thumb.background": "#644AC977",
+        "scrollbar.thumb.hover_background": "#644AC9",
+        "scrollbar.thumb.border": null,
+        "scrollbar.track.background": "#F5F5F5",
+        "scrollbar.track.border": "#d1c9efff",
+        "editor.foreground": "#1F1F1F",
+        "editor.background": "#F5F5F5",
+        "editor.gutter.background": "#F5F5F5",
+        "editor.subheader.background": "#d0d0d0ff",
+        "editor.active_line.background": "acb0be30",
+        "editor.highlighted_line.background": "#CFCFDE",
+        "editor.line_number": "#1F1F1F80",
+        "editor.active_line_number": "#1F1F1F",
+        "editor.invisible": "#1F1F1F40",
+        "editor.wrap_guide": "#1F1F1F28",
+        "editor.active_wrap_guide": "#b2a5e4ff",
+        "editor.document_highlight.read_background": "#036A9630",
+        "editor.document_highlight.write_background": "#CFCFDE",
+        "editor.document_highlight.bracket_background": "#644AC925",
+        "editor.indent_guide": "#1F1F1F30",
+        "editor.indent_guide_active": "#644AC960",
+        "link_text.hover": "#036A96",
+        "conflict": "#dec184ff",
+        "conflict.background": "#dec18433",
+        "conflict.border": "#5d4c2fff",
+        "created": "#5b9c54ff",
+        "created.background": "#222e1dff",
+        "created.border": "#38482fff",
+        "deleted": "#db756aff",
+        "deleted.background": "#ddddddee",
+        "deleted.border": "#db756aff",
+        "error": "#b83233ff",
+        "error.background": "#ddddddee",
+        "error.border": "#993a27ff",
+        "hidden": "#414754ff",
+        "hidden.background": "#ddddddee",
+        "hidden.border": "#414754ff",
+        "hint": "#635D97",
+        "hint.background": "#f0f0f0ee",
+        "hint.border": "#635D97",
+        "ignored": "#1F1F1F70",
+        "ignored.background": "#4a4a4aff",
+        "ignored.border": "#1F1F1F50",
+        "info": "#0067a1ff",
+        "info.background": "#f0f0f0ee",
+        "info.border": "#0067a1ff",
+        "modified": "#4f97b6ff",
+        "modified.background": "#f0f0f0ee",
+        "modified.border": "#4f97b6ff",
+        "predictive": "#575757ff",
+        "predictive.background": "#f0f0f0ee",
+        "predictive.border": "#575757ff",
+        "renamed": "#036A96",
+        "renamed.background": "#f0f0f0ee",
+        "renamed.border": "#036A96",
+        "success": "#1b7108ff",
+        "success.background": "#f0f0f0ee",
+        "success.border": "#1b7108ff",
+        "unreachable": "#575757ff",
+        "unreachable.background": "#f0f0f0ee",
+        "unreachable.border": "#575757ff",
+        "warning": "#ccb517ff",
+        "warning.background": "#f0f0f0ee",
+        "warning.border": "#984f00",
+        "players": [
+          {
+            "cursor": "#644AC9",
+            "background": "#644AC9",
+            "selection": "#644AC933"
+          },
+          {
+            "cursor": "#14710A",
+            "background": "#14710A",
+            "selection": "#14710A33"
+          },
+          {
+            "cursor": "#A3144D",
+            "background": "#A3144D",
+            "selection": "#A3144D33"
+          },
+          {
+            "cursor": "#846E15",
+            "background": "#846E15",
+            "selection": "#846E1533"
+          },
+          {
+            "cursor": "#036A96",
+            "background": "#036A96",
+            "selection": "#036A9633"
+          },
+          {
+            "cursor": "#A34D14",
+            "background": "#A34D14",
+            "selection": "#A34D1433"
+          },
+          {
+            "cursor": "#CB3A2A",
+            "background": "#CB3A2A",
+            "selection": "#CB3A2A33"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": "#A3144D",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#A3144D",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#635D97",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#A3144D",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#644AC9",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#A3144D",
+            "font_style": null,
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#1F1F1F",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": "#846E15",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": "#A34D14",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "enum": {
+            "color": "#644AC9",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function": {
+            "color": "#14710A",
+            "font_style": null,
+            "font_weight": null
+          },
+          "hint": {
+            "color": "#644AC9",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "keyword": {
+            "color": "#A3144D",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#1F1F1F",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#A3144D",
+            "font_style": "normal",
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#036A96",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#644AC9",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#A3144D",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predictive": {
+            "color": "#191919ff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#635D97",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "#1F1F1F",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#036A96",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#A3144D",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#1F1F1F",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#A3144D",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#036A96",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#A3144D",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#846E15",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#A3144D",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#CB3A2A",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#A3144D",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#644AC9",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#A3144D",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#14710A",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#644AC9",
+            "font_style": null,
+            "font_weight": 600
+          },
+          "type": {
+            "color": "#036A96",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.interface": {
+            "color": "#036A96",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "type.super": {
+            "color": "#036A96",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#1F1F1F",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.member": {
+            "color": "#1F1F1F",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.parameter": {
+            "color": "#A34D14",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#644AC9",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "variant": {
+            "color": "#644AC9",
+            "font_style": null,
+            "font_weight": null
+          }
+        },
+        "terminal.background": "#f3f3f3ff",
+        "terminal.foreground": "#1F1F1F",
+        "terminal.bright_foreground": "#1D1D1D",
+        "terminal.dim_foreground": "#655C95",
+        "terminal.ansi.background": "#f3f3f3ff",
+        "terminal.ansi.black": "#F5F5F5",
+        "terminal.ansi.bright_black": "#928eb6ff",
+        "terminal.ansi.dim_black": "#1D1D1D",
+        "terminal.ansi.red": "#CB3A2A",
+        "terminal.ansi.bright_red": "#D74C3D",
+        "terminal.ansi.dim_red": "#D74B3B",
+        "terminal.ansi.green": "#14710A",
+        "terminal.ansi.bright_green": "#198D0C",
+        "terminal.ansi.dim_green": "#D74B3B",
+        "terminal.ansi.yellow": "#846E15",
+        "terminal.ansi.bright_yellow": "#9E841A",
+        "terminal.ansi.dim_yellow": "#D74B3B",
+        "terminal.ansi.blue": "#644AC9",
+        "terminal.ansi.bright_blue": "#7862D0",
+        "terminal.ansi.dim_blue": "#D74B3B",
+        "terminal.ansi.magenta": "#A3144D",
+        "terminal.ansi.bright_magenta": "#BF185A",
+        "terminal.ansi.dim_magenta": "#D74B3B",
+        "terminal.ansi.cyan": "#036A96",
+        "terminal.ansi.bright_cyan": "#047FB4",
+        "terminal.ansi.dim_cyan": "#D74B3B",
+        "terminal.ansi.white": "#1F1F1F",
+        "terminal.ansi.bright_white": "#2C2B31",
+        "terminal.ansi.dim_white": "#D74B3B",
+        "vim.normal.background": "#036A96",
+        "vim.insert.background": "#14710A",
+        "vim.replace.background": "#CB3A2A",
+        "vim.visual.background": "#644AC9",
+        "vim.visual_line.background": "#644AC9",
+        "vim.visual_block.background": "#644AC9",
+        "vim.helix_normal.background": "#036A96",
+        "vim.helix_select.background": "#14710A",
+        "vim.mode.text": "#F5F5F5"
+      }
+    }
+  ]
+}

--- a/themes/github_theme.json
+++ b/themes/github_theme.json
@@ -1,0 +1,3753 @@
+{
+  "$schema": "https://zed.dev/schema/themes/v0.1.0.json",
+  "name": "Github Theme",
+  "author": "Pyae Sone Aung",
+  "themes": [
+    {
+      "appearance": "light",
+      "name": "Github Light",
+      "style": {
+        "accents": [
+          "#006edbff",
+          "#30a147ff",
+          "#b88700ff",
+          "#df0c24ff",
+          "#ce2c85ff",
+          "#894cebff"
+        ],
+        "background.appearance": "opaque",
+        "background": "#ffffffff",
+        "border": "#d1d9e0ff",
+        "border.disabled": "#818b981a",
+        "border.focused": "#0969daff",
+        "border.selected": "#0969daff",
+        "border.transparent": "#ffffff00",
+        "border.variant": "#d1d9e0b3",
+        "conflict": "#bc4c00ff",
+        "conflict.background": "#fff1e5ff",
+        "conflict.border": "#fb8f4466",
+        "created": "#1a7f37ff",
+        "created.background": "#dafbe1ff",
+        "created.border": "#4ac26b66",
+        "deleted": "#d1242fff",
+        "deleted.background": "#ffebe9ff",
+        "deleted.border": "#ff818266",
+        "drop_target.background": "#ddf4ffff",
+        "editor.active_line.background": "#f6f8faff",
+        "editor.active_line_number": "#1f2328ff",
+        "editor.active_wrap_guide": "#d1d9e0b3",
+        "editor.background": "#ffffffff",
+        "editor.document_highlight.read_background": "#0969da4d",
+        "editor.document_highlight.write_background": "#0969da33",
+        "editor.foreground": "#1f2328ff",
+        "editor.gutter.background": "#ffffffff",
+        "editor.highlighted_line.background": "#818b981f",
+        "editor.invisible": "#818b98ff",
+        "editor.line_number": "#59636eff",
+        "editor.subheader.background": "#f6f8faff",
+        "editor.wrap_guide": "#d1d9e0b3",
+        "element.active": "#818b981f",
+        "element.background": "#818b981f",
+        "element.disabled": "#eff2f5ff",
+        "element.hover": "#818b981f",
+        "element.selected": "#818b981f",
+        "elevated_surface.background": "#ffffffff",
+        "error": "#d1242fff",
+        "error.background": "#f6f8faff",
+        "error.border": "#d1d9e0b3",
+        "ghost_element.active": "#818b981f",
+        "ghost_element.background": "#ffffff00",
+        "ghost_element.disabled": "#eff2f5ff",
+        "ghost_element.hover": "#818b981f",
+        "ghost_element.selected": "#818b981f",
+        "hidden": "#818b98ff",
+        "hidden.background": "#eff2f5ff",
+        "hidden.border": "#818b981a",
+        "hint": "#59636eff",
+        "hint.background": "#f6f8faff",
+        "hint.border": "#d1d9e0b3",
+        "icon": "#1f2328ff",
+        "icon.background": "#ffffffff",
+        "icon.border": "#d1d9e0ff",
+        "icon.accent": "#0969daff",
+        "icon.muted": "#59636eff",
+        "icon.disabled": "#818b98ff",
+        "ignored": "#59636eff",
+        "ignored.background": "#eff2f5ff",
+        "ignored.border": "#818b981a",
+        "info": "#9a6700ff",
+        "info.background": "#f6f8faff",
+        "info.border": "#d1d9e0b3",
+        "link_text.hover": "#0969daff",
+        "modified": "#9a6700ff",
+        "modified.background": "#fff8c5ff",
+        "modified.border": "#d4a72c66",
+        "pane.focused_border": "#d1d9e0ff",
+        "panel.background": "#f6f8faff",
+        "panel.focused_border": "#d1d9e0ff",
+        "predictive": "#59636eff",
+        "predictive.background": "#818b981f",
+        "predictive.border": "#d1d9e0b3",
+        "renamed": "#1a7f37ff",
+        "renamed.background": "#dafbe1ff",
+        "renamed.border": "#4ac26b66",
+        "scrollbar.thumb.border": "#ffffff00",
+        "scrollbar.thumb.hover_background": "#f6f8faff",
+        "scrollbar.track.background": "#ffffff00",
+        "scrollbar.track.border": "#ffffff00",
+        "search.match_background": "#fae17d4d",
+        "status_bar.background": "#f6f8faff",
+        "success": "#1a7f37ff",
+        "success.background": "#dafbe1ff",
+        "success.border": "#4ac26b66",
+        "surface.background": "#f6f8faff",
+        "tab.active_background": "#ffffffff",
+        "tab.inactive_background": "#f6f8faff",
+        "tab_bar.background": "#f6f8faff",
+        "terminal.ansi.black": "#1f2328ff",
+        "terminal.ansi.bright_black": "#393f46ff",
+        "terminal.ansi.dim_black": "#1f2328ff",
+        "terminal.ansi.blue": "#0969daff",
+        "terminal.ansi.bright_blue": "#218bffff",
+        "terminal.ansi.dim_blue": "#0969daff",
+        "terminal.ansi.cyan": "#1b7c83ff",
+        "terminal.ansi.bright_cyan": "#3192aaff",
+        "terminal.ansi.dim_cyan": "#1b7c83ff",
+        "terminal.ansi.green": "#116329ff",
+        "terminal.ansi.bright_green": "#1a7f37ff",
+        "terminal.ansi.dim_green": "#116329ff",
+        "terminal.ansi.magenta": "#8250dfff",
+        "terminal.ansi.bright_magenta": "#a475f9ff",
+        "terminal.ansi.dim_magenta": "#8250dfff",
+        "terminal.ansi.red": "#cf222eff",
+        "terminal.ansi.bright_red": "#a40e26ff",
+        "terminal.ansi.dim_red": "#cf222eff",
+        "terminal.ansi.white": "#59636eff",
+        "terminal.ansi.bright_white": "#818b98ff",
+        "terminal.ansi.dim_white": "#59636eff",
+        "terminal.ansi.yellow": "#4d2d00ff",
+        "terminal.ansi.bright_yellow": "#633c01ff",
+        "terminal.ansi.dim_yellow": "#4d2d00ff",
+        "terminal.background": "#f6f8faff",
+        "terminal.bright_foreground": "#ffffffff",
+        "terminal.dim_foreground": "#59636eff",
+        "terminal.foreground": "#1f2328ff",
+        "text": "#1f2328ff",
+        "text.accent": "#0969daff",
+        "text.disabled": "#818b98ff",
+        "text.muted": "#1f2328ff",
+        "text.placeholder": "#59636eff",
+        "title_bar.background": "#f6f8faff",
+        "toolbar.background": "#ffffffff",
+        "unreachable": "#818b98ff",
+        "unreachable.background": "#eff2f5ff",
+        "unreachable.border": "#818b981a",
+        "vim.mode.text": "#1f2328ff",
+        "vim.normal.background": "#59636eff",
+        "vim.helix_normal.background": "#59636eff",
+        "vim.visual.background": "#0969daff",
+        "vim.helix_select.background": "#0969daff",
+        "vim.insert.background": "#1f883dff",
+        "vim.visual_line.background": "#0969daff",
+        "vim.visual_block.background": "#8250dfff",
+        "vim.replace.background": "#bf3989ff",
+        "warning": "#9a6700ff",
+        "warning.background": "#f6f8faff",
+        "warning.border": "#d1d9e0b3",
+        "players": [
+          {
+            "cursor": "#006edbff",
+            "background": "#006edbff",
+            "selection": "#006edb66"
+          },
+          {
+            "cursor": "#30a147ff",
+            "background": "#30a147ff",
+            "selection": "#30a14766"
+          },
+          {
+            "cursor": "#b88700ff",
+            "background": "#b88700ff",
+            "selection": "#b8870066"
+          },
+          {
+            "cursor": "#df0c24ff",
+            "background": "#df0c24ff",
+            "selection": "#df0c2466"
+          },
+          {
+            "cursor": "#ce2c85ff",
+            "background": "#ce2c85ff",
+            "selection": "#ce2c8566"
+          },
+          {
+            "cursor": "#894cebff",
+            "background": "#894cebff",
+            "selection": "#894ceb66"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#59636eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#59636eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#cf222eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#cf222eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": null,
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": null,
+            "font_style": null,
+            "font_weight": 700
+          },
+          "enum": {
+            "color": "#953800ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function": {
+            "color": "#8250dfff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.method": {
+            "color": "#8250dfff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.special.definition": {
+            "color": "#8250dfff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "hint": {
+            "color": "#59636eff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "keyword": {
+            "color": "#cf222eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.operator": {
+            "color": "#cf222eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#0a3069ff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#cf222eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predictive": {
+            "color": "#59636eff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#cf222eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "#1f2328ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#1f2328ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property.json_key": {
+            "color": "#116329ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#cf222eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#1f2328ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#1f2328ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter.jsx": {
+            "color": "#cf222eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#953800ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#cf222eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#0a3069ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#cf222eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#0a3069ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#116329ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "type": {
+            "color": "#953800ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.builtin": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#1f2328ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.builtin": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.parameter": {
+            "color": "#953800ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variant": {
+            "color": "#953800ff",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    },
+    {
+      "appearance": "light",
+      "name": "Github Light Colorblind",
+      "style": {
+        "accents": [
+          "#006edbff",
+          null,
+          "#b88700ff",
+          "#ce2c85ff"
+        ],
+        "background.appearance": "opaque",
+        "background": "#ffffffff",
+        "border": "#d1d9e0ff",
+        "border.disabled": "#818b981a",
+        "border.focused": "#0969daff",
+        "border.selected": "#0969daff",
+        "border.transparent": "#ffffff00",
+        "border.variant": "#d1d9e0b3",
+        "conflict": "#bc4c00ff",
+        "conflict.background": "#fff1e5ff",
+        "conflict.border": "#fb8f4466",
+        "created": "#0969daff",
+        "created.background": "#ddf4ffff",
+        "created.border": "#54aeff66",
+        "deleted": "#be4e02ff",
+        "deleted.background": "#fff1e5ff",
+        "deleted.border": "#fb8f4466",
+        "drop_target.background": "#ddf4ffff",
+        "editor.active_line.background": "#f6f8faff",
+        "editor.active_line_number": "#1f2328ff",
+        "editor.active_wrap_guide": "#d1d9e0b3",
+        "editor.background": "#ffffffff",
+        "editor.document_highlight.read_background": "#0969da4d",
+        "editor.document_highlight.write_background": "#0969da33",
+        "editor.foreground": "#1f2328ff",
+        "editor.gutter.background": "#ffffffff",
+        "editor.highlighted_line.background": "#818b981f",
+        "editor.invisible": "#818b98ff",
+        "editor.line_number": "#59636eff",
+        "editor.subheader.background": "#f6f8faff",
+        "editor.wrap_guide": "#d1d9e0b3",
+        "element.active": "#818b981f",
+        "element.background": "#818b981f",
+        "element.disabled": "#eff2f5ff",
+        "element.hover": "#818b981f",
+        "element.selected": "#818b981f",
+        "elevated_surface.background": "#ffffffff",
+        "error": "#be4e02ff",
+        "error.background": "#f6f8faff",
+        "error.border": "#d1d9e0b3",
+        "ghost_element.active": "#818b981f",
+        "ghost_element.background": "#ffffff00",
+        "ghost_element.disabled": "#eff2f5ff",
+        "ghost_element.hover": "#818b981f",
+        "ghost_element.selected": "#818b981f",
+        "hidden": "#818b98ff",
+        "hidden.background": "#eff2f5ff",
+        "hidden.border": "#818b981a",
+        "hint": "#59636eff",
+        "hint.background": "#f6f8faff",
+        "hint.border": "#d1d9e0b3",
+        "icon": "#1f2328ff",
+        "icon.background": "#ffffffff",
+        "icon.border": "#d1d9e0ff",
+        "icon.accent": "#0969daff",
+        "icon.muted": "#59636eff",
+        "icon.disabled": "#818b98ff",
+        "ignored": "#59636eff",
+        "ignored.background": "#eff2f5ff",
+        "ignored.border": "#818b981a",
+        "info": "#9a6700ff",
+        "info.background": "#f6f8faff",
+        "info.border": "#d1d9e0b3",
+        "link_text.hover": "#0969daff",
+        "modified": "#9a6700ff",
+        "modified.background": "#fff8c5ff",
+        "modified.border": "#d4a72c66",
+        "pane.focused_border": "#d1d9e0ff",
+        "panel.background": "#f6f8faff",
+        "panel.focused_border": "#d1d9e0ff",
+        "predictive": "#59636eff",
+        "predictive.background": "#818b981f",
+        "predictive.border": "#d1d9e0b3",
+        "renamed": "#0969daff",
+        "renamed.background": "#ddf4ffff",
+        "renamed.border": "#54aeff66",
+        "scrollbar.thumb.border": "#ffffff00",
+        "scrollbar.thumb.hover_background": "#f6f8faff",
+        "scrollbar.track.background": "#ffffff00",
+        "scrollbar.track.border": "#ffffff00",
+        "search.match_background": "#fae17d4d",
+        "status_bar.background": "#f6f8faff",
+        "success": "#0969daff",
+        "success.background": "#ddf4ffff",
+        "success.border": "#54aeff66",
+        "surface.background": "#f6f8faff",
+        "tab.active_background": "#ffffffff",
+        "tab.inactive_background": "#f6f8faff",
+        "tab_bar.background": "#f6f8faff",
+        "terminal.ansi.black": "#1f2328ff",
+        "terminal.ansi.bright_black": "#393f46ff",
+        "terminal.ansi.dim_black": "#1f2328ff",
+        "terminal.ansi.blue": "#0969daff",
+        "terminal.ansi.bright_blue": "#218bffff",
+        "terminal.ansi.dim_blue": "#0969daff",
+        "terminal.ansi.cyan": "#1b7c83ff",
+        "terminal.ansi.bright_cyan": "#3192aaff",
+        "terminal.ansi.dim_cyan": "#1b7c83ff",
+        "terminal.ansi.green": "#0550aeff",
+        "terminal.ansi.bright_green": "#0969daff",
+        "terminal.ansi.dim_green": "#0550aeff",
+        "terminal.ansi.magenta": "#8250dfff",
+        "terminal.ansi.bright_magenta": "#a475f9ff",
+        "terminal.ansi.dim_magenta": "#8250dfff",
+        "terminal.ansi.red": "#bc4c00ff",
+        "terminal.ansi.bright_red": "#953800ff",
+        "terminal.ansi.dim_red": "#bc4c00ff",
+        "terminal.ansi.white": "#59636eff",
+        "terminal.ansi.bright_white": "#818b98ff",
+        "terminal.ansi.dim_white": "#59636eff",
+        "terminal.ansi.yellow": "#4d2d00ff",
+        "terminal.ansi.bright_yellow": "#633c01ff",
+        "terminal.ansi.dim_yellow": "#4d2d00ff",
+        "terminal.background": "#f6f8faff",
+        "terminal.bright_foreground": "#ffffffff",
+        "terminal.dim_foreground": "#59636eff",
+        "terminal.foreground": "#1f2328ff",
+        "text": "#1f2328ff",
+        "text.accent": "#0969daff",
+        "text.disabled": "#818b98ff",
+        "text.muted": "#1f2328ff",
+        "text.placeholder": "#59636eff",
+        "title_bar.background": "#f6f8faff",
+        "toolbar.background": "#ffffffff",
+        "unreachable": "#818b98ff",
+        "unreachable.background": "#eff2f5ff",
+        "unreachable.border": "#818b981a",
+        "vim.mode.text": "#1f2328ff",
+        "vim.normal.background": "#59636eff",
+        "vim.helix_normal.background": "#59636eff",
+        "vim.visual.background": "#0969daff",
+        "vim.helix_select.background": "#0969daff",
+        "vim.insert.background": "#0969daff",
+        "vim.visual_line.background": "#0969daff",
+        "vim.visual_block.background": "#8250dfff",
+        "vim.replace.background": "#bf3989ff",
+        "warning": "#9a6700ff",
+        "warning.background": "#f6f8faff",
+        "warning.border": "#d1d9e0b3",
+        "players": [
+          {
+            "cursor": "#006edbff",
+            "background": "#006edbff",
+            "selection": "#006edb66"
+          },
+          {
+            "selection": null
+          },
+          {
+            "cursor": "#b88700ff",
+            "background": "#b88700ff",
+            "selection": "#b8870066"
+          },
+          {
+            "cursor": "#ce2c85ff",
+            "background": "#ce2c85ff",
+            "selection": "#ce2c8566"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#59636eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#59636eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#cf222eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#cf222eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": null,
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": null,
+            "font_style": null,
+            "font_weight": 700
+          },
+          "enum": {
+            "color": "#953800ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function": {
+            "color": "#8250dfff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.method": {
+            "color": "#8250dfff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.special.definition": {
+            "color": "#8250dfff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "hint": {
+            "color": "#59636eff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "keyword": {
+            "color": "#cf222eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.operator": {
+            "color": "#cf222eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#0a3069ff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#cf222eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predictive": {
+            "color": "#59636eff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#cf222eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "#1f2328ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#1f2328ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property.json_key": {
+            "color": "#116329ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#cf222eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#1f2328ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#1f2328ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter.jsx": {
+            "color": "#cf222eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#953800ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#cf222eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#0a3069ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#cf222eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#0a3069ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#116329ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "type": {
+            "color": "#953800ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.builtin": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#1f2328ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.builtin": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.parameter": {
+            "color": "#953800ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variant": {
+            "color": "#953800ff",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    },
+    {
+      "appearance": "light",
+      "name": "Github Light High Contrast",
+      "style": {
+        "accents": [
+          "#006edbff",
+          "#30a147ff",
+          "#b88700ff",
+          "#df0c24ff",
+          "#ce2c85ff",
+          "#894cebff"
+        ],
+        "background.appearance": "opaque",
+        "background": "#ffffffff",
+        "border": "#454c54ff",
+        "border.disabled": "#59636e1f",
+        "border.focused": "#0349b4ff",
+        "border.selected": "#0349b4ff",
+        "border.transparent": "#ffffff00",
+        "border.variant": "#454c54ff",
+        "conflict": "#702c00ff",
+        "conflict.background": "#fff2d5ff",
+        "conflict.border": "#dc6d1aff",
+        "created": "#024c1aff",
+        "created.background": "#d2fedbff",
+        "created.border": "#26a148ff",
+        "deleted": "#8a071eff",
+        "deleted.background": "#fff0eeff",
+        "deleted.border": "#ee5a5dff",
+        "drop_target.background": "#dff7ffff",
+        "editor.active_line.background": "#e6eaefff",
+        "editor.active_line_number": "#010409ff",
+        "editor.active_wrap_guide": "#454c54ff",
+        "editor.background": "#ffffffff",
+        "editor.document_highlight.read_background": "#023b954d",
+        "editor.document_highlight.write_background": "#023b9533",
+        "editor.foreground": "#010409ff",
+        "editor.gutter.background": "#ffffffff",
+        "editor.highlighted_line.background": "#e0e6ebff",
+        "editor.invisible": "#59636eff",
+        "editor.line_number": "#454c54ff",
+        "editor.subheader.background": "#e6eaefff",
+        "editor.wrap_guide": "#454c54ff",
+        "element.active": "#e0e6ebff",
+        "element.background": "#e0e6ebff",
+        "element.disabled": "#e0e6ebff",
+        "element.hover": "#e0e6ebff",
+        "element.selected": "#e0e6ebff",
+        "elevated_surface.background": "#ffffffff",
+        "error": "#8a071eff",
+        "error.background": "#e6eaefff",
+        "error.border": "#454c54ff",
+        "ghost_element.active": "#e0e6ebff",
+        "ghost_element.background": "#ffffff00",
+        "ghost_element.disabled": "#e0e6ebff",
+        "ghost_element.hover": "#e0e6ebff",
+        "ghost_element.selected": "#e0e6ebff",
+        "hidden": "#59636eff",
+        "hidden.background": "#e0e6ebff",
+        "hidden.border": "#59636e1f",
+        "hint": "#454c54ff",
+        "hint.background": "#e6eaefff",
+        "hint.border": "#454c54ff",
+        "icon": "#010409ff",
+        "icon.background": "#ffffffff",
+        "icon.border": "#454c54ff",
+        "icon.accent": "#023b95ff",
+        "icon.muted": "#454c54ff",
+        "icon.disabled": "#59636eff",
+        "ignored": "#454c54ff",
+        "ignored.background": "#e0e6ebff",
+        "ignored.border": "#59636e1f",
+        "info": "#603700ff",
+        "info.background": "#e6eaefff",
+        "info.border": "#454c54ff",
+        "link_text.hover": "#023b95ff",
+        "modified": "#603700ff",
+        "modified.background": "#fcf7beff",
+        "modified.border": "#b58407ff",
+        "pane.focused_border": "#454c54ff",
+        "panel.background": "#eff2f5ff",
+        "panel.focused_border": "#454c54ff",
+        "predictive": "#454c54ff",
+        "predictive.background": "#e0e6ebff",
+        "predictive.border": "#454c54ff",
+        "renamed": "#024c1aff",
+        "renamed.background": "#d2fedbff",
+        "renamed.border": "#26a148ff",
+        "scrollbar.thumb.border": "#ffffff00",
+        "scrollbar.thumb.hover_background": "#e6eaefff",
+        "scrollbar.track.background": "#ffffff00",
+        "scrollbar.track.border": "#ffffff00",
+        "search.match_background": "#f0ce534d",
+        "status_bar.background": "#eff2f5ff",
+        "success": "#024c1aff",
+        "success.background": "#d2fedbff",
+        "success.border": "#26a148ff",
+        "surface.background": "#eff2f5ff",
+        "tab.active_background": "#ffffffff",
+        "tab.inactive_background": "#eff2f5ff",
+        "tab_bar.background": "#eff2f5ff",
+        "terminal.ansi.black": "#010409ff",
+        "terminal.ansi.bright_black": "#393f46ff",
+        "terminal.ansi.dim_black": "#010409ff",
+        "terminal.ansi.blue": "#0349b4ff",
+        "terminal.ansi.bright_blue": "#1168e3ff",
+        "terminal.ansi.dim_blue": "#0349b4ff",
+        "terminal.ansi.cyan": "#1b7c83ff",
+        "terminal.ansi.bright_cyan": "#3192aaff",
+        "terminal.ansi.dim_cyan": "#1b7c83ff",
+        "terminal.ansi.green": "#024c1aff",
+        "terminal.ansi.bright_green": "#055d20ff",
+        "terminal.ansi.dim_green": "#024c1aff",
+        "terminal.ansi.magenta": "#622cbcff",
+        "terminal.ansi.bright_magenta": "#844ae7ff",
+        "terminal.ansi.dim_magenta": "#622cbcff",
+        "terminal.ansi.red": "#a0111fff",
+        "terminal.ansi.bright_red": "#86061dff",
+        "terminal.ansi.dim_red": "#a0111fff",
+        "terminal.ansi.white": "#59636eff",
+        "terminal.ansi.bright_white": "#818b98ff",
+        "terminal.ansi.dim_white": "#59636eff",
+        "terminal.ansi.yellow": "#3f2200ff",
+        "terminal.ansi.bright_yellow": "#4e2c00ff",
+        "terminal.ansi.dim_yellow": "#3f2200ff",
+        "terminal.background": "#eff2f5ff",
+        "terminal.bright_foreground": "#ffffffff",
+        "terminal.dim_foreground": "#454c54ff",
+        "terminal.foreground": "#010409ff",
+        "text": "#010409ff",
+        "text.accent": "#023b95ff",
+        "text.disabled": "#59636eff",
+        "text.muted": "#010409ff",
+        "text.placeholder": "#454c54ff",
+        "title_bar.background": "#eff2f5ff",
+        "toolbar.background": "#ffffffff",
+        "unreachable": "#59636eff",
+        "unreachable.background": "#e0e6ebff",
+        "unreachable.border": "#59636e1f",
+        "vim.mode.text": "#010409ff",
+        "vim.normal.background": "#454c54ff",
+        "vim.helix_normal.background": "#454c54ff",
+        "vim.visual.background": "#0349b4ff",
+        "vim.helix_select.background": "#0349b4ff",
+        "vim.insert.background": "#055d20ff",
+        "vim.visual_line.background": "#0349b4ff",
+        "vim.visual_block.background": "#622cbcff",
+        "vim.replace.background": "#971368ff",
+        "warning": "#603700ff",
+        "warning.background": "#e6eaefff",
+        "warning.border": "#454c54ff",
+        "players": [
+          {
+            "cursor": "#006edbff",
+            "background": "#006edbff",
+            "selection": "#006edb66"
+          },
+          {
+            "cursor": "#30a147ff",
+            "background": "#30a147ff",
+            "selection": "#30a14766"
+          },
+          {
+            "cursor": "#b88700ff",
+            "background": "#b88700ff",
+            "selection": "#b8870066"
+          },
+          {
+            "cursor": "#df0c24ff",
+            "background": "#df0c24ff",
+            "selection": "#df0c2466"
+          },
+          {
+            "cursor": "#ce2c85ff",
+            "background": "#ce2c85ff",
+            "selection": "#ce2c8566"
+          },
+          {
+            "cursor": "#894cebff",
+            "background": "#894cebff",
+            "selection": "#894ceb66"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": "#023b95ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#023b95ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#59636eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#59636eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#023b95ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#a0111fff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#a0111fff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": null,
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": null,
+            "font_style": null,
+            "font_weight": 700
+          },
+          "enum": {
+            "color": "#702c00ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function": {
+            "color": "#622cbcff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.method": {
+            "color": "#622cbcff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.special.definition": {
+            "color": "#622cbcff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "hint": {
+            "color": "#454c54ff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "keyword": {
+            "color": "#a0111fff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.operator": {
+            "color": "#a0111fff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#023b95ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#032563ff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#023b95ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#023b95ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#a0111fff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predictive": {
+            "color": "#454c54ff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#a0111fff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "#010409ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#010409ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property.json_key": {
+            "color": "#024c1aff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#a0111fff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#010409ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#010409ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter.jsx": {
+            "color": "#a0111fff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#702c00ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#a0111fff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#032563ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#a0111fff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#032563ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#023b95ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#023b95ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#024c1aff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#023b95ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#023b95ff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "type": {
+            "color": "#702c00ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.builtin": {
+            "color": "#023b95ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#010409ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.builtin": {
+            "color": "#023b95ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.parameter": {
+            "color": "#702c00ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#023b95ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variant": {
+            "color": "#702c00ff",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    },
+    {
+      "appearance": "light",
+      "name": "Github Light Tritanopia",
+      "style": {
+        "accents": [
+          "#179b9bff",
+          "#b88700ff",
+          "#894cebff",
+          "#ce2c85ff"
+        ],
+        "background.appearance": "opaque",
+        "background": "#ffffffff",
+        "border": "#d1d9e0ff",
+        "border.disabled": "#818b981a",
+        "border.focused": "#0969daff",
+        "border.selected": "#0969daff",
+        "border.transparent": "#ffffff00",
+        "border.variant": "#d1d9e0b3",
+        "conflict": "#cf222eff",
+        "conflict.background": "#ffebe9ff",
+        "conflict.border": "#ff818266",
+        "created": "#0969daff",
+        "created.background": "#ddf4ffff",
+        "created.border": "#54aeff66",
+        "deleted": "#d1242fff",
+        "deleted.background": "#ffebe9ff",
+        "deleted.border": "#ff818266",
+        "drop_target.background": "#ddf4ffff",
+        "editor.active_line.background": "#f6f8faff",
+        "editor.active_line_number": "#1f2328ff",
+        "editor.active_wrap_guide": "#d1d9e0b3",
+        "editor.background": "#ffffffff",
+        "editor.document_highlight.read_background": "#0969da4d",
+        "editor.document_highlight.write_background": "#0969da33",
+        "editor.foreground": "#1f2328ff",
+        "editor.gutter.background": "#ffffffff",
+        "editor.highlighted_line.background": "#818b981f",
+        "editor.invisible": "#818b98ff",
+        "editor.line_number": "#59636eff",
+        "editor.subheader.background": "#f6f8faff",
+        "editor.wrap_guide": "#d1d9e0b3",
+        "element.active": "#818b981f",
+        "element.background": "#818b981f",
+        "element.disabled": "#eff2f5ff",
+        "element.hover": "#818b981f",
+        "element.selected": "#818b981f",
+        "elevated_surface.background": "#ffffffff",
+        "error": "#d1242fff",
+        "error.background": "#f6f8faff",
+        "error.border": "#d1d9e0b3",
+        "ghost_element.active": "#818b981f",
+        "ghost_element.background": "#ffffff00",
+        "ghost_element.disabled": "#eff2f5ff",
+        "ghost_element.hover": "#818b981f",
+        "ghost_element.selected": "#818b981f",
+        "hidden": "#818b98ff",
+        "hidden.background": "#eff2f5ff",
+        "hidden.border": "#818b981a",
+        "hint": "#59636eff",
+        "hint.background": "#f6f8faff",
+        "hint.border": "#d1d9e0b3",
+        "icon": "#1f2328ff",
+        "icon.background": "#ffffffff",
+        "icon.border": "#d1d9e0ff",
+        "icon.accent": "#0969daff",
+        "icon.muted": "#59636eff",
+        "icon.disabled": "#818b98ff",
+        "ignored": "#59636eff",
+        "ignored.background": "#eff2f5ff",
+        "ignored.border": "#818b981a",
+        "info": "#9a6700ff",
+        "info.background": "#f6f8faff",
+        "info.border": "#d1d9e0b3",
+        "link_text.hover": "#0969daff",
+        "modified": "#9a6700ff",
+        "modified.background": "#fff8c5ff",
+        "modified.border": "#d4a72c66",
+        "pane.focused_border": "#d1d9e0ff",
+        "panel.background": "#f6f8faff",
+        "panel.focused_border": "#d1d9e0ff",
+        "predictive": "#59636eff",
+        "predictive.background": "#818b981f",
+        "predictive.border": "#d1d9e0b3",
+        "renamed": "#0969daff",
+        "renamed.background": "#ddf4ffff",
+        "renamed.border": "#54aeff66",
+        "scrollbar.thumb.border": "#ffffff00",
+        "scrollbar.thumb.hover_background": "#f6f8faff",
+        "scrollbar.track.background": "#ffffff00",
+        "scrollbar.track.border": "#ffffff00",
+        "search.match_background": "#fae17d4d",
+        "status_bar.background": "#f6f8faff",
+        "success": "#0969daff",
+        "success.background": "#ddf4ffff",
+        "success.border": "#54aeff66",
+        "surface.background": "#f6f8faff",
+        "tab.active_background": "#ffffffff",
+        "tab.inactive_background": "#f6f8faff",
+        "tab_bar.background": "#f6f8faff",
+        "terminal.ansi.black": "#1f2328ff",
+        "terminal.ansi.bright_black": "#393f46ff",
+        "terminal.ansi.dim_black": "#1f2328ff",
+        "terminal.ansi.blue": "#0969daff",
+        "terminal.ansi.bright_blue": "#218bffff",
+        "terminal.ansi.dim_blue": "#0969daff",
+        "terminal.ansi.cyan": "#1b7c83ff",
+        "terminal.ansi.bright_cyan": "#3192aaff",
+        "terminal.ansi.dim_cyan": "#1b7c83ff",
+        "terminal.ansi.green": "#0550aeff",
+        "terminal.ansi.bright_green": "#0969daff",
+        "terminal.ansi.dim_green": "#0550aeff",
+        "terminal.ansi.magenta": "#8250dfff",
+        "terminal.ansi.bright_magenta": "#a475f9ff",
+        "terminal.ansi.dim_magenta": "#8250dfff",
+        "terminal.ansi.red": "#cf222eff",
+        "terminal.ansi.bright_red": "#a40e26ff",
+        "terminal.ansi.dim_red": "#cf222eff",
+        "terminal.ansi.white": "#59636eff",
+        "terminal.ansi.bright_white": "#818b98ff",
+        "terminal.ansi.dim_white": "#59636eff",
+        "terminal.ansi.yellow": "#4d2d00ff",
+        "terminal.ansi.bright_yellow": "#633c01ff",
+        "terminal.ansi.dim_yellow": "#4d2d00ff",
+        "terminal.background": "#f6f8faff",
+        "terminal.bright_foreground": "#ffffffff",
+        "terminal.dim_foreground": "#59636eff",
+        "terminal.foreground": "#1f2328ff",
+        "text": "#1f2328ff",
+        "text.accent": "#0969daff",
+        "text.disabled": "#818b98ff",
+        "text.muted": "#1f2328ff",
+        "text.placeholder": "#59636eff",
+        "title_bar.background": "#f6f8faff",
+        "toolbar.background": "#ffffffff",
+        "unreachable": "#818b98ff",
+        "unreachable.background": "#eff2f5ff",
+        "unreachable.border": "#818b981a",
+        "vim.mode.text": "#1f2328ff",
+        "vim.normal.background": "#59636eff",
+        "vim.helix_normal.background": "#59636eff",
+        "vim.visual.background": "#0969daff",
+        "vim.helix_select.background": "#0969daff",
+        "vim.insert.background": "#0969daff",
+        "vim.visual_line.background": "#0969daff",
+        "vim.visual_block.background": "#8250dfff",
+        "vim.replace.background": "#bf3989ff",
+        "warning": "#9a6700ff",
+        "warning.background": "#f6f8faff",
+        "warning.border": "#d1d9e0b3",
+        "players": [
+          {
+            "cursor": "#179b9bff",
+            "background": "#179b9bff",
+            "selection": "#179b9b66"
+          },
+          {
+            "cursor": "#b88700ff",
+            "background": "#b88700ff",
+            "selection": "#b8870066"
+          },
+          {
+            "cursor": "#894cebff",
+            "background": "#894cebff",
+            "selection": "#894ceb66"
+          },
+          {
+            "cursor": "#ce2c85ff",
+            "background": "#ce2c85ff",
+            "selection": "#ce2c8566"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#59636eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#59636eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#cf222eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#cf222eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": null,
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": null,
+            "font_style": null,
+            "font_weight": 700
+          },
+          "enum": {
+            "color": "#953800ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function": {
+            "color": "#8250dfff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.method": {
+            "color": "#8250dfff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.special.definition": {
+            "color": "#8250dfff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "hint": {
+            "color": "#59636eff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "keyword": {
+            "color": "#cf222eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.operator": {
+            "color": "#cf222eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#0a3069ff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#cf222eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predictive": {
+            "color": "#59636eff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#cf222eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "#1f2328ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#1f2328ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property.json_key": {
+            "color": "#116329ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#cf222eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#1f2328ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#1f2328ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter.jsx": {
+            "color": "#cf222eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#953800ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#cf222eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#0a3069ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#cf222eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#0a3069ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#116329ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "type": {
+            "color": "#953800ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.builtin": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#1f2328ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.builtin": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.parameter": {
+            "color": "#953800ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#0550aeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variant": {
+            "color": "#953800ff",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    },
+    {
+      "appearance": "dark",
+      "name": "Github Dark",
+      "style": {
+        "accents": [
+          "#0576ffff",
+          "#2f6f37ff",
+          "#895906ff",
+          "#eb3342ff",
+          "#d34591ff",
+          "#975bf1ff"
+        ],
+        "background.appearance": "opaque",
+        "background": "#0d1117ff",
+        "border": "#3d444dff",
+        "border.disabled": "#656c761a",
+        "border.focused": "#1f6febff",
+        "border.selected": "#1f6febff",
+        "border.transparent": "#00000000",
+        "border.variant": "#3d444db3",
+        "conflict": "#db6d28ff",
+        "conflict.background": "#db6d281a",
+        "conflict.border": "#db6d2866",
+        "created": "#3fb950ff",
+        "created.background": "#2ea04326",
+        "created.border": "#2ea04366",
+        "deleted": "#f85149ff",
+        "deleted.background": "#f851491a",
+        "deleted.border": "#f8514966",
+        "drop_target.background": "#388bfd1a",
+        "editor.active_line.background": "#151b23ff",
+        "editor.active_line_number": "#f0f6fcff",
+        "editor.active_wrap_guide": "#3d444db3",
+        "editor.background": "#0d1117ff",
+        "editor.document_highlight.read_background": "#4493f84d",
+        "editor.document_highlight.write_background": "#4493f833",
+        "editor.foreground": "#f0f6fcff",
+        "editor.gutter.background": "#0d1117ff",
+        "editor.highlighted_line.background": "#656c7633",
+        "editor.invisible": "#656c7699",
+        "editor.line_number": "#9198a1ff",
+        "editor.subheader.background": "#151b23ff",
+        "editor.wrap_guide": "#3d444db3",
+        "element.active": "#656c7633",
+        "element.background": "#656c7633",
+        "element.disabled": "#212830ff",
+        "element.hover": "#656c7633",
+        "element.selected": "#656c7633",
+        "elevated_surface.background": "#151b23ff",
+        "error": "#f85149ff",
+        "error.background": "#151b23ff",
+        "error.border": "#3d444db3",
+        "ghost_element.active": "#656c7633",
+        "ghost_element.background": "#00000000",
+        "ghost_element.disabled": "#212830ff",
+        "ghost_element.hover": "#656c7633",
+        "ghost_element.selected": "#656c7633",
+        "hidden": "#656c7699",
+        "hidden.background": "#212830ff",
+        "hidden.border": "#656c761a",
+        "hint": "#9198a1ff",
+        "hint.background": "#151b23ff",
+        "hint.border": "#3d444db3",
+        "icon": "#f0f6fcff",
+        "icon.background": "#0d1117ff",
+        "icon.border": "#3d444dff",
+        "icon.accent": "#4493f8ff",
+        "icon.muted": "#9198a1ff",
+        "icon.disabled": "#656c7699",
+        "ignored": "#9198a1ff",
+        "ignored.background": "#212830ff",
+        "ignored.border": "#656c761a",
+        "info": "#d29922ff",
+        "info.background": "#151b23ff",
+        "info.border": "#3d444db3",
+        "link_text.hover": "#4493f8ff",
+        "modified": "#d29922ff",
+        "modified.background": "#bb800926",
+        "modified.border": "#bb800966",
+        "pane.focused_border": "#3d444dff",
+        "panel.background": "#010409ff",
+        "panel.focused_border": "#3d444dff",
+        "predictive": "#9198a1ff",
+        "predictive.background": "#656c7633",
+        "predictive.border": "#3d444db3",
+        "renamed": "#3fb950ff",
+        "renamed.background": "#2ea04326",
+        "renamed.border": "#2ea04366",
+        "scrollbar.thumb.border": "#00000000",
+        "scrollbar.thumb.hover_background": "#151b23ff",
+        "scrollbar.track.background": "#00000000",
+        "scrollbar.track.border": "#00000000",
+        "search.match_background": "#f2cc604d",
+        "status_bar.background": "#010409ff",
+        "success": "#3fb950ff",
+        "success.background": "#2ea04326",
+        "success.border": "#2ea04366",
+        "surface.background": "#010409ff",
+        "tab.active_background": "#0d1117ff",
+        "tab.inactive_background": "#010409ff",
+        "tab_bar.background": "#010409ff",
+        "terminal.ansi.black": "#2f3742ff",
+        "terminal.ansi.bright_black": "#656c76ff",
+        "terminal.ansi.dim_black": "#2f3742ff",
+        "terminal.ansi.blue": "#58a6ffff",
+        "terminal.ansi.bright_blue": "#79c0ffff",
+        "terminal.ansi.dim_blue": "#58a6ffff",
+        "terminal.ansi.cyan": "#39c5cfff",
+        "terminal.ansi.bright_cyan": "#56d4ddff",
+        "terminal.ansi.dim_cyan": "#39c5cfff",
+        "terminal.ansi.green": "#3fb950ff",
+        "terminal.ansi.bright_green": "#56d364ff",
+        "terminal.ansi.dim_green": "#3fb950ff",
+        "terminal.ansi.magenta": "#be8fffff",
+        "terminal.ansi.bright_magenta": "#d2a8ffff",
+        "terminal.ansi.dim_magenta": "#be8fffff",
+        "terminal.ansi.red": "#ff7b72ff",
+        "terminal.ansi.bright_red": "#ffa198ff",
+        "terminal.ansi.dim_red": "#ff7b72ff",
+        "terminal.ansi.white": "#f0f6fcff",
+        "terminal.ansi.bright_white": "#ffffffff",
+        "terminal.ansi.dim_white": "#f0f6fcff",
+        "terminal.ansi.yellow": "#d29922ff",
+        "terminal.ansi.bright_yellow": "#e3b341ff",
+        "terminal.ansi.dim_yellow": "#d29922ff",
+        "terminal.background": "#010409ff",
+        "terminal.bright_foreground": "#ffffffff",
+        "terminal.dim_foreground": "#9198a1ff",
+        "terminal.foreground": "#f0f6fcff",
+        "text": "#f0f6fcff",
+        "text.accent": "#4493f8ff",
+        "text.disabled": "#656c7699",
+        "text.muted": "#f0f6fcff",
+        "text.placeholder": "#9198a1ff",
+        "title_bar.background": "#010409ff",
+        "toolbar.background": "#0d1117ff",
+        "unreachable": "#656c7699",
+        "unreachable.background": "#212830ff",
+        "unreachable.border": "#656c761a",
+        "vim.mode.text": "#f0f6fcff",
+        "vim.normal.background": "#656c76ff",
+        "vim.helix_normal.background": "#656c76ff",
+        "vim.visual.background": "#1f6febff",
+        "vim.helix_select.background": "#1f6febff",
+        "vim.insert.background": "#238636ff",
+        "vim.visual_line.background": "#1f6febff",
+        "vim.visual_block.background": "#8957e5ff",
+        "vim.replace.background": "#bf4b8aff",
+        "warning": "#d29922ff",
+        "warning.background": "#151b23ff",
+        "warning.border": "#3d444db3",
+        "players": [
+          {
+            "cursor": "#0576ffff",
+            "background": "#0576ffff",
+            "selection": "#0576ff66"
+          },
+          {
+            "cursor": "#2f6f37ff",
+            "background": "#2f6f37ff",
+            "selection": "#2f6f3766"
+          },
+          {
+            "cursor": "#895906ff",
+            "background": "#895906ff",
+            "selection": "#89590666"
+          },
+          {
+            "cursor": "#eb3342ff",
+            "background": "#eb3342ff",
+            "selection": "#eb334266"
+          },
+          {
+            "cursor": "#d34591ff",
+            "background": "#d34591ff",
+            "selection": "#d3459166"
+          },
+          {
+            "cursor": "#975bf1ff",
+            "background": "#975bf1ff",
+            "selection": "#975bf166"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#9198a1ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#9198a1ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#ff7b72ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#ff7b72ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": null,
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": null,
+            "font_style": null,
+            "font_weight": 700
+          },
+          "enum": {
+            "color": "#ffa657ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function": {
+            "color": "#d2a8ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.method": {
+            "color": "#d2a8ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.special.definition": {
+            "color": "#d2a8ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "hint": {
+            "color": "#9198a1ff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "keyword": {
+            "color": "#ff7b72ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.operator": {
+            "color": "#ff7b72ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#a5d6ffff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#ff7b72ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predictive": {
+            "color": "#9198a1ff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#ff7b72ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "#f0f6fcff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#f0f6fcff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property.json_key": {
+            "color": "#7ee787ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#ff7b72ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#f0f6fcff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#f0f6fcff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter.jsx": {
+            "color": "#ff7b72ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#ffa657ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#ff7b72ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#a5d6ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#ff7b72ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#a5d6ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#7ee787ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "type": {
+            "color": "#ffa657ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.builtin": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#f0f6fcff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.builtin": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.parameter": {
+            "color": "#ffa657ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variant": {
+            "color": "#ffa657ff",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    },
+    {
+      "appearance": "dark",
+      "name": "Github Dark Colorblind",
+      "style": {
+        "accents": [
+          "#0576ffff",
+          null,
+          "#895906ff",
+          "#d34591ff"
+        ],
+        "background.appearance": "opaque",
+        "background": "#0d1117ff",
+        "border": "#3d444dff",
+        "border.disabled": "#656c761a",
+        "border.focused": "#1f6febff",
+        "border.selected": "#1f6febff",
+        "border.transparent": "#00000000",
+        "border.variant": "#3d444db3",
+        "conflict": "#db6d28ff",
+        "conflict.background": "#db6d281a",
+        "conflict.border": "#db6d2866",
+        "created": "#58a6ffff",
+        "created.background": "#388bfd26",
+        "created.border": "#388bfd66",
+        "deleted": "#db6d28ff",
+        "deleted.background": "#db6d281a",
+        "deleted.border": "#db6d2866",
+        "drop_target.background": "#388bfd1a",
+        "editor.active_line.background": "#151b23ff",
+        "editor.active_line_number": "#f0f6fcff",
+        "editor.active_wrap_guide": "#3d444db3",
+        "editor.background": "#0d1117ff",
+        "editor.document_highlight.read_background": "#4493f84d",
+        "editor.document_highlight.write_background": "#4493f833",
+        "editor.foreground": "#f0f6fcff",
+        "editor.gutter.background": "#0d1117ff",
+        "editor.highlighted_line.background": "#656c7633",
+        "editor.invisible": "#656c7699",
+        "editor.line_number": "#9198a1ff",
+        "editor.subheader.background": "#151b23ff",
+        "editor.wrap_guide": "#3d444db3",
+        "element.active": "#656c7633",
+        "element.background": "#656c7633",
+        "element.disabled": "#212830ff",
+        "element.hover": "#656c7633",
+        "element.selected": "#656c7633",
+        "elevated_surface.background": "#151b23ff",
+        "error": "#db6d28ff",
+        "error.background": "#151b23ff",
+        "error.border": "#3d444db3",
+        "ghost_element.active": "#656c7633",
+        "ghost_element.background": "#00000000",
+        "ghost_element.disabled": "#212830ff",
+        "ghost_element.hover": "#656c7633",
+        "ghost_element.selected": "#656c7633",
+        "hidden": "#656c7699",
+        "hidden.background": "#212830ff",
+        "hidden.border": "#656c761a",
+        "hint": "#9198a1ff",
+        "hint.background": "#151b23ff",
+        "hint.border": "#3d444db3",
+        "icon": "#f0f6fcff",
+        "icon.background": "#0d1117ff",
+        "icon.border": "#3d444dff",
+        "icon.accent": "#4493f8ff",
+        "icon.muted": "#9198a1ff",
+        "icon.disabled": "#656c7699",
+        "ignored": "#9198a1ff",
+        "ignored.background": "#212830ff",
+        "ignored.border": "#656c761a",
+        "info": "#d29922ff",
+        "info.background": "#151b23ff",
+        "info.border": "#3d444db3",
+        "link_text.hover": "#4493f8ff",
+        "modified": "#d29922ff",
+        "modified.background": "#bb800926",
+        "modified.border": "#bb800966",
+        "pane.focused_border": "#3d444dff",
+        "panel.background": "#010409ff",
+        "panel.focused_border": "#3d444dff",
+        "predictive": "#9198a1ff",
+        "predictive.background": "#656c7633",
+        "predictive.border": "#3d444db3",
+        "renamed": "#58a6ffff",
+        "renamed.background": "#388bfd26",
+        "renamed.border": "#388bfd66",
+        "scrollbar.thumb.border": "#00000000",
+        "scrollbar.thumb.hover_background": "#151b23ff",
+        "scrollbar.track.background": "#00000000",
+        "scrollbar.track.border": "#00000000",
+        "search.match_background": "#f2cc604d",
+        "status_bar.background": "#010409ff",
+        "success": "#58a6ffff",
+        "success.background": "#388bfd26",
+        "success.border": "#388bfd66",
+        "surface.background": "#010409ff",
+        "tab.active_background": "#0d1117ff",
+        "tab.inactive_background": "#010409ff",
+        "tab_bar.background": "#010409ff",
+        "terminal.ansi.black": "#2f3742ff",
+        "terminal.ansi.bright_black": "#656c76ff",
+        "terminal.ansi.dim_black": "#2f3742ff",
+        "terminal.ansi.blue": "#58a6ffff",
+        "terminal.ansi.bright_blue": "#79c0ffff",
+        "terminal.ansi.dim_blue": "#58a6ffff",
+        "terminal.ansi.cyan": "#39c5cfff",
+        "terminal.ansi.bright_cyan": "#56d4ddff",
+        "terminal.ansi.dim_cyan": "#39c5cfff",
+        "terminal.ansi.green": "#58a6ffff",
+        "terminal.ansi.bright_green": "#79c0ffff",
+        "terminal.ansi.dim_green": "#58a6ffff",
+        "terminal.ansi.magenta": "#be8fffff",
+        "terminal.ansi.bright_magenta": "#d2a8ffff",
+        "terminal.ansi.dim_magenta": "#be8fffff",
+        "terminal.ansi.red": "#f0883eff",
+        "terminal.ansi.bright_red": "#ffa657ff",
+        "terminal.ansi.dim_red": "#f0883eff",
+        "terminal.ansi.white": "#f0f6fcff",
+        "terminal.ansi.bright_white": "#ffffffff",
+        "terminal.ansi.dim_white": "#f0f6fcff",
+        "terminal.ansi.yellow": "#d29922ff",
+        "terminal.ansi.bright_yellow": "#e3b341ff",
+        "terminal.ansi.dim_yellow": "#d29922ff",
+        "terminal.background": "#010409ff",
+        "terminal.bright_foreground": "#ffffffff",
+        "terminal.dim_foreground": "#9198a1ff",
+        "terminal.foreground": "#f0f6fcff",
+        "text": "#f0f6fcff",
+        "text.accent": "#4493f8ff",
+        "text.disabled": "#656c7699",
+        "text.muted": "#f0f6fcff",
+        "text.placeholder": "#9198a1ff",
+        "title_bar.background": "#010409ff",
+        "toolbar.background": "#0d1117ff",
+        "unreachable": "#656c7699",
+        "unreachable.background": "#212830ff",
+        "unreachable.border": "#656c761a",
+        "vim.mode.text": "#f0f6fcff",
+        "vim.normal.background": "#656c76ff",
+        "vim.helix_normal.background": "#656c76ff",
+        "vim.visual.background": "#1f6febff",
+        "vim.helix_select.background": "#1f6febff",
+        "vim.insert.background": "#1f6febff",
+        "vim.visual_line.background": "#1f6febff",
+        "vim.visual_block.background": "#8957e5ff",
+        "vim.replace.background": "#bf4b8aff",
+        "warning": "#d29922ff",
+        "warning.background": "#151b23ff",
+        "warning.border": "#3d444db3",
+        "players": [
+          {
+            "cursor": "#0576ffff",
+            "background": "#0576ffff",
+            "selection": "#0576ff66"
+          },
+          {
+            "selection": null
+          },
+          {
+            "cursor": "#895906ff",
+            "background": "#895906ff",
+            "selection": "#89590666"
+          },
+          {
+            "cursor": "#d34591ff",
+            "background": "#d34591ff",
+            "selection": "#d3459166"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#9198a1ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#9198a1ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#ff7b72ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#ff7b72ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": null,
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": null,
+            "font_style": null,
+            "font_weight": 700
+          },
+          "enum": {
+            "color": "#ffa657ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function": {
+            "color": "#d2a8ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.method": {
+            "color": "#d2a8ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.special.definition": {
+            "color": "#d2a8ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "hint": {
+            "color": "#9198a1ff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "keyword": {
+            "color": "#ff7b72ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.operator": {
+            "color": "#ff7b72ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#a5d6ffff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#ff7b72ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predictive": {
+            "color": "#9198a1ff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#ff7b72ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "#f0f6fcff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#f0f6fcff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property.json_key": {
+            "color": "#7ee787ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#ff7b72ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#f0f6fcff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#f0f6fcff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter.jsx": {
+            "color": "#ff7b72ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#ffa657ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#ff7b72ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#a5d6ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#ff7b72ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#a5d6ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#7ee787ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "type": {
+            "color": "#ffa657ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.builtin": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#f0f6fcff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.builtin": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.parameter": {
+            "color": "#ffa657ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variant": {
+            "color": "#ffa657ff",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    },
+    {
+      "appearance": "dark",
+      "name": "Github Dark High Contrast",
+      "style": {
+        "accents": [
+          "#0576ffff",
+          "#2f6f37ff",
+          "#895906ff",
+          "#eb3342ff",
+          "#d34591ff",
+          "#975bf1ff"
+        ],
+        "background.appearance": "opaque",
+        "background": "#010409ff",
+        "border": "#b7bdc8ff",
+        "border.disabled": "#9198a11f",
+        "border.focused": "#409effff",
+        "border.selected": "#409effff",
+        "border.transparent": "#00000000",
+        "border.variant": "#b7bdc8ff",
+        "conflict": "#fe9a2dff",
+        "conflict.background": "#f48b251a",
+        "conflict.border": "#f48b25ff",
+        "created": "#2bd853ff",
+        "created.background": "#0ac74026",
+        "created.border": "#0ac740ff",
+        "deleted": "#ff9492ff",
+        "deleted.background": "#ff80801a",
+        "deleted.border": "#ff8080ff",
+        "drop_target.background": "#5cacff1a",
+        "editor.active_line.background": "#151b23ff",
+        "editor.active_line_number": "#ffffffff",
+        "editor.active_wrap_guide": "#b7bdc8ff",
+        "editor.background": "#010409ff",
+        "editor.document_highlight.read_background": "#74b9ff4d",
+        "editor.document_highlight.write_background": "#74b9ff33",
+        "editor.foreground": "#ffffffff",
+        "editor.gutter.background": "#010409ff",
+        "editor.highlighted_line.background": "#212830ff",
+        "editor.invisible": "#9198a199",
+        "editor.line_number": "#b7bdc8ff",
+        "editor.subheader.background": "#151b23ff",
+        "editor.wrap_guide": "#b7bdc8ff",
+        "element.active": "#212830ff",
+        "element.background": "#212830ff",
+        "element.disabled": "#262c36ff",
+        "element.hover": "#212830ff",
+        "element.selected": "#212830ff",
+        "elevated_surface.background": "#151b23ff",
+        "error": "#ff9492ff",
+        "error.background": "#151b23ff",
+        "error.border": "#b7bdc8ff",
+        "ghost_element.active": "#212830ff",
+        "ghost_element.background": "#00000000",
+        "ghost_element.disabled": "#262c36ff",
+        "ghost_element.hover": "#212830ff",
+        "ghost_element.selected": "#212830ff",
+        "hidden": "#9198a199",
+        "hidden.background": "#262c36ff",
+        "hidden.border": "#9198a11f",
+        "hint": "#b7bdc8ff",
+        "hint.background": "#151b23ff",
+        "hint.border": "#b7bdc8ff",
+        "icon": "#ffffffff",
+        "icon.background": "#010409ff",
+        "icon.border": "#b7bdc8ff",
+        "icon.accent": "#74b9ffff",
+        "icon.muted": "#b7bdc8ff",
+        "icon.disabled": "#9198a199",
+        "ignored": "#b7bdc8ff",
+        "ignored.background": "#262c36ff",
+        "ignored.border": "#9198a11f",
+        "info": "#f0b72fff",
+        "info.background": "#151b23ff",
+        "info.border": "#b7bdc8ff",
+        "link_text.hover": "#74b9ffff",
+        "modified": "#f0b72fff",
+        "modified.background": "#edaa2726",
+        "modified.border": "#edaa27ff",
+        "pane.focused_border": "#b7bdc8ff",
+        "panel.background": "#010409ff",
+        "panel.focused_border": "#b7bdc8ff",
+        "predictive": "#b7bdc8ff",
+        "predictive.background": "#212830ff",
+        "predictive.border": "#b7bdc8ff",
+        "renamed": "#2bd853ff",
+        "renamed.background": "#0ac74026",
+        "renamed.border": "#0ac740ff",
+        "scrollbar.thumb.border": "#00000000",
+        "scrollbar.thumb.hover_background": "#151b23ff",
+        "scrollbar.track.background": "#00000000",
+        "scrollbar.track.border": "#00000000",
+        "search.match_background": "#fbd6694d",
+        "status_bar.background": "#010409ff",
+        "success": "#2bd853ff",
+        "success.background": "#0ac74026",
+        "success.border": "#0ac740ff",
+        "surface.background": "#010409ff",
+        "tab.active_background": "#010409ff",
+        "tab.inactive_background": "#010409ff",
+        "tab_bar.background": "#010409ff",
+        "terminal.ansi.black": "#2f3742ff",
+        "terminal.ansi.bright_black": "#656c76ff",
+        "terminal.ansi.dim_black": "#2f3742ff",
+        "terminal.ansi.blue": "#71b7ffff",
+        "terminal.ansi.bright_blue": "#91cbffff",
+        "terminal.ansi.dim_blue": "#71b7ffff",
+        "terminal.ansi.cyan": "#39c5cfff",
+        "terminal.ansi.bright_cyan": "#56d4ddff",
+        "terminal.ansi.dim_cyan": "#39c5cfff",
+        "terminal.ansi.green": "#28d751ff",
+        "terminal.ansi.bright_green": "#4ae168ff",
+        "terminal.ansi.dim_green": "#28d751ff",
+        "terminal.ansi.magenta": "#cb9effff",
+        "terminal.ansi.bright_magenta": "#dbb7ffff",
+        "terminal.ansi.dim_magenta": "#cb9effff",
+        "terminal.ansi.red": "#ff9492ff",
+        "terminal.ansi.bright_red": "#ffb1afff",
+        "terminal.ansi.dim_red": "#ff9492ff",
+        "terminal.ansi.white": "#f0f6fcff",
+        "terminal.ansi.bright_white": "#ffffffff",
+        "terminal.ansi.dim_white": "#f0f6fcff",
+        "terminal.ansi.yellow": "#f0b72fff",
+        "terminal.ansi.bright_yellow": "#f7c843ff",
+        "terminal.ansi.dim_yellow": "#f0b72fff",
+        "terminal.background": "#010409ff",
+        "terminal.bright_foreground": "#ffffffff",
+        "terminal.dim_foreground": "#b7bdc8ff",
+        "terminal.foreground": "#ffffffff",
+        "text": "#ffffffff",
+        "text.accent": "#74b9ffff",
+        "text.disabled": "#9198a199",
+        "text.muted": "#ffffffff",
+        "text.placeholder": "#b7bdc8ff",
+        "title_bar.background": "#010409ff",
+        "toolbar.background": "#010409ff",
+        "unreachable": "#9198a199",
+        "unreachable.background": "#262c36ff",
+        "unreachable.border": "#9198a11f",
+        "vim.mode.text": "#ffffffff",
+        "vim.normal.background": "#3d444dff",
+        "vim.helix_normal.background": "#3d444dff",
+        "vim.visual.background": "#194fb1ff",
+        "vim.helix_select.background": "#194fb1ff",
+        "vim.insert.background": "#006222ff",
+        "vim.visual_line.background": "#194fb1ff",
+        "vim.visual_block.background": "#6921d7ff",
+        "vim.replace.background": "#9c1d6aff",
+        "warning": "#f0b72fff",
+        "warning.background": "#151b23ff",
+        "warning.border": "#b7bdc8ff",
+        "players": [
+          {
+            "cursor": "#0576ffff",
+            "background": "#0576ffff",
+            "selection": "#0576ff66"
+          },
+          {
+            "cursor": "#2f6f37ff",
+            "background": "#2f6f37ff",
+            "selection": "#2f6f3766"
+          },
+          {
+            "cursor": "#895906ff",
+            "background": "#895906ff",
+            "selection": "#89590666"
+          },
+          {
+            "cursor": "#eb3342ff",
+            "background": "#eb3342ff",
+            "selection": "#eb334266"
+          },
+          {
+            "cursor": "#d34591ff",
+            "background": "#d34591ff",
+            "selection": "#d3459166"
+          },
+          {
+            "cursor": "#975bf1ff",
+            "background": "#975bf1ff",
+            "selection": "#975bf166"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": "#91cbffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#91cbffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#9198a1ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#9198a1ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#91cbffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#ff9492ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#ff9492ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": null,
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": null,
+            "font_style": null,
+            "font_weight": 700
+          },
+          "enum": {
+            "color": "#ffb757ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function": {
+            "color": "#dbb7ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.method": {
+            "color": "#dbb7ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.special.definition": {
+            "color": "#dbb7ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "hint": {
+            "color": "#b7bdc8ff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "keyword": {
+            "color": "#ff9492ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.operator": {
+            "color": "#ff9492ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#91cbffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#addcffff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#91cbffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#91cbffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#ff9492ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predictive": {
+            "color": "#b7bdc8ff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#ff9492ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "#ffffffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#ffffffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property.json_key": {
+            "color": "#72f088ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#ff9492ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#ffffffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#ffffffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter.jsx": {
+            "color": "#ff9492ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#ffb757ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#ff9492ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#addcffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#ff9492ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#addcffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#91cbffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#91cbffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#72f088ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#91cbffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#91cbffff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "type": {
+            "color": "#ffb757ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.builtin": {
+            "color": "#91cbffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#ffffffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.builtin": {
+            "color": "#91cbffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.parameter": {
+            "color": "#ffb757ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#91cbffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variant": {
+            "color": "#ffb757ff",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    },
+    {
+      "appearance": "dark",
+      "name": "Github Dark Tritanopia",
+      "style": {
+        "accents": [
+          "#106c70ff",
+          "#895906ff",
+          "#975bf1ff",
+          "#d34591ff"
+        ],
+        "background.appearance": "opaque",
+        "background": "#0d1117ff",
+        "border": "#3d444dff",
+        "border.disabled": "#656c761a",
+        "border.focused": "#1f6febff",
+        "border.selected": "#1f6febff",
+        "border.transparent": "#00000000",
+        "border.variant": "#3d444db3",
+        "conflict": "#f85149ff",
+        "conflict.background": "#f851491a",
+        "conflict.border": "#f8514966",
+        "created": "#58a6ffff",
+        "created.background": "#388bfd26",
+        "created.border": "#388bfd66",
+        "deleted": "#f85149ff",
+        "deleted.background": "#f851491a",
+        "deleted.border": "#f8514966",
+        "drop_target.background": "#388bfd1a",
+        "editor.active_line.background": "#151b23ff",
+        "editor.active_line_number": "#f0f6fcff",
+        "editor.active_wrap_guide": "#3d444db3",
+        "editor.background": "#0d1117ff",
+        "editor.document_highlight.read_background": "#4493f84d",
+        "editor.document_highlight.write_background": "#4493f833",
+        "editor.foreground": "#f0f6fcff",
+        "editor.gutter.background": "#0d1117ff",
+        "editor.highlighted_line.background": "#656c7633",
+        "editor.invisible": "#656c7699",
+        "editor.line_number": "#9198a1ff",
+        "editor.subheader.background": "#151b23ff",
+        "editor.wrap_guide": "#3d444db3",
+        "element.active": "#656c7633",
+        "element.background": "#656c7633",
+        "element.disabled": "#212830ff",
+        "element.hover": "#656c7633",
+        "element.selected": "#656c7633",
+        "elevated_surface.background": "#151b23ff",
+        "error": "#f85149ff",
+        "error.background": "#151b23ff",
+        "error.border": "#3d444db3",
+        "ghost_element.active": "#656c7633",
+        "ghost_element.background": "#00000000",
+        "ghost_element.disabled": "#212830ff",
+        "ghost_element.hover": "#656c7633",
+        "ghost_element.selected": "#656c7633",
+        "hidden": "#656c7699",
+        "hidden.background": "#212830ff",
+        "hidden.border": "#656c761a",
+        "hint": "#9198a1ff",
+        "hint.background": "#151b23ff",
+        "hint.border": "#3d444db3",
+        "icon": "#f0f6fcff",
+        "icon.background": "#0d1117ff",
+        "icon.border": "#3d444dff",
+        "icon.accent": "#4493f8ff",
+        "icon.muted": "#9198a1ff",
+        "icon.disabled": "#656c7699",
+        "ignored": "#9198a1ff",
+        "ignored.background": "#212830ff",
+        "ignored.border": "#656c761a",
+        "info": "#d29922ff",
+        "info.background": "#151b23ff",
+        "info.border": "#3d444db3",
+        "link_text.hover": "#4493f8ff",
+        "modified": "#d29922ff",
+        "modified.background": "#bb800926",
+        "modified.border": "#bb800966",
+        "pane.focused_border": "#3d444dff",
+        "panel.background": "#010409ff",
+        "panel.focused_border": "#3d444dff",
+        "predictive": "#9198a1ff",
+        "predictive.background": "#656c7633",
+        "predictive.border": "#3d444db3",
+        "renamed": "#58a6ffff",
+        "renamed.background": "#388bfd26",
+        "renamed.border": "#388bfd66",
+        "scrollbar.thumb.border": "#00000000",
+        "scrollbar.thumb.hover_background": "#151b23ff",
+        "scrollbar.track.background": "#00000000",
+        "scrollbar.track.border": "#00000000",
+        "search.match_background": "#f2cc604d",
+        "status_bar.background": "#010409ff",
+        "success": "#58a6ffff",
+        "success.background": "#388bfd26",
+        "success.border": "#388bfd66",
+        "surface.background": "#010409ff",
+        "tab.active_background": "#0d1117ff",
+        "tab.inactive_background": "#010409ff",
+        "tab_bar.background": "#010409ff",
+        "terminal.ansi.black": "#2f3742ff",
+        "terminal.ansi.bright_black": "#656c76ff",
+        "terminal.ansi.dim_black": "#2f3742ff",
+        "terminal.ansi.blue": "#58a6ffff",
+        "terminal.ansi.bright_blue": "#79c0ffff",
+        "terminal.ansi.dim_blue": "#58a6ffff",
+        "terminal.ansi.cyan": "#39c5cfff",
+        "terminal.ansi.bright_cyan": "#56d4ddff",
+        "terminal.ansi.dim_cyan": "#39c5cfff",
+        "terminal.ansi.green": "#58a6ffff",
+        "terminal.ansi.bright_green": "#79c0ffff",
+        "terminal.ansi.dim_green": "#58a6ffff",
+        "terminal.ansi.magenta": "#be8fffff",
+        "terminal.ansi.bright_magenta": "#d2a8ffff",
+        "terminal.ansi.dim_magenta": "#be8fffff",
+        "terminal.ansi.red": "#ff7b72ff",
+        "terminal.ansi.bright_red": "#ffa198ff",
+        "terminal.ansi.dim_red": "#ff7b72ff",
+        "terminal.ansi.white": "#f0f6fcff",
+        "terminal.ansi.bright_white": "#ffffffff",
+        "terminal.ansi.dim_white": "#f0f6fcff",
+        "terminal.ansi.yellow": "#d29922ff",
+        "terminal.ansi.bright_yellow": "#e3b341ff",
+        "terminal.ansi.dim_yellow": "#d29922ff",
+        "terminal.background": "#010409ff",
+        "terminal.bright_foreground": "#ffffffff",
+        "terminal.dim_foreground": "#9198a1ff",
+        "terminal.foreground": "#f0f6fcff",
+        "text": "#f0f6fcff",
+        "text.accent": "#4493f8ff",
+        "text.disabled": "#656c7699",
+        "text.muted": "#f0f6fcff",
+        "text.placeholder": "#9198a1ff",
+        "title_bar.background": "#010409ff",
+        "toolbar.background": "#0d1117ff",
+        "unreachable": "#656c7699",
+        "unreachable.background": "#212830ff",
+        "unreachable.border": "#656c761a",
+        "vim.mode.text": "#f0f6fcff",
+        "vim.normal.background": "#656c76ff",
+        "vim.helix_normal.background": "#656c76ff",
+        "vim.visual.background": "#1f6febff",
+        "vim.helix_select.background": "#1f6febff",
+        "vim.insert.background": "#1f6febff",
+        "vim.visual_line.background": "#1f6febff",
+        "vim.visual_block.background": "#8957e5ff",
+        "vim.replace.background": "#bf4b8aff",
+        "warning": "#d29922ff",
+        "warning.background": "#151b23ff",
+        "warning.border": "#3d444db3",
+        "players": [
+          {
+            "cursor": "#106c70ff",
+            "background": "#106c70ff",
+            "selection": "#106c7066"
+          },
+          {
+            "cursor": "#895906ff",
+            "background": "#895906ff",
+            "selection": "#89590666"
+          },
+          {
+            "cursor": "#975bf1ff",
+            "background": "#975bf1ff",
+            "selection": "#975bf166"
+          },
+          {
+            "cursor": "#d34591ff",
+            "background": "#d34591ff",
+            "selection": "#d3459166"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#9198a1ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#9198a1ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#ff7b72ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#ff7b72ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": null,
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": null,
+            "font_style": null,
+            "font_weight": 700
+          },
+          "enum": {
+            "color": "#ffa657ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function": {
+            "color": "#d2a8ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.method": {
+            "color": "#d2a8ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.special.definition": {
+            "color": "#d2a8ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "hint": {
+            "color": "#9198a1ff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "keyword": {
+            "color": "#ff7b72ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.operator": {
+            "color": "#ff7b72ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#a5d6ffff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#ff7b72ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predictive": {
+            "color": "#9198a1ff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#ff7b72ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "#f0f6fcff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#f0f6fcff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property.json_key": {
+            "color": "#7ee787ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#ff7b72ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#f0f6fcff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#f0f6fcff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter.jsx": {
+            "color": "#ff7b72ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#ffa657ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#ff7b72ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#a5d6ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#ff7b72ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#a5d6ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#7ee787ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "type": {
+            "color": "#ffa657ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.builtin": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#f0f6fcff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.builtin": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.parameter": {
+            "color": "#ffa657ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#79c0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variant": {
+            "color": "#ffa657ff",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    },
+    {
+      "appearance": "dark",
+      "name": "Github Dark Dimmed",
+      "style": {
+        "accents": [
+          "#0576ffff",
+          "#2f6f37ff",
+          "#895906ff",
+          "#eb3342ff",
+          "#d34591ff",
+          "#975bf1ff"
+        ],
+        "background.appearance": "opaque",
+        "background": "#212830ff",
+        "border": "#3d444dff",
+        "border.disabled": "#656c761a",
+        "border.focused": "#316dcaff",
+        "border.selected": "#316dcaff",
+        "border.transparent": "#00000000",
+        "border.variant": "#3d444db3",
+        "conflict": "#cc6b2cff",
+        "conflict.background": "#cc6b2c1a",
+        "conflict.border": "#cc6b2c66",
+        "created": "#57ab5aff",
+        "created.background": "#46954a26",
+        "created.border": "#46954a66",
+        "deleted": "#e5534bff",
+        "deleted.background": "#e5534b1a",
+        "deleted.border": "#e5534b66",
+        "drop_target.background": "#4184e41a",
+        "editor.active_line.background": "#262c36ff",
+        "editor.active_line_number": "#d1d7e0ff",
+        "editor.active_wrap_guide": "#3d444db3",
+        "editor.background": "#212830ff",
+        "editor.document_highlight.read_background": "#478be64d",
+        "editor.document_highlight.write_background": "#478be633",
+        "editor.foreground": "#d1d7e0ff",
+        "editor.gutter.background": "#212830ff",
+        "editor.highlighted_line.background": "#656c7633",
+        "editor.invisible": "#656c76ff",
+        "editor.line_number": "#9198a1ff",
+        "editor.subheader.background": "#262c36ff",
+        "editor.wrap_guide": "#3d444db3",
+        "element.active": "#656c7633",
+        "element.background": "#656c7633",
+        "element.disabled": "#2a313cff",
+        "element.hover": "#656c7633",
+        "element.selected": "#656c7633",
+        "elevated_surface.background": "#2a313cff",
+        "error": "#e5534bff",
+        "error.background": "#262c36ff",
+        "error.border": "#3d444db3",
+        "ghost_element.active": "#656c7633",
+        "ghost_element.background": "#00000000",
+        "ghost_element.disabled": "#2a313cff",
+        "ghost_element.hover": "#656c7633",
+        "ghost_element.selected": "#656c7633",
+        "hidden": "#656c76ff",
+        "hidden.background": "#2a313cff",
+        "hidden.border": "#656c761a",
+        "hint": "#9198a1ff",
+        "hint.background": "#262c36ff",
+        "hint.border": "#3d444db3",
+        "icon": "#d1d7e0ff",
+        "icon.background": "#212830ff",
+        "icon.border": "#3d444dff",
+        "icon.accent": "#478be6ff",
+        "icon.muted": "#9198a1ff",
+        "icon.disabled": "#656c76ff",
+        "ignored": "#9198a1ff",
+        "ignored.background": "#2a313cff",
+        "ignored.border": "#656c761a",
+        "info": "#c69026ff",
+        "info.background": "#262c36ff",
+        "info.border": "#3d444db3",
+        "link_text.hover": "#478be6ff",
+        "modified": "#c69026ff",
+        "modified.background": "#ae7c1426",
+        "modified.border": "#ae7c1466",
+        "pane.focused_border": "#3d444dff",
+        "panel.background": "#151b23ff",
+        "panel.focused_border": "#3d444dff",
+        "predictive": "#9198a1ff",
+        "predictive.background": "#656c7633",
+        "predictive.border": "#3d444db3",
+        "renamed": "#57ab5aff",
+        "renamed.background": "#46954a26",
+        "renamed.border": "#46954a66",
+        "scrollbar.thumb.border": "#00000000",
+        "scrollbar.thumb.hover_background": "#262c36ff",
+        "scrollbar.track.background": "#00000000",
+        "scrollbar.track.border": "#00000000",
+        "search.match_background": "#eac55f4d",
+        "status_bar.background": "#151b23ff",
+        "success": "#57ab5aff",
+        "success.background": "#46954a26",
+        "success.border": "#46954a66",
+        "surface.background": "#151b23ff",
+        "tab.active_background": "#212830ff",
+        "tab.inactive_background": "#151b23ff",
+        "tab_bar.background": "#151b23ff",
+        "terminal.ansi.black": "#2f3742ff",
+        "terminal.ansi.bright_black": "#656c76ff",
+        "terminal.ansi.dim_black": "#2f3742ff",
+        "terminal.ansi.blue": "#539bf5ff",
+        "terminal.ansi.bright_blue": "#6cb6ffff",
+        "terminal.ansi.dim_blue": "#539bf5ff",
+        "terminal.ansi.cyan": "#39c5cfff",
+        "terminal.ansi.bright_cyan": "#56d4ddff",
+        "terminal.ansi.dim_cyan": "#39c5cfff",
+        "terminal.ansi.green": "#57ab5aff",
+        "terminal.ansi.bright_green": "#6bc46dff",
+        "terminal.ansi.dim_green": "#57ab5aff",
+        "terminal.ansi.magenta": "#b083f0ff",
+        "terminal.ansi.bright_magenta": "#dcbdfbff",
+        "terminal.ansi.dim_magenta": "#b083f0ff",
+        "terminal.ansi.red": "#f47067ff",
+        "terminal.ansi.bright_red": "#ff938aff",
+        "terminal.ansi.dim_red": "#f47067ff",
+        "terminal.ansi.white": "#f0f6fcff",
+        "terminal.ansi.bright_white": "#cdd9e5ff",
+        "terminal.ansi.dim_white": "#f0f6fcff",
+        "terminal.ansi.yellow": "#c69026ff",
+        "terminal.ansi.bright_yellow": "#daaa3fff",
+        "terminal.ansi.dim_yellow": "#c69026ff",
+        "terminal.background": "#151b23ff",
+        "terminal.bright_foreground": "#f0f6fcff",
+        "terminal.dim_foreground": "#9198a1ff",
+        "terminal.foreground": "#d1d7e0ff",
+        "text": "#d1d7e0ff",
+        "text.accent": "#478be6ff",
+        "text.disabled": "#656c76ff",
+        "text.muted": "#d1d7e0ff",
+        "text.placeholder": "#9198a1ff",
+        "title_bar.background": "#151b23ff",
+        "toolbar.background": "#212830ff",
+        "unreachable": "#656c76ff",
+        "unreachable.background": "#2a313cff",
+        "unreachable.border": "#656c761a",
+        "vim.mode.text": "#d1d7e0ff",
+        "vim.normal.background": "#656c76ff",
+        "vim.helix_normal.background": "#656c76ff",
+        "vim.visual.background": "#316dcaff",
+        "vim.helix_select.background": "#316dcaff",
+        "vim.insert.background": "#347d39ff",
+        "vim.visual_line.background": "#316dcaff",
+        "vim.visual_block.background": "#8256d0ff",
+        "vim.replace.background": "#ae4c82ff",
+        "warning": "#c69026ff",
+        "warning.background": "#262c36ff",
+        "warning.border": "#3d444db3",
+        "players": [
+          {
+            "cursor": "#0576ffff",
+            "background": "#0576ffff",
+            "selection": "#0576ff66"
+          },
+          {
+            "cursor": "#2f6f37ff",
+            "background": "#2f6f37ff",
+            "selection": "#2f6f3766"
+          },
+          {
+            "cursor": "#895906ff",
+            "background": "#895906ff",
+            "selection": "#89590666"
+          },
+          {
+            "cursor": "#eb3342ff",
+            "background": "#eb3342ff",
+            "selection": "#eb334266"
+          },
+          {
+            "cursor": "#d34591ff",
+            "background": "#d34591ff",
+            "selection": "#d3459166"
+          },
+          {
+            "cursor": "#975bf1ff",
+            "background": "#975bf1ff",
+            "selection": "#975bf166"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": "#6cb6ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#6cb6ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#9198a1ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#9198a1ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#6cb6ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#f47067ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#f47067ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": null,
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": null,
+            "font_style": null,
+            "font_weight": 700
+          },
+          "enum": {
+            "color": "#f69d50ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function": {
+            "color": "#dcbdfbff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.method": {
+            "color": "#dcbdfbff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.special.definition": {
+            "color": "#dcbdfbff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "hint": {
+            "color": "#9198a1ff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "keyword": {
+            "color": "#f47067ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.operator": {
+            "color": "#f47067ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#6cb6ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#96d0ffff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#6cb6ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#6cb6ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#f47067ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predictive": {
+            "color": "#9198a1ff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#f47067ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "#d1d7e0ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#d1d7e0ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property.json_key": {
+            "color": "#8ddb8cff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#f47067ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#d1d7e0ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#d1d7e0ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter.jsx": {
+            "color": "#f47067ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#f69d50ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#f47067ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#96d0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#f47067ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#96d0ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#6cb6ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#6cb6ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#8ddb8cff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#6cb6ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#6cb6ffff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "type": {
+            "color": "#f69d50ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.builtin": {
+            "color": "#6cb6ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#d1d7e0ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.builtin": {
+            "color": "#6cb6ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.parameter": {
+            "color": "#f69d50ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#6cb6ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variant": {
+            "color": "#f69d50ff",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    }
+  ]
+}

--- a/themes/gruber_darker_zed.json
+++ b/themes/gruber_darker_zed.json
@@ -1,0 +1,349 @@
+{
+  "$schema": "https://zed.dev/schema/themes/v0.2.0.json",
+  "name": "Gruber Darker",
+  "author": "Ported from rexim's Gruber Darker theme",
+  "themes": [
+    {
+      "name": "Gruber Darker",
+      "appearance": "dark",
+      "style": {
+        "background": "#181818",
+        "foreground": "#e4e4ef",
+        
+        "cursor": "#ffdd33",
+        "selection": "#484848",
+        "invisible": "#453d41",
+        
+        "border": "#453d41",
+        "border.variant": "#282828",
+        "border.focused": "#565f73",
+        "border.selected": "#96a6c8",
+        "border.transparent": "#00000000",
+        "border.disabled": "#282828",
+        
+        "elevated_surface.background": "#282828",
+        "surface.background": "#282828",
+        "panel.background": "#181818",
+        
+        "element.background": "#282828",
+        "element.hover": "#453d41",
+        "element.active": "#52494e",
+        "element.selected": "#484848",
+        "element.disabled": "#282828",
+        
+        "ghost_element.background": "#00000000",
+        "ghost_element.hover": "#282828",
+        "ghost_element.active": "#453d41",
+        "ghost_element.selected": "#484848",
+        "ghost_element.disabled": "#282828",
+        
+        "drop_target.background": "#48484840",
+        
+        "text": "#e4e4ef",
+        "text.muted": "#95a99f",
+        "text.placeholder": "#565f73",
+        "text.disabled": "#565f73",
+        "text.accent": "#96a6c8",
+        
+        "icon": "#e4e4ef",
+        "icon.muted": "#95a99f",
+        "icon.disabled": "#565f73",
+        "icon.placeholder": "#565f73",
+        "icon.accent": "#96a6c8",
+        
+        "status_bar.background": "#181818",
+        "title_bar.background": "#181818",
+        "title_bar.inactive_background": "#101010",
+        "toolbar.background": "#181818",
+        "tab_bar.background": "#181818",
+        
+        "tab.inactive_background": "#181818",
+        "tab.active_background": "#282828",
+        
+        "editor.background": "#181818",
+        "editor.gutter.background": "#181818",
+        "editor.subheader.background": "#282828",
+        "editor.active_line.background": "#282828",
+        "editor.highlighted_line.background": "#282828",
+        "editor.line_number": "#95a99f",
+        "editor.active_line_number": "#ffdd33",
+        "editor.invisible": "#453d41",
+        "editor.wrap_guide": "#453d41",
+        "editor.active_wrap_guide": "#565f73",
+        "editor.document_highlight.read_background": "#30354040",
+        "editor.document_highlight.write_background": "#30354060",
+        "editor.document_highlight.bracket_background": "#52494e",
+        
+        "terminal.background": "#181818",
+        "terminal.foreground": "#e4e4ef",
+        "terminal.bright_foreground": "#f4f4ff",
+        "terminal.dim_foreground": "#95a99f",
+        "terminal.ansi.background": "#181818",
+        "terminal.ansi.black": "#484848",
+        "terminal.ansi.red": "#c73c3f",
+        "terminal.ansi.green": "#73c936",
+        "terminal.ansi.yellow": "#ffdd33",
+        "terminal.ansi.blue": "#96a6c8",
+        "terminal.ansi.magenta": "#9e95c7",
+        "terminal.ansi.cyan": "#95a99f",
+        "terminal.ansi.white": "#e4e4ef",
+        "terminal.ansi.bright_black": "#565f73",
+        "terminal.ansi.bright_red": "#f43841",
+        "terminal.ansi.bright_green": "#73c936",
+        "terminal.ansi.bright_yellow": "#ffdd33",
+        "terminal.ansi.bright_blue": "#96a6c8",
+        "terminal.ansi.bright_magenta": "#9e95c7",
+        "terminal.ansi.bright_cyan": "#95a99f",
+        "terminal.ansi.bright_white": "#f4f4ff",
+        "terminal.ansi.dim_black": "#282828",
+        "terminal.ansi.dim_red": "#c73c3f",
+        "terminal.ansi.dim_green": "#73c936",
+        "terminal.ansi.dim_yellow": "#cc8c3c",
+        "terminal.ansi.dim_blue": "#565f73",
+        "terminal.ansi.dim_magenta": "#9e95c7",
+        "terminal.ansi.dim_cyan": "#95a99f",
+        "terminal.ansi.dim_white": "#95a99f",
+        
+        "link_text.hover": "#9e95c7",
+        
+        "conflict": "#f43841",
+        "conflict.background": "#f4384120",
+        "conflict.border": "#f43841",
+        
+        "created": "#73c936",
+        "created.background": "#73c93620",
+        "created.border": "#73c936",
+        
+        "deleted": "#f43841",
+        "deleted.background": "#f4384120",
+        "deleted.border": "#f43841",
+        
+        "error": "#f43841",
+        "error.background": "#f4384120",
+        "error.border": "#f43841",
+        
+        "hidden": "#565f73",
+        "hidden.background": "#565f7320",
+        "hidden.border": "#565f73",
+        
+        "hint": "#96a6c8",
+        "hint.background": "#96a6c820",
+        "hint.border": "#96a6c8",
+        
+        "ignored": "#95a99f",
+        "ignored.background": "#95a99f20",
+        "ignored.border": "#95a99f",
+        
+        "info": "#96a6c8",
+        "info.background": "#96a6c820",
+        "info.border": "#96a6c8",
+        
+        "modified": "#ffdd33",
+        "modified.background": "#ffdd3320",
+        "modified.border": "#ffdd33",
+        
+        "predictive": "#9e95c7",
+        "predictive.background": "#9e95c720",
+        "predictive.border": "#9e95c7",
+        
+        "renamed": "#96a6c8",
+        "renamed.background": "#96a6c820",
+        "renamed.border": "#96a6c8",
+        
+        "success": "#73c936",
+        "success.background": "#73c93620",
+        "success.border": "#73c936",
+        
+        "unreachable": "#565f73",
+        "unreachable.background": "#565f7320",
+        "unreachable.border": "#565f73",
+        
+        "warning": "#cc8c3c",
+        "warning.background": "#cc8c3c20",
+        "warning.border": "#cc8c3c",
+        
+        "players": [
+          {
+            "cursor": "#96a6c8",
+            "background": "#96a6c820",
+            "selection": "#96a6c830"
+          },
+          {
+            "cursor": "#73c936",
+            "background": "#73c93620",
+            "selection": "#73c93630"
+          },
+          {
+            "cursor": "#ffdd33",
+            "background": "#ffdd3320",
+            "selection": "#ffdd3330"
+          },
+          {
+            "cursor": "#9e95c7",
+            "background": "#9e95c720",
+            "selection": "#9e95c730"
+          },
+          {
+            "cursor": "#f43841",
+            "background": "#f4384120",
+            "selection": "#f4384130"
+          },
+          {
+            "cursor": "#cc8c3c",
+            "background": "#cc8c3c20",
+            "selection": "#cc8c3c30"
+          },
+          {
+            "cursor": "#95a99f",
+            "background": "#95a99f20",
+            "selection": "#95a99f30"
+          },
+          {
+            "cursor": "#565f73",
+            "background": "#565f7320",
+            "selection": "#565f7330"
+          }
+        ],
+        
+        "scrollbar.thumb.background": "#453d41",
+        "scrollbar.thumb.hover_background": "#52494e",
+        "scrollbar.thumb.border": "#00000000",
+        "scrollbar.track.background": "#282828",
+        "scrollbar.track.border": "#00000000",
+        
+        "search.match_background": "#ffdd3340",
+        
+        "panel.focused_border": "#96a6c8",
+        "pane.focused_border": "#96a6c8",
+        "pane_group.border": "#453d41",
+        
+        "syntax": {
+          "attribute": {
+            "color": "#95a99f"
+          },
+          "boolean": {
+            "color": "#9e95c7"
+          },
+          "comment": {
+            "color": "#cc8c3c",
+            "font_style": "italic"
+          },
+          "comment.doc": {
+            "color": "#73c936",
+            "font_style": "italic"
+          },
+          "constant": {
+            "color": "#95a99f"
+          },
+          "constructor": {
+            "color": "#96a6c8"
+          },
+          "embedded": {
+            "color": "#e4e4ef"
+          },
+          "emphasis": {
+            "font_style": "italic"
+          },
+          "emphasis.strong": {
+            "font_weight": 700
+          },
+          "enum": {
+            "color": "#95a99f"
+          },
+          "function": {
+            "color": "#96a6c8"
+          },
+          "hint": {
+            "color": "#96a6c8",
+            "font_weight": 700
+          },
+          "keyword": {
+            "color": "#ffdd33",
+            "font_weight": 700
+          },
+          "label": {
+            "color": "#96a6c8"
+          },
+          "link_text": {
+            "color": "#96a6c8",
+            "font_style": "italic"
+          },
+          "link_uri": {
+            "color": "#95a99f"
+          },
+          "number": {
+            "color": "#9e95c7"
+          },
+          "operator": {
+            "color": "#e4e4ef"
+          },
+          "predictive": {
+            "color": "#565f73",
+            "font_style": "italic"
+          },
+          "preproc": {
+            "color": "#95a99f"
+          },
+          "primary": {
+            "color": "#e4e4ef"
+          },
+          "property": {
+            "color": "#f4f4ff"
+          },
+          "punctuation": {
+            "color": "#e4e4ef"
+          },
+          "punctuation.bracket": {
+            "color": "#e4e4ef"
+          },
+          "punctuation.delimiter": {
+            "color": "#e4e4ef"
+          },
+          "punctuation.list_marker": {
+            "color": "#e4e4ef"
+          },
+          "punctuation.special": {
+            "color": "#9e95c7"
+          },
+          "string": {
+            "color": "#73c936"
+          },
+          "string.escape": {
+            "color": "#9e95c7"
+          },
+          "string.regex": {
+            "color": "#73c936"
+          },
+          "string.special": {
+            "color": "#9e95c7"
+          },
+          "string.special.symbol": {
+            "color": "#9e95c7"
+          },
+          "tag": {
+            "color": "#96a6c8"
+          },
+          "text.literal": {
+            "color": "#73c936"
+          },
+          "title": {
+            "color": "#96a6c8",
+            "font_weight": 700
+          },
+          "type": {
+            "color": "#95a99f"
+          },
+          "variable": {
+            "color": "#f4f4ff"
+          },
+          "variable.special": {
+            "color": "#9e95c7"
+          },
+          "variant": {
+            "color": "#95a99f"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/themes/gruvbox.json
+++ b/themes/gruvbox.json
@@ -1,0 +1,2449 @@
+{
+  "$schema": "https://zed.dev/schema/themes/v0.2.0.json",
+  "name": "Gruvbox",
+  "author": "Zed Industries",
+  "themes": [
+    {
+      "name": "Gruvbox Dark",
+      "appearance": "dark",
+      "style": {
+        "accents": ["#cc241dff", "#98971aff", "#d79921ff", "#458588ff", "#b16286ff", "#689d6aff", "#d65d0eff"],
+        "border": "#5b534dff",
+        "border.variant": "#494340ff",
+        "border.focused": "#303a36ff",
+        "border.selected": "#303a36ff",
+        "border.transparent": "#00000000",
+        "border.disabled": "#544c48ff",
+        "elevated_surface.background": "#3a3735ff",
+        "surface.background": "#3a3735ff",
+        "background": "#4c4642ff",
+        "element.background": "#3a3735ff",
+        "element.hover": "#494340ff",
+        "element.active": "#5b524cff",
+        "element.selected": "#5b524cff",
+        "element.disabled": "#3a3735ff",
+        "drop_target.background": "#c5b59780",
+        "ghost_element.background": "#00000000",
+        "ghost_element.hover": "#494340ff",
+        "ghost_element.active": "#5b524cff",
+        "ghost_element.selected": "#5b524cff",
+        "ghost_element.disabled": "#3a3735ff",
+        "text": "#fbf1c7ff",
+        "text.muted": "#c5b597ff",
+        "text.placeholder": "#998b78ff",
+        "text.disabled": "#998b78ff",
+        "text.accent": "#83a598ff",
+        "icon": "#fbf1c7ff",
+        "icon.muted": "#c5b597ff",
+        "icon.disabled": "#998b78ff",
+        "icon.placeholder": "#c5b597ff",
+        "icon.accent": "#83a598ff",
+        "status_bar.background": "#4c4642ff",
+        "title_bar.background": "#4c4642ff",
+        "title_bar.inactive_background": "#3a3735ff",
+        "toolbar.background": "#282828ff",
+        "tab_bar.background": "#3a3735ff",
+        "tab.inactive_background": "#3a3735ff",
+        "tab.active_background": "#282828ff",
+        "search.match_background": "#83a59866",
+        "search.active_match_background": "#c09f3f66",
+        "panel.background": "#3a3735ff",
+        "panel.focused_border": "#83a598ff",
+        "pane.focused_border": null,
+        "scrollbar.thumb.active_background": "#83a598ac",
+        "scrollbar.thumb.hover_background": "#fbf1c74c",
+        "scrollbar.thumb.background": "#a899844c",
+        "scrollbar.thumb.border": "#494340ff",
+        "scrollbar.track.background": "#00000000",
+        "scrollbar.track.border": "#373432ff",
+        "editor.foreground": "#ebdbb2ff",
+        "editor.background": "#282828ff",
+        "editor.gutter.background": "#282828ff",
+        "editor.subheader.background": "#3a3735ff",
+        "editor.active_line.background": "#3a3735bf",
+        "editor.highlighted_line.background": "#3a3735ff",
+        "editor.line_number": "#6e6b5e",
+        "editor.active_line_number": "#dedcd3",
+        "editor.hover_line_number": "#c9c5b6",
+        "editor.invisible": "#928474ff",
+        "editor.wrap_guide": "#fbf1c70d",
+        "editor.active_wrap_guide": "#fbf1c71a",
+        "editor.document_highlight.read_background": "#83a5981a",
+        "editor.document_highlight.write_background": "#92847466",
+        "terminal.background": "#282828ff",
+        "terminal.foreground": "#ebdbb2ff",
+        "terminal.bright_foreground": "#fbf1c7ff",
+        "terminal.dim_foreground": "#766b5dff",
+        "terminal.ansi.black": "#282828ff",
+        "terminal.ansi.bright_black": "#928374ff",
+        "terminal.ansi.dim_black": "#fbf1c7ff",
+        "terminal.ansi.red": "#cc241dff",
+        "terminal.ansi.bright_red": "#fb4934ff",
+        "terminal.ansi.dim_red": "#8e1814ff",
+        "terminal.ansi.green": "#98971aff",
+        "terminal.ansi.bright_green": "#b8bb26ff",
+        "terminal.ansi.dim_green": "#6a6912ff",
+        "terminal.ansi.yellow": "#d79921ff",
+        "terminal.ansi.bright_yellow": "#fabd2fff",
+        "terminal.ansi.dim_yellow": "#966a17ff",
+        "terminal.ansi.blue": "#458588ff",
+        "terminal.ansi.bright_blue": "#83a598ff",
+        "terminal.ansi.dim_blue": "#305d5fff",
+        "terminal.ansi.magenta": "#b16286ff",
+        "terminal.ansi.bright_magenta": "#d3869bff",
+        "terminal.ansi.dim_magenta": "#7c455eff",
+        "terminal.ansi.cyan": "#689d6aff",
+        "terminal.ansi.bright_cyan": "#8ec07cff",
+        "terminal.ansi.dim_cyan": "#496e4aff",
+        "terminal.ansi.white": "#a89984ff",
+        "terminal.ansi.bright_white": "#fbf1c7ff",
+        "terminal.ansi.dim_white": "#766b5dff",
+        "link_text.hover": "#83a598ff",
+        "version_control.added": "#b7bb26ff",
+        "version_control.modified": "#f9bd2fff",
+        "version_control.deleted": "#fb4a35ff",
+        "conflict": "#f9bd2fff",
+        "conflict.background": "#572e10ff",
+        "conflict.border": "#754916ff",
+        "created": "#b7bb26ff",
+        "created.background": "#322b11ff",
+        "created.border": "#4a4516ff",
+        "deleted": "#fb4a35ff",
+        "deleted.background": "#590a0fff",
+        "deleted.border": "#771617ff",
+        "error": "#fb4a35ff",
+        "error.background": "#590a0fff",
+        "error.border": "#771617ff",
+        "hidden": "#998b78ff",
+        "hidden.background": "#4c4642ff",
+        "hidden.border": "#544c48ff",
+        "hint": "#8c957dff",
+        "hint.background": "#1e2321ff",
+        "hint.border": "#303a36ff",
+        "ignored": "#998b78ff",
+        "ignored.background": "#4c4642ff",
+        "ignored.border": "#5b534dff",
+        "info": "#83a598ff",
+        "info.background": "#1e2321ff",
+        "info.border": "#303a36ff",
+        "modified": "#f9bd2fff",
+        "modified.background": "#572e10ff",
+        "modified.border": "#754916ff",
+        "predictive": "#717363ff",
+        "predictive.background": "#322b11ff",
+        "predictive.border": "#4a4516ff",
+        "renamed": "#83a598ff",
+        "renamed.background": "#1e2321ff",
+        "renamed.border": "#303a36ff",
+        "success": "#b7bb26ff",
+        "success.background": "#322b11ff",
+        "success.border": "#4a4516ff",
+        "unreachable": "#c5b597ff",
+        "unreachable.background": "#4c4642ff",
+        "unreachable.border": "#5b534dff",
+        "warning": "#f9bd2fff",
+        "warning.background": "#572e10ff",
+        "warning.border": "#754916ff",
+        "players": [
+          {
+            "cursor": "#83a598ff",
+            "background": "#83a598ff",
+            "selection": "#83a5983d"
+          },
+          {
+            "cursor": "#a89984ff",
+            "background": "#a89984ff",
+            "selection": "#a899843d"
+          },
+          {
+            "cursor": "#fd801bff",
+            "background": "#fd801bff",
+            "selection": "#fd801b3d"
+          },
+          {
+            "cursor": "#d3869bff",
+            "background": "#d3869bff",
+            "selection": "#d3869b3d"
+          },
+          {
+            "cursor": "#8ec07cff",
+            "background": "#8ec07cff",
+            "selection": "#8ec07c3d"
+          },
+          {
+            "cursor": "#fb4a35ff",
+            "background": "#fb4a35ff",
+            "selection": "#fb4a353d"
+          },
+          {
+            "cursor": "#f9bd2fff",
+            "background": "#f9bd2fff",
+            "selection": "#f9bd2f3d"
+          },
+          {
+            "cursor": "#b7bb26ff",
+            "background": "#b7bb26ff",
+            "selection": "#b7bb263d"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#d3869bff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#a89984ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#c6b697ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#fabd2eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#8ec07cff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "enum": {
+            "color": "#fe7f18ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function": {
+            "color": "#b8bb25ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.builtin": {
+            "color": "#fb4833ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "hint": {
+            "color": "#8c957dff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword": {
+            "color": "#fb4833ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#8ec07cff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#d3869bff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#d3869bff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#8ec07cff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predictive": {
+            "color": "#717363ff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#fbf1c7ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "#ebdbb2ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#ebdbb2ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#d5c4a1ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#a89984ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#e5d5adff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#ebdbb2ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.markup": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#e5d5adff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector": {
+            "color": "#fabd2eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector.pseudo": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#b8bb25ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#c6b697ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#fe7f18ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#d3869bff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#8ec07cff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#8ec07cff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#b8bb25ff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "type": {
+            "color": "#fabd2eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#ebdbb2ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variant": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    },
+    {
+      "name": "Gruvbox Dark Hard",
+      "appearance": "dark",
+      "style": {
+        "accents": ["#cc241dff", "#98971aff", "#d79921ff", "#458588ff", "#b16286ff", "#689d6aff", "#d65d0eff"],
+        "border": "#5b534dff",
+        "border.variant": "#494340ff",
+        "border.focused": "#303a36ff",
+        "border.selected": "#303a36ff",
+        "border.transparent": "#00000000",
+        "border.disabled": "#544c48ff",
+        "elevated_surface.background": "#393634ff",
+        "surface.background": "#393634ff",
+        "background": "#4c4642ff",
+        "element.background": "#393634ff",
+        "element.hover": "#494340ff",
+        "element.active": "#5b524cff",
+        "element.selected": "#5b524cff",
+        "element.disabled": "#393634ff",
+        "drop_target.background": "#c5b59780",
+        "ghost_element.background": "#00000000",
+        "ghost_element.hover": "#494340ff",
+        "ghost_element.active": "#5b524cff",
+        "ghost_element.selected": "#5b524cff",
+        "ghost_element.disabled": "#393634ff",
+        "text": "#fbf1c7ff",
+        "text.muted": "#c5b597ff",
+        "text.placeholder": "#998b78ff",
+        "text.disabled": "#998b78ff",
+        "text.accent": "#83a598ff",
+        "icon": "#fbf1c7ff",
+        "icon.muted": "#c5b597ff",
+        "icon.disabled": "#998b78ff",
+        "icon.placeholder": "#c5b597ff",
+        "icon.accent": "#83a598ff",
+        "status_bar.background": "#4c4642ff",
+        "title_bar.background": "#4c4642ff",
+        "title_bar.inactive_background": "#393634ff",
+        "toolbar.background": "#1d2021ff",
+        "tab_bar.background": "#393634ff",
+        "tab.inactive_background": "#393634ff",
+        "tab.active_background": "#1d2021ff",
+        "search.match_background": "#83a59866",
+        "search.active_match_background": "#c9653666",
+        "panel.background": "#393634ff",
+        "panel.focused_border": "#83a598ff",
+        "pane.focused_border": null,
+        "scrollbar.thumb.active_background": "#83a598ac",
+        "scrollbar.thumb.hover_background": "#fbf1c74c",
+        "scrollbar.thumb.background": "#a899844c",
+        "scrollbar.thumb.border": "#494340ff",
+        "scrollbar.track.background": "#00000000",
+        "scrollbar.track.border": "#343130ff",
+        "editor.foreground": "#ebdbb2ff",
+        "editor.background": "#1d2021ff",
+        "editor.gutter.background": "#1d2021ff",
+        "editor.subheader.background": "#393634ff",
+        "editor.active_line.background": "#393634bf",
+        "editor.highlighted_line.background": "#393634ff",
+        "editor.line_number": "#6e6b5e",
+        "editor.active_line_number": "#dedcd3",
+        "editor.hover_line_number": "#c9c5b6",
+        "editor.invisible": "#928474ff",
+        "editor.wrap_guide": "#fbf1c70d",
+        "editor.active_wrap_guide": "#fbf1c71a",
+        "editor.document_highlight.read_background": "#83a5981a",
+        "editor.document_highlight.write_background": "#92847466",
+        "terminal.background": "#1d2021ff",
+        "terminal.foreground": "#ebdbb2ff",
+        "terminal.bright_foreground": "#fbf1c7ff",
+        "terminal.dim_foreground": "#766b5dff",
+        "terminal.ansi.black": "#282828ff",
+        "terminal.ansi.bright_black": "#928374ff",
+        "terminal.ansi.dim_black": "#fbf1c7ff",
+        "terminal.ansi.red": "#cc241dff",
+        "terminal.ansi.bright_red": "#fb4934ff",
+        "terminal.ansi.dim_red": "#8e1814ff",
+        "terminal.ansi.green": "#98971aff",
+        "terminal.ansi.bright_green": "#b8bb26ff",
+        "terminal.ansi.dim_green": "#6a6912ff",
+        "terminal.ansi.yellow": "#d79921ff",
+        "terminal.ansi.bright_yellow": "#fabd2fff",
+        "terminal.ansi.dim_yellow": "#966a17ff",
+        "terminal.ansi.blue": "#458588ff",
+        "terminal.ansi.bright_blue": "#83a598ff",
+        "terminal.ansi.dim_blue": "#305d5fff",
+        "terminal.ansi.magenta": "#b16286ff",
+        "terminal.ansi.bright_magenta": "#d3869bff",
+        "terminal.ansi.dim_magenta": "#7c455eff",
+        "terminal.ansi.cyan": "#689d6aff",
+        "terminal.ansi.bright_cyan": "#8ec07cff",
+        "terminal.ansi.dim_cyan": "#496e4aff",
+        "terminal.ansi.white": "#a89984ff",
+        "terminal.ansi.bright_white": "#fbf1c7ff",
+        "terminal.ansi.dim_white": "#766b5dff",
+        "link_text.hover": "#83a598ff",
+        "version_control.added": "#b7bb26ff",
+        "version_control.modified": "#f9bd2fff",
+        "version_control.deleted": "#fb4a35ff",
+        "conflict": "#f9bd2fff",
+        "conflict.background": "#572e10ff",
+        "conflict.border": "#754916ff",
+        "created": "#b7bb26ff",
+        "created.background": "#322b11ff",
+        "created.border": "#4a4516ff",
+        "deleted": "#fb4a35ff",
+        "deleted.background": "#590a0fff",
+        "deleted.border": "#771617ff",
+        "error": "#fb4a35ff",
+        "error.background": "#590a0fff",
+        "error.border": "#771617ff",
+        "hidden": "#998b78ff",
+        "hidden.background": "#4c4642ff",
+        "hidden.border": "#544c48ff",
+        "hint": "#6a695bff",
+        "hint.background": "#1e2321ff",
+        "hint.border": "#303a36ff",
+        "ignored": "#998b78ff",
+        "ignored.background": "#4c4642ff",
+        "ignored.border": "#5b534dff",
+        "info": "#83a598ff",
+        "info.background": "#1e2321ff",
+        "info.border": "#303a36ff",
+        "modified": "#f9bd2fff",
+        "modified.background": "#572e10ff",
+        "modified.border": "#754916ff",
+        "predictive": "#717363ff",
+        "predictive.background": "#322b11ff",
+        "predictive.border": "#4a4516ff",
+        "renamed": "#83a598ff",
+        "renamed.background": "#1e2321ff",
+        "renamed.border": "#303a36ff",
+        "success": "#b7bb26ff",
+        "success.background": "#322b11ff",
+        "success.border": "#4a4516ff",
+        "unreachable": "#c5b597ff",
+        "unreachable.background": "#4c4642ff",
+        "unreachable.border": "#5b534dff",
+        "warning": "#f9bd2fff",
+        "warning.background": "#572e10ff",
+        "warning.border": "#754916ff",
+        "players": [
+          {
+            "cursor": "#83a598ff",
+            "background": "#83a598ff",
+            "selection": "#83a5983d"
+          },
+          {
+            "cursor": "#a89984ff",
+            "background": "#a89984ff",
+            "selection": "#a899843d"
+          },
+          {
+            "cursor": "#fd801bff",
+            "background": "#fd801bff",
+            "selection": "#fd801b3d"
+          },
+          {
+            "cursor": "#d3869bff",
+            "background": "#d3869bff",
+            "selection": "#d3869b3d"
+          },
+          {
+            "cursor": "#8ec07cff",
+            "background": "#8ec07cff",
+            "selection": "#8ec07c3d"
+          },
+          {
+            "cursor": "#fb4a35ff",
+            "background": "#fb4a35ff",
+            "selection": "#fb4a353d"
+          },
+          {
+            "cursor": "#f9bd2fff",
+            "background": "#f9bd2fff",
+            "selection": "#f9bd2f3d"
+          },
+          {
+            "cursor": "#b7bb26ff",
+            "background": "#b7bb26ff",
+            "selection": "#b7bb263d"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#d3869bff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#a89984ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#c6b697ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#fabd2eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#8ec07cff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "enum": {
+            "color": "#fe7f18ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function": {
+            "color": "#b8bb25ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.builtin": {
+            "color": "#fb4833ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "hint": {
+            "color": "#8c957dff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword": {
+            "color": "#fb4833ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#8ec07cff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#d3869bff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#d3869bff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#8ec07cff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predictive": {
+            "color": "#717363ff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#fbf1c7ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "#ebdbb2ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#ebdbb2ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#d5c4a1ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#a89984ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#e5d5adff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#ebdbb2ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.markup": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#e5d5adff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector": {
+            "color": "#fabd2eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector.pseudo": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#b8bb25ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#c6b697ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#fe7f18ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#d3869bff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#8ec07cff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#8ec07cff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#b8bb25ff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "type": {
+            "color": "#fabd2eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#ebdbb2ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variant": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    },
+    {
+      "name": "Gruvbox Dark Soft",
+      "appearance": "dark",
+      "style": {
+        "accents": ["#cc241dff", "#98971aff", "#d79921ff", "#458588ff", "#b16286ff", "#689d6aff", "#d65d0eff"],
+        "border": "#5b534dff",
+        "border.variant": "#494340ff",
+        "border.focused": "#303a36ff",
+        "border.selected": "#303a36ff",
+        "border.transparent": "#00000000",
+        "border.disabled": "#544c48ff",
+        "elevated_surface.background": "#3b3735ff",
+        "surface.background": "#3b3735ff",
+        "background": "#4c4642ff",
+        "element.background": "#3b3735ff",
+        "element.hover": "#494340ff",
+        "element.active": "#5b524cff",
+        "element.selected": "#5b524cff",
+        "element.disabled": "#3b3735ff",
+        "drop_target.background": "#c5b59780",
+        "ghost_element.background": "#00000000",
+        "ghost_element.hover": "#494340ff",
+        "ghost_element.active": "#5b524cff",
+        "ghost_element.selected": "#5b524cff",
+        "ghost_element.disabled": "#3b3735ff",
+        "text": "#fbf1c7ff",
+        "text.muted": "#c5b597ff",
+        "text.placeholder": "#998b78ff",
+        "text.disabled": "#998b78ff",
+        "text.accent": "#83a598ff",
+        "icon": "#fbf1c7ff",
+        "icon.muted": "#c5b597ff",
+        "icon.disabled": "#998b78ff",
+        "icon.placeholder": "#c5b597ff",
+        "icon.accent": "#83a598ff",
+        "status_bar.background": "#4c4642ff",
+        "title_bar.background": "#4c4642ff",
+        "title_bar.inactive_background": "#3b3735ff",
+        "toolbar.background": "#32302fff",
+        "tab_bar.background": "#3b3735ff",
+        "tab.inactive_background": "#3b3735ff",
+        "tab.active_background": "#32302fff",
+        "search.match_background": "#83a59866",
+        "search.active_match_background": "#aea85166",
+        "panel.background": "#3b3735ff",
+        "panel.focused_border": null,
+        "pane.focused_border": null,
+        "scrollbar.thumb.active_background": "#83a598ac",
+        "scrollbar.thumb.hover_background": "#fbf1c74c",
+        "scrollbar.thumb.background": "#a899844c",
+        "scrollbar.thumb.border": "#494340ff",
+        "scrollbar.track.background": "#00000000",
+        "scrollbar.track.border": "#393634ff",
+        "editor.foreground": "#ebdbb2ff",
+        "editor.background": "#32302fff",
+        "editor.gutter.background": "#32302fff",
+        "editor.subheader.background": "#3b3735ff",
+        "editor.active_line.background": "#3b3735bf",
+        "editor.highlighted_line.background": "#3b3735ff",
+        "editor.line_number": "#6e6b5e",
+        "editor.active_line_number": "#dedcd3",
+        "editor.hover_line_number": "#c9c5b6",
+        "editor.invisible": "#928474ff",
+        "editor.wrap_guide": "#fbf1c70d",
+        "editor.active_wrap_guide": "#fbf1c71a",
+        "editor.document_highlight.read_background": "#83a5981a",
+        "editor.document_highlight.write_background": "#92847466",
+        "terminal.background": "#32302fff",
+        "terminal.foreground": "#ebdbb2ff",
+        "terminal.bright_foreground": "#fbf1c7ff",
+        "terminal.dim_foreground": "#766b5dff",
+        "terminal.ansi.black": "#282828ff",
+        "terminal.ansi.bright_black": "#928374ff",
+        "terminal.ansi.dim_black": "#fbf1c7ff",
+        "terminal.ansi.red": "#cc241dff",
+        "terminal.ansi.bright_red": "#fb4934ff",
+        "terminal.ansi.dim_red": "#8e1814ff",
+        "terminal.ansi.green": "#98971aff",
+        "terminal.ansi.bright_green": "#b8bb26ff",
+        "terminal.ansi.dim_green": "#6a6912ff",
+        "terminal.ansi.yellow": "#d79921ff",
+        "terminal.ansi.bright_yellow": "#fabd2fff",
+        "terminal.ansi.dim_yellow": "#966a17ff",
+        "terminal.ansi.blue": "#458588ff",
+        "terminal.ansi.bright_blue": "#83a598ff",
+        "terminal.ansi.dim_blue": "#305d5fff",
+        "terminal.ansi.magenta": "#b16286ff",
+        "terminal.ansi.bright_magenta": "#d3869bff",
+        "terminal.ansi.dim_magenta": "#7c455eff",
+        "terminal.ansi.cyan": "#689d6aff",
+        "terminal.ansi.bright_cyan": "#8ec07cff",
+        "terminal.ansi.dim_cyan": "#496e4aff",
+        "terminal.ansi.white": "#a89984ff",
+        "terminal.ansi.bright_white": "#fbf1c7ff",
+        "terminal.ansi.dim_white": "#766b5dff",
+        "link_text.hover": "#83a598ff",
+        "version_control.added": "#b7bb26ff",
+        "version_control.modified": "#f9bd2fff",
+        "version_control.deleted": "#fb4a35ff",
+        "conflict": "#f9bd2fff",
+        "conflict.background": "#572e10ff",
+        "conflict.border": "#754916ff",
+        "created": "#b7bb26ff",
+        "created.background": "#322b11ff",
+        "created.border": "#4a4516ff",
+        "deleted": "#fb4a35ff",
+        "deleted.background": "#590a0fff",
+        "deleted.border": "#771617ff",
+        "error": "#fb4a35ff",
+        "error.background": "#590a0fff",
+        "error.border": "#771617ff",
+        "hidden": "#998b78ff",
+        "hidden.background": "#4c4642ff",
+        "hidden.border": "#544c48ff",
+        "hint": "#8c957dff",
+        "hint.background": "#1e2321ff",
+        "hint.border": "#303a36ff",
+        "ignored": "#998b78ff",
+        "ignored.background": "#4c4642ff",
+        "ignored.border": "#5b534dff",
+        "info": "#83a598ff",
+        "info.background": "#1e2321ff",
+        "info.border": "#303a36ff",
+        "modified": "#f9bd2fff",
+        "modified.background": "#572e10ff",
+        "modified.border": "#754916ff",
+        "predictive": "#717363ff",
+        "predictive.background": "#322b11ff",
+        "predictive.border": "#4a4516ff",
+        "renamed": "#83a598ff",
+        "renamed.background": "#1e2321ff",
+        "renamed.border": "#303a36ff",
+        "success": "#b7bb26ff",
+        "success.background": "#322b11ff",
+        "success.border": "#4a4516ff",
+        "unreachable": "#c5b597ff",
+        "unreachable.background": "#4c4642ff",
+        "unreachable.border": "#5b534dff",
+        "warning": "#f9bd2fff",
+        "warning.background": "#572e10ff",
+        "warning.border": "#754916ff",
+        "players": [
+          {
+            "cursor": "#83a598ff",
+            "background": "#83a598ff",
+            "selection": "#83a5983d"
+          },
+          {
+            "cursor": "#a89984ff",
+            "background": "#a89984ff",
+            "selection": "#a899843d"
+          },
+          {
+            "cursor": "#fd801bff",
+            "background": "#fd801bff",
+            "selection": "#fd801b3d"
+          },
+          {
+            "cursor": "#d3869bff",
+            "background": "#d3869bff",
+            "selection": "#d3869b3d"
+          },
+          {
+            "cursor": "#8ec07cff",
+            "background": "#8ec07cff",
+            "selection": "#8ec07c3d"
+          },
+          {
+            "cursor": "#fb4a35ff",
+            "background": "#fb4a35ff",
+            "selection": "#fb4a353d"
+          },
+          {
+            "cursor": "#f9bd2fff",
+            "background": "#f9bd2fff",
+            "selection": "#f9bd2f3d"
+          },
+          {
+            "cursor": "#b7bb26ff",
+            "background": "#b7bb26ff",
+            "selection": "#b7bb263d"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#d3869bff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#a89984ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#c6b697ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#fabd2eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#8ec07cff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "enum": {
+            "color": "#fe7f18ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function": {
+            "color": "#b8bb25ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.builtin": {
+            "color": "#fb4833ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "hint": {
+            "color": "#8c957dff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword": {
+            "color": "#fb4833ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#8ec07cff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#d3869bff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#d3869bff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#8ec07cff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predictive": {
+            "color": "#717363ff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#fbf1c7ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "#ebdbb2ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#ebdbb2ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#d5c4a1ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#a89984ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#e5d5adff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#ebdbb2ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.markup": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#e5d5adff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector": {
+            "color": "#fabd2eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector.pseudo": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#b8bb25ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#c6b697ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#fe7f18ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#d3869bff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#8ec07cff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#8ec07cff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#b8bb25ff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "type": {
+            "color": "#fabd2eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#ebdbb2ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variant": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    },
+    {
+      "name": "Gruvbox Light",
+      "appearance": "light",
+      "style": {
+        "accents": ["#cc241dff", "#98971aff", "#d79921ff", "#458588ff", "#b16286ff", "#689d6aff", "#d65d0eff"],
+        "border": "#c8b899ff",
+        "border.variant": "#ddcca7ff",
+        "border.focused": "#adc5ccff",
+        "border.selected": "#adc5ccff",
+        "border.transparent": "#00000000",
+        "border.disabled": "#d0bf9dff",
+        "elevated_surface.background": "#ecddb4ff",
+        "surface.background": "#ecddb4ff",
+        "background": "#d9c8a4ff",
+        "element.background": "#ecddb4ff",
+        "element.hover": "#ddcca7ff",
+        "element.active": "#c8b899ff",
+        "element.selected": "#c8b899ff",
+        "element.disabled": "#ecddb4ff",
+        "drop_target.background": "#5f565080",
+        "ghost_element.background": "#00000000",
+        "ghost_element.hover": "#ddcca7ff",
+        "ghost_element.active": "#c8b899ff",
+        "ghost_element.selected": "#c8b899ff",
+        "ghost_element.disabled": "#ecddb4ff",
+        "text": "#282828ff",
+        "text.muted": "#5f5650ff",
+        "text.placeholder": "#897b6eff",
+        "text.disabled": "#897b6eff",
+        "text.accent": "#0b6678ff",
+        "icon": "#282828ff",
+        "icon.muted": "#5f5650ff",
+        "icon.disabled": "#897b6eff",
+        "icon.placeholder": "#5f5650ff",
+        "icon.accent": "#0b6678ff",
+        "status_bar.background": "#d9c8a4ff",
+        "title_bar.background": "#d9c8a4ff",
+        "title_bar.inactive_background": "#ecddb4ff",
+        "toolbar.background": "#fbf1c7ff",
+        "tab_bar.background": "#ecddb4ff",
+        "tab.inactive_background": "#ecddb4ff",
+        "tab.active_background": "#fbf1c7ff",
+        "search.match_background": "#0b667866",
+        "search.active_match_background": "#ba2d1166",
+        "panel.background": "#ecddb4ff",
+        "panel.focused_border": null,
+        "pane.focused_border": null,
+        "scrollbar.thumb.active_background": "#458588ac",
+        "scrollbar.thumb.hover_background": "#2828284c",
+        "scrollbar.thumb.background": "#7c6f644c",
+        "scrollbar.thumb.border": "#ddcca7ff",
+        "scrollbar.track.background": "#00000000",
+        "scrollbar.track.border": "#eee0b7ff",
+        "editor.foreground": "#282828ff",
+        "editor.background": "#fbf1c7ff",
+        "editor.gutter.background": "#fbf1c7ff",
+        "editor.subheader.background": "#ecddb4ff",
+        "editor.active_line.background": "#ecddb4bf",
+        "editor.highlighted_line.background": "#ecddb4ff",
+        "editor.line_number": "#a9a389",
+        "editor.active_line_number": "#3b382b",
+        "editor.hover_line_number": "#5e5a45",
+        "editor.invisible": "#928474ff",
+        "editor.wrap_guide": "#2828280d",
+        "editor.active_wrap_guide": "#2828281a",
+        "editor.document_highlight.read_background": "#0b66781a",
+        "editor.document_highlight.write_background": "#92847466",
+        "terminal.background": "#fbf1c7ff",
+        "terminal.foreground": "#282828ff",
+        "terminal.bright_foreground": "#282828ff",
+        "terminal.dim_foreground": "#fbf1c7ff",
+        "terminal.ansi.black": "#fbf1c7ff",
+        "terminal.ansi.bright_black": "#928374ff",
+        "terminal.ansi.dim_black": "#7c6f64ff",
+        "terminal.ansi.red": "#cc241dff",
+        "terminal.ansi.bright_red": "#9d0006ff",
+        "terminal.ansi.dim_red": "#c31c16ff",
+        "terminal.ansi.green": "#98971aff",
+        "terminal.ansi.bright_green": "#79740eff",
+        "terminal.ansi.dim_green": "#929015ff",
+        "terminal.ansi.yellow": "#d79921ff",
+        "terminal.ansi.bright_yellow": "#b57614ff",
+        "terminal.ansi.dim_yellow": "#cf8e1aff",
+        "terminal.ansi.blue": "#458588ff",
+        "terminal.ansi.bright_blue": "#076678ff",
+        "terminal.ansi.dim_blue": "#356f77ff",
+        "terminal.ansi.magenta": "#b16286ff",
+        "terminal.ansi.bright_magenta": "#8f3f71ff",
+        "terminal.ansi.dim_magenta": "#a85580ff",
+        "terminal.ansi.cyan": "#689d6aff",
+        "terminal.ansi.bright_cyan": "#427b58ff",
+        "terminal.ansi.dim_cyan": "#5f9166ff",
+        "terminal.ansi.white": "#7c6f64ff",
+        "terminal.ansi.bright_white": "#282828ff",
+        "terminal.ansi.dim_white": "#282828ff",
+        "link_text.hover": "#0b6678ff",
+        "version_control.added": "#797410ff",
+        "version_control.modified": "#b57615ff",
+        "version_control.deleted": "#9d0308ff",
+        "conflict": "#b57615ff",
+        "conflict.background": "#f5e2d0ff",
+        "conflict.border": "#ebccabff",
+        "created": "#797410ff",
+        "created.background": "#e4e0cdff",
+        "created.border": "#d1cba8ff",
+        "deleted": "#9d0308ff",
+        "deleted.background": "#f4d1c9ff",
+        "deleted.border": "#e8ac9eff",
+        "error": "#9d0308ff",
+        "error.background": "#f4d1c9ff",
+        "error.border": "#e8ac9eff",
+        "hidden": "#897b6eff",
+        "hidden.background": "#d9c8a4ff",
+        "hidden.border": "#d0bf9dff",
+        "hint": "#677562ff",
+        "hint.background": "#d2dee2ff",
+        "hint.border": "#adc5ccff",
+        "ignored": "#897b6eff",
+        "ignored.background": "#d9c8a4ff",
+        "ignored.border": "#c8b899ff",
+        "info": "#0b6678ff",
+        "info.background": "#d2dee2ff",
+        "info.border": "#adc5ccff",
+        "modified": "#b57615ff",
+        "modified.background": "#f5e2d0ff",
+        "modified.border": "#ebccabff",
+        "predictive": "#7c9780ff",
+        "predictive.background": "#e4e0cdff",
+        "predictive.border": "#d1cba8ff",
+        "renamed": "#0b6678ff",
+        "renamed.background": "#d2dee2ff",
+        "renamed.border": "#adc5ccff",
+        "success": "#797410ff",
+        "success.background": "#e4e0cdff",
+        "success.border": "#d1cba8ff",
+        "unreachable": "#5f5650ff",
+        "unreachable.background": "#d9c8a4ff",
+        "unreachable.border": "#c8b899ff",
+        "warning": "#b57615ff",
+        "warning.background": "#f5e2d0ff",
+        "warning.border": "#ebccabff",
+        "players": [
+          {
+            "cursor": "#0b6678ff",
+            "background": "#0b6678ff",
+            "selection": "#0b66783d"
+          },
+          {
+            "cursor": "#7c6f64ff",
+            "background": "#7c6f64ff",
+            "selection": "#7c6f643d"
+          },
+          {
+            "cursor": "#af3a04ff",
+            "background": "#af3a04ff",
+            "selection": "#af3a043d"
+          },
+          {
+            "cursor": "#8f3f70ff",
+            "background": "#8f3f70ff",
+            "selection": "#8f3f703d"
+          },
+          {
+            "cursor": "#437b59ff",
+            "background": "#437b59ff",
+            "selection": "#437b593d"
+          },
+          {
+            "cursor": "#9d0308ff",
+            "background": "#9d0308ff",
+            "selection": "#9d03083d"
+          },
+          {
+            "cursor": "#b57615ff",
+            "background": "#b57615ff",
+            "selection": "#b576153d"
+          },
+          {
+            "cursor": "#797410ff",
+            "background": "#797410ff",
+            "selection": "#7974103d"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": "#0b6678ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#8f3e71ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#7c6f64ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#5d544eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#b57613ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#0b6678ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#427b58ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": "#0b6678ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": "#0b6678ff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "enum": {
+            "color": "#af3a02ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function": {
+            "color": "#79740eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.builtin": {
+            "color": "#9d0006ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "hint": {
+            "color": "#677562ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword": {
+            "color": "#9d0006ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#0b6678ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#427b58ff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#8f3e71ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#066578ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#8f3e71ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#427b58ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predictive": {
+            "color": "#7c9780ff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#282828ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "#282828ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#282828ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#3c3836ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#665c54ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#413d3aff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#282828ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.markup": {
+            "color": "#066578ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#413d3aff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector": {
+            "color": "#b57613ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector.pseudo": {
+            "color": "#0b6678ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#79740eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#5d544eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#af3a02ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#8f3e71ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#427b58ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#427b58ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#066578ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#79740eff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "type": {
+            "color": "#b57613ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#282828ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#066578ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variant": {
+            "color": "#0b6678ff",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    },
+    {
+      "name": "Gruvbox Light Hard",
+      "appearance": "light",
+      "style": {
+        "accents": ["#cc241dff", "#98971aff", "#d79921ff", "#458588ff", "#b16286ff", "#689d6aff", "#d65d0eff"],
+        "border": "#c8b899ff",
+        "border.variant": "#ddcca7ff",
+        "border.focused": "#adc5ccff",
+        "border.selected": "#adc5ccff",
+        "border.transparent": "#00000000",
+        "border.disabled": "#d0bf9dff",
+        "elevated_surface.background": "#ecddb5ff",
+        "surface.background": "#ecddb5ff",
+        "background": "#d9c8a4ff",
+        "element.background": "#ecddb5ff",
+        "element.hover": "#ddcca7ff",
+        "element.active": "#c8b899ff",
+        "element.selected": "#c8b899ff",
+        "element.disabled": "#ecddb5ff",
+        "drop_target.background": "#5f565080",
+        "ghost_element.background": "#00000000",
+        "ghost_element.hover": "#ddcca7ff",
+        "ghost_element.active": "#c8b899ff",
+        "ghost_element.selected": "#c8b899ff",
+        "ghost_element.disabled": "#ecddb5ff",
+        "text": "#282828ff",
+        "text.muted": "#5f5650ff",
+        "text.placeholder": "#897b6eff",
+        "text.disabled": "#897b6eff",
+        "text.accent": "#0b6678ff",
+        "icon": "#282828ff",
+        "icon.muted": "#5f5650ff",
+        "icon.disabled": "#897b6eff",
+        "icon.placeholder": "#5f5650ff",
+        "icon.accent": "#0b6678ff",
+        "status_bar.background": "#d9c8a4ff",
+        "title_bar.background": "#d9c8a4ff",
+        "title_bar.inactive_background": "#ecddb5ff",
+        "toolbar.background": "#f9f5d7ff",
+        "tab_bar.background": "#ecddb5ff",
+        "tab.inactive_background": "#ecddb5ff",
+        "tab.active_background": "#f9f5d7ff",
+        "search.match_background": "#0b667866",
+        "search.active_match_background": "#dc351466",
+        "panel.background": "#ecddb5ff",
+        "panel.focused_border": null,
+        "pane.focused_border": null,
+        "scrollbar.thumb.active_background": "#458588ac",
+        "scrollbar.thumb.hover_background": "#2828284c",
+        "scrollbar.thumb.background": "#7c6f644c",
+        "scrollbar.thumb.border": "#ddcca7ff",
+        "scrollbar.track.background": "#00000000",
+        "scrollbar.track.border": "#eee1bbff",
+        "editor.foreground": "#282828ff",
+        "editor.background": "#f9f5d7ff",
+        "editor.gutter.background": "#f9f5d7ff",
+        "editor.subheader.background": "#ecddb5ff",
+        "editor.active_line.background": "#ecddb5bf",
+        "editor.highlighted_line.background": "#ecddb5ff",
+        "editor.line_number": "#a9a389",
+        "editor.active_line_number": "#3b382b",
+        "editor.hover_line_number": "#5e5a45",
+        "editor.invisible": "#928474ff",
+        "editor.wrap_guide": "#2828280d",
+        "editor.active_wrap_guide": "#2828281a",
+        "editor.document_highlight.read_background": "#0b66781a",
+        "editor.document_highlight.write_background": "#92847466",
+        "terminal.background": "#f9f5d7ff",
+        "terminal.foreground": "#282828ff",
+        "terminal.bright_foreground": "#282828ff",
+        "terminal.dim_foreground": "#f9f5d7ff",
+        "terminal.ansi.black": "#fbf1c7ff",
+        "terminal.ansi.bright_black": "#928374ff",
+        "terminal.ansi.dim_black": "#7c6f64ff",
+        "terminal.ansi.red": "#cc241dff",
+        "terminal.ansi.bright_red": "#9d0006ff",
+        "terminal.ansi.dim_red": "#c31c16ff",
+        "terminal.ansi.green": "#98971aff",
+        "terminal.ansi.bright_green": "#79740eff",
+        "terminal.ansi.dim_green": "#929015ff",
+        "terminal.ansi.yellow": "#d79921ff",
+        "terminal.ansi.bright_yellow": "#b57614ff",
+        "terminal.ansi.dim_yellow": "#cf8e1aff",
+        "terminal.ansi.blue": "#458588ff",
+        "terminal.ansi.bright_blue": "#076678ff",
+        "terminal.ansi.dim_blue": "#356f77ff",
+        "terminal.ansi.magenta": "#b16286ff",
+        "terminal.ansi.bright_magenta": "#8f3f71ff",
+        "terminal.ansi.dim_magenta": "#a85580ff",
+        "terminal.ansi.cyan": "#689d6aff",
+        "terminal.ansi.bright_cyan": "#427b58ff",
+        "terminal.ansi.dim_cyan": "#5f9166ff",
+        "terminal.ansi.white": "#7c6f64ff",
+        "terminal.ansi.bright_white": "#282828ff",
+        "terminal.ansi.dim_white": "#282828ff",
+        "link_text.hover": "#0b6678ff",
+        "version_control.added": "#797410ff",
+        "version_control.modified": "#b57615ff",
+        "version_control.deleted": "#9d0308ff",
+        "conflict": "#b57615ff",
+        "conflict.background": "#f5e2d0ff",
+        "conflict.border": "#ebccabff",
+        "created": "#797410ff",
+        "created.background": "#e4e0cdff",
+        "created.border": "#d1cba8ff",
+        "deleted": "#9d0308ff",
+        "deleted.background": "#f4d1c9ff",
+        "deleted.border": "#e8ac9eff",
+        "error": "#9d0308ff",
+        "error.background": "#f4d1c9ff",
+        "error.border": "#e8ac9eff",
+        "hidden": "#897b6eff",
+        "hidden.background": "#d9c8a4ff",
+        "hidden.border": "#d0bf9dff",
+        "hint": "#677562ff",
+        "hint.background": "#d2dee2ff",
+        "hint.border": "#adc5ccff",
+        "ignored": "#897b6eff",
+        "ignored.background": "#d9c8a4ff",
+        "ignored.border": "#c8b899ff",
+        "info": "#0b6678ff",
+        "info.background": "#d2dee2ff",
+        "info.border": "#adc5ccff",
+        "modified": "#b57615ff",
+        "modified.background": "#f5e2d0ff",
+        "modified.border": "#ebccabff",
+        "predictive": "#7c9780ff",
+        "predictive.background": "#e4e0cdff",
+        "predictive.border": "#d1cba8ff",
+        "renamed": "#0b6678ff",
+        "renamed.background": "#d2dee2ff",
+        "renamed.border": "#adc5ccff",
+        "success": "#797410ff",
+        "success.background": "#e4e0cdff",
+        "success.border": "#d1cba8ff",
+        "unreachable": "#5f5650ff",
+        "unreachable.background": "#d9c8a4ff",
+        "unreachable.border": "#c8b899ff",
+        "warning": "#b57615ff",
+        "warning.background": "#f5e2d0ff",
+        "warning.border": "#ebccabff",
+        "players": [
+          {
+            "cursor": "#0b6678ff",
+            "background": "#0b6678ff",
+            "selection": "#0b66783d"
+          },
+          {
+            "cursor": "#7c6f64ff",
+            "background": "#7c6f64ff",
+            "selection": "#7c6f643d"
+          },
+          {
+            "cursor": "#af3a04ff",
+            "background": "#af3a04ff",
+            "selection": "#af3a043d"
+          },
+          {
+            "cursor": "#8f3f70ff",
+            "background": "#8f3f70ff",
+            "selection": "#8f3f703d"
+          },
+          {
+            "cursor": "#437b59ff",
+            "background": "#437b59ff",
+            "selection": "#437b593d"
+          },
+          {
+            "cursor": "#9d0308ff",
+            "background": "#9d0308ff",
+            "selection": "#9d03083d"
+          },
+          {
+            "cursor": "#b57615ff",
+            "background": "#b57615ff",
+            "selection": "#b576153d"
+          },
+          {
+            "cursor": "#797410ff",
+            "background": "#797410ff",
+            "selection": "#7974103d"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": "#0b6678ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#8f3e71ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#7c6f64ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#5d544eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#b57613ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#0b6678ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#427b58ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": "#0b6678ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": "#0b6678ff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "enum": {
+            "color": "#af3a02ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function": {
+            "color": "#79740eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.builtin": {
+            "color": "#9d0006ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "hint": {
+            "color": "#677562ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword": {
+            "color": "#9d0006ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#0b6678ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#427b58ff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#8f3e71ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#066578ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#8f3e71ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#427b58ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predictive": {
+            "color": "#7c9780ff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#282828ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "#282828ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#282828ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#3c3836ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#665c54ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#413d3aff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#282828ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.markup": {
+            "color": "#066578ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#413d3aff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector": {
+            "color": "#b57613ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector.pseudo": {
+            "color": "#0b6678ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#79740eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#5d544eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#af3a02ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#8f3e71ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#427b58ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#427b58ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#066578ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#79740eff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "type": {
+            "color": "#b57613ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#282828ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#066578ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variant": {
+            "color": "#0b6678ff",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    },
+    {
+      "name": "Gruvbox Light Soft",
+      "appearance": "light",
+      "style": {
+        "accents": ["#cc241dff", "#98971aff", "#d79921ff", "#458588ff", "#b16286ff", "#689d6aff", "#d65d0eff"],
+        "border": "#c8b899ff",
+        "border.variant": "#ddcca7ff",
+        "border.focused": "#adc5ccff",
+        "border.selected": "#adc5ccff",
+        "border.transparent": "#00000000",
+        "border.disabled": "#d0bf9dff",
+        "elevated_surface.background": "#ecdcb3ff",
+        "surface.background": "#ecdcb3ff",
+        "background": "#d9c8a4ff",
+        "element.background": "#ecdcb3ff",
+        "element.hover": "#ddcca7ff",
+        "element.active": "#c8b899ff",
+        "element.selected": "#c8b899ff",
+        "element.disabled": "#ecdcb3ff",
+        "drop_target.background": "#5f565080",
+        "ghost_element.background": "#00000000",
+        "ghost_element.hover": "#ddcca7ff",
+        "ghost_element.active": "#c8b899ff",
+        "ghost_element.selected": "#c8b899ff",
+        "ghost_element.disabled": "#ecdcb3ff",
+        "text": "#282828ff",
+        "text.muted": "#5f5650ff",
+        "text.placeholder": "#897b6eff",
+        "text.disabled": "#897b6eff",
+        "text.accent": "#0b6678ff",
+        "icon": "#282828ff",
+        "icon.muted": "#5f5650ff",
+        "icon.disabled": "#897b6eff",
+        "icon.placeholder": "#5f5650ff",
+        "icon.accent": "#0b6678ff",
+        "status_bar.background": "#d9c8a4ff",
+        "title_bar.background": "#d9c8a4ff",
+        "title_bar.inactive_background": "#ecdcb3ff",
+        "toolbar.background": "#f2e5bcff",
+        "tab_bar.background": "#ecdcb3ff",
+        "tab.inactive_background": "#ecdcb3ff",
+        "tab.active_background": "#f2e5bcff",
+        "search.match_background": "#0b667866",
+        "search.active_match_background": "#d7331466",
+        "panel.background": "#ecdcb3ff",
+        "panel.focused_border": null,
+        "pane.focused_border": null,
+        "scrollbar.thumb.active_background": "#458588ac",
+        "scrollbar.thumb.hover_background": "#2828284c",
+        "scrollbar.thumb.background": "#7c6f644c",
+        "scrollbar.thumb.border": "#ddcca7ff",
+        "scrollbar.track.background": "#00000000",
+        "scrollbar.track.border": "#eddeb5ff",
+        "editor.foreground": "#282828ff",
+        "editor.background": "#f2e5bcff",
+        "editor.gutter.background": "#f2e5bcff",
+        "editor.subheader.background": "#ecdcb3ff",
+        "editor.active_line.background": "#ecdcb3bf",
+        "editor.highlighted_line.background": "#ecdcb3ff",
+        "editor.line_number": "#a9a389",
+        "editor.active_line_number": "#3b382b",
+        "editor.hover_line_number": "#5e5a45",
+        "editor.invisible": "#928474ff",
+        "editor.wrap_guide": "#2828280d",
+        "editor.active_wrap_guide": "#2828281a",
+        "editor.document_highlight.read_background": "#0b66781a",
+        "editor.document_highlight.write_background": "#92847466",
+        "terminal.background": "#f2e5bcff",
+        "terminal.foreground": "#282828ff",
+        "terminal.bright_foreground": "#282828ff",
+        "terminal.dim_foreground": "#f2e5bcff",
+        "terminal.ansi.black": "#fbf1c7ff",
+        "terminal.ansi.bright_black": "#928374ff",
+        "terminal.ansi.dim_black": "#7c6f64ff",
+        "terminal.ansi.red": "#cc241dff",
+        "terminal.ansi.bright_red": "#9d0006ff",
+        "terminal.ansi.dim_red": "#c31c16ff",
+        "terminal.ansi.green": "#98971aff",
+        "terminal.ansi.bright_green": "#79740eff",
+        "terminal.ansi.dim_green": "#929015ff",
+        "terminal.ansi.yellow": "#d79921ff",
+        "terminal.ansi.bright_yellow": "#b57614ff",
+        "terminal.ansi.dim_yellow": "#cf8e1aff",
+        "terminal.ansi.blue": "#458588ff",
+        "terminal.ansi.bright_blue": "#076678ff",
+        "terminal.ansi.dim_blue": "#356f77ff",
+        "terminal.ansi.magenta": "#b16286ff",
+        "terminal.ansi.bright_magenta": "#8f3f71ff",
+        "terminal.ansi.dim_magenta": "#a85580ff",
+        "terminal.ansi.cyan": "#689d6aff",
+        "terminal.ansi.bright_cyan": "#427b58ff",
+        "terminal.ansi.dim_cyan": "#5f9166ff",
+        "terminal.ansi.white": "#7c6f64ff",
+        "terminal.ansi.bright_white": "#282828ff",
+        "terminal.ansi.dim_white": "#282828ff",
+        "link_text.hover": "#0b6678ff",
+        "version_control.added": "#797410ff",
+        "version_control.modified": "#b57615ff",
+        "version_control.deleted": "#9d0308ff",
+        "conflict": "#b57615ff",
+        "conflict.background": "#f5e2d0ff",
+        "conflict.border": "#ebccabff",
+        "created": "#797410ff",
+        "created.background": "#e4e0cdff",
+        "created.border": "#d1cba8ff",
+        "deleted": "#9d0308ff",
+        "deleted.background": "#f4d1c9ff",
+        "deleted.border": "#e8ac9eff",
+        "error": "#9d0308ff",
+        "error.background": "#f4d1c9ff",
+        "error.border": "#e8ac9eff",
+        "hidden": "#897b6eff",
+        "hidden.background": "#d9c8a4ff",
+        "hidden.border": "#d0bf9dff",
+        "hint": "#677562ff",
+        "hint.background": "#d2dee2ff",
+        "hint.border": "#adc5ccff",
+        "ignored": "#897b6eff",
+        "ignored.background": "#d9c8a4ff",
+        "ignored.border": "#c8b899ff",
+        "info": "#0b6678ff",
+        "info.background": "#d2dee2ff",
+        "info.border": "#adc5ccff",
+        "modified": "#b57615ff",
+        "modified.background": "#f5e2d0ff",
+        "modified.border": "#ebccabff",
+        "predictive": "#7c9780ff",
+        "predictive.background": "#e4e0cdff",
+        "predictive.border": "#d1cba8ff",
+        "renamed": "#0b6678ff",
+        "renamed.background": "#d2dee2ff",
+        "renamed.border": "#adc5ccff",
+        "success": "#797410ff",
+        "success.background": "#e4e0cdff",
+        "success.border": "#d1cba8ff",
+        "unreachable": "#5f5650ff",
+        "unreachable.background": "#d9c8a4ff",
+        "unreachable.border": "#c8b899ff",
+        "warning": "#b57615ff",
+        "warning.background": "#f5e2d0ff",
+        "warning.border": "#ebccabff",
+        "players": [
+          {
+            "cursor": "#0b6678ff",
+            "background": "#0b6678ff",
+            "selection": "#0b66783d"
+          },
+          {
+            "cursor": "#7c6f64ff",
+            "background": "#7c6f64ff",
+            "selection": "#7c6f643d"
+          },
+          {
+            "cursor": "#af3a04ff",
+            "background": "#af3a04ff",
+            "selection": "#af3a043d"
+          },
+          {
+            "cursor": "#8f3f70ff",
+            "background": "#8f3f70ff",
+            "selection": "#8f3f703d"
+          },
+          {
+            "cursor": "#437b59ff",
+            "background": "#437b59ff",
+            "selection": "#437b593d"
+          },
+          {
+            "cursor": "#9d0308ff",
+            "background": "#9d0308ff",
+            "selection": "#9d03083d"
+          },
+          {
+            "cursor": "#b57615ff",
+            "background": "#b57615ff",
+            "selection": "#b576153d"
+          },
+          {
+            "cursor": "#797410ff",
+            "background": "#797410ff",
+            "selection": "#7974103d"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": "#0b6678ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#8f3e71ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#7c6f64ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#5d544eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#b57613ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#0b6678ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#427b58ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": "#0b6678ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": "#0b6678ff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "enum": {
+            "color": "#af3a02ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function": {
+            "color": "#79740eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.builtin": {
+            "color": "#9d0006ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "hint": {
+            "color": "#677562ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword": {
+            "color": "#9d0006ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#0b6678ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#427b58ff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#8f3e71ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#066578ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#8f3e71ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#427b58ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predictive": {
+            "color": "#7c9780ff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#282828ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "#282828ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#282828ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#3c3836ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#665c54ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#413d3aff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#282828ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.markup": {
+            "color": "#066578ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#413d3aff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector": {
+            "color": "#b57613ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector.pseudo": {
+            "color": "#0b6678ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#79740eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#5d544eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#af3a02ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#8f3e71ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#427b58ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#427b58ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#066578ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#79740eff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "type": {
+            "color": "#b57613ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#282828ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#066578ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variant": {
+            "color": "#0b6678ff",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    }
+  ]
+}

--- a/themes/modus.json
+++ b/themes/modus.json
@@ -1,0 +1,1991 @@
+{
+   "$schema": "https://zed.dev/schema/themes/v0.2.0.json",
+   "author": "Vitaly Slobodin <vitaliy.slobodin@gmail.com>",
+   "name": "Modus Themes",
+   "themes": [
+      {
+         "appearance": "light",
+         "name": "Modus Operandi",
+         "style": {
+            "accents": [
+               "#000000",
+               "#dd22dd",
+               "#008899",
+               "#972500",
+               "#808000",
+               "#531ab6",
+               "#008900",
+               "#3548cf"
+            ],
+            "background": "#ffffff",
+            "border": "#595959",
+            "border.variant": "#595959",
+            "conflict": "#655000",
+            "conflict.background": "#ffdfa9",
+            "conflict.border": "#595959",
+            "created": "#006700",
+            "created.background": "#c1f2d1",
+            "created.border": "#595959",
+            "debugger.accent": "#a60000",
+            "deleted": "#aa2222",
+            "deleted.background": "#ffd8d5",
+            "deleted.border": "#595959",
+            "drop_target.background": "#c4c4c48c",
+            "editor.active_line.background": "#dae5ec",
+            "editor.active_line_number": "#000000",
+            "editor.background": "#ffffff",
+            "editor.debugger_active_line.background": "#dae5ec",
+            "editor.document_highlight.bracket_background": "#5fcfff8c",
+            "editor.document_highlight.read_background": "#f2f2f2",
+            "editor.document_highlight.write_background": "#b2e4dc",
+            "editor.foreground": "#000000",
+            "editor.gutter.background": "#f2f2f2",
+            "editor.highlighted_line.background": "#dae5ec",
+            "editor.invisible": "#595959",
+            "editor.line_number": "#595959",
+            "editor.subheader.background": "#c8c8c8",
+            "element.active": "#c4c4c4",
+            "element.background": "#f2f2f2",
+            "element.disabled": "#f2f2f2",
+            "element.hover": "#b2e4dc",
+            "element.selected": "#c4c4c4",
+            "elevated_surface.background": "#f2f2f2",
+            "error": "#a60000",
+            "error.background": "#ff8f88",
+            "error.border": "#595959",
+            "ghost_element.active": "#c4c4c4",
+            "ghost_element.background": "#f2f2f2",
+            "ghost_element.disabled": "#f2f2f2",
+            "ghost_element.hover": "#b2e4dc",
+            "ghost_element.selected": "#c4c4c4",
+            "hint": "#595959",
+            "hint.background": "#f2f2f2",
+            "hint.border": "#595959",
+            "icon": "#000000",
+            "icon.accent": "#0000b0",
+            "icon.disabled": "#595959",
+            "icon.muted": "#193668",
+            "icon.placeholder": "#595959",
+            "info": "#005f5f",
+            "info.background": "#bfc9ff",
+            "info.border": "#595959",
+            "modified": "#655000",
+            "modified.background": "#ffdfa9",
+            "modified.border": "#595959",
+            "panel.background": "#ffffff",
+            "players": [
+               {
+                  "background": "#bdbdbd",
+                  "cursor": "#000000",
+                  "selection": "#0000003d"
+               },
+               {
+                  "background": "#dd22dd",
+                  "cursor": "#dd22dd",
+                  "selection": "#dd22dd3d"
+               },
+               {
+                  "background": "#008899",
+                  "cursor": "#008899",
+                  "selection": "#0088993d"
+               },
+               {
+                  "background": "#972500",
+                  "cursor": "#972500",
+                  "selection": "#9725003d"
+               },
+               {
+                  "background": "#808000",
+                  "cursor": "#808000",
+                  "selection": "#8080003d"
+               },
+               {
+                  "background": "#531ab6",
+                  "cursor": "#531ab6",
+                  "selection": "#531ab63d"
+               },
+               {
+                  "background": "#008900",
+                  "cursor": "#008900",
+                  "selection": "#0089003d"
+               }
+            ],
+            "predictive": "#595959",
+            "predictive.background": null,
+            "predictive.border": "#595959",
+            "renamed": "#655000",
+            "renamed.background": "#ffdfa9",
+            "renamed.border": "#595959",
+            "scrollbar.thumb.background": "#c8c8c88c",
+            "scrollbar.thumb.border": "#595959",
+            "scrollbar.thumb.hover_background": "#c4c4c4",
+            "scrollbar.track.background": "#f2f2f2",
+            "scrollbar.track.border": "#595959",
+            "search.match_background": "#a4d5f9",
+            "status_bar.background": "#c8c8c8",
+            "success": "#000000",
+            "success.background": "#a4d5f9",
+            "success.border": "#595959",
+            "surface.background": "#f2f2f2",
+            "syntax": {
+               "attribute": {
+                  "color": "#a0132f"
+               },
+               "boolean": {
+                  "color": "#0000b0"
+               },
+               "comment": {
+                  "color": "#595959",
+                  "font_style": "italic"
+               },
+               "constant": {
+                  "color": "#0000b0"
+               },
+               "constructor": {
+                  "color": "#721045"
+               },
+               "embedded": {
+                  "color": "#a0132f"
+               },
+               "function": {
+                  "color": "#721045"
+               },
+               "keyword": {
+                  "color": "#531ab6"
+               },
+               "number": {
+                  "color": "#000000"
+               },
+               "operator": {
+                  "color": "#721045"
+               },
+               "property": {
+                  "color": "#005e8b"
+               },
+               "string": {
+                  "color": "#3548cf"
+               },
+               "string.escape": {
+                  "color": "#3548cf"
+               },
+               "string.regex": {
+                  "color": "#3548cf"
+               },
+               "string.special": {
+                  "color": "#3548cf"
+               },
+               "string.special.symbol": {
+                  "color": "#3548cf"
+               },
+               "tag": {
+                  "color": "#0000b0"
+               },
+               "text.literal": {
+                  "color": "#005f5f"
+               },
+               "title": {
+                  "color": "#624416"
+               },
+               "type": {
+                  "color": "#005f5f"
+               },
+               "variable": {
+                  "color": "#005e8b"
+               },
+               "variable.special": {
+                  "color": "#531ab6"
+               }
+            },
+            "tab.active_background": "#ffffff",
+            "tab.inactive_background": "#c2c2c2",
+            "tab_bar.background": "#dfdfdf",
+            "terminal.ansi.black": "#000000",
+            "terminal.ansi.blue": "#0031a9",
+            "terminal.ansi.bright_black": "#595959",
+            "terminal.ansi.bright_blue": "#3548cf",
+            "terminal.ansi.bright_cyan": "#005f5f",
+            "terminal.ansi.bright_green": "#00663f",
+            "terminal.ansi.bright_magenta": "#531ab6",
+            "terminal.ansi.bright_red": "#972500",
+            "terminal.ansi.bright_white": "#ffffff",
+            "terminal.ansi.bright_yellow": "#884900",
+            "terminal.ansi.cyan": "#005e8b",
+            "terminal.ansi.dim_black": null,
+            "terminal.ansi.dim_blue": null,
+            "terminal.ansi.dim_cyan": null,
+            "terminal.ansi.dim_green": null,
+            "terminal.ansi.dim_magenta": null,
+            "terminal.ansi.dim_red": null,
+            "terminal.ansi.dim_white": null,
+            "terminal.ansi.dim_yellow": null,
+            "terminal.ansi.green": "#006800",
+            "terminal.ansi.magenta": "#721045",
+            "terminal.ansi.red": "#a60000",
+            "terminal.ansi.white": "#a6a6a6",
+            "terminal.ansi.yellow": "#6f5500",
+            "terminal.background": "#ffffff",
+            "terminal.bright_foreground": "#193668",
+            "terminal.dim_foreground": "#595959",
+            "terminal.foreground": "#000000",
+            "text": "#000000",
+            "text.accent": "#0000b0",
+            "text.disabled": "#595959",
+            "text.muted": "#193668",
+            "text.placeholder": "#595959",
+            "title_bar.background": "#ffffff",
+            "title_bar.inactive_background": "#f2f2f2",
+            "toolbar.background": "#ffffff",
+            "unreachable": "#595959",
+            "unreachable.background": "#f2f2f2",
+            "unreachable.border": "#595959",
+            "version_control.added": "#6cc06c",
+            "version_control.conflict": "#d7c20a",
+            "version_control.conflict_marker.ours": "#ffd8d5",
+            "version_control.conflict_marker.theirs": "#c1f2d1",
+            "version_control.deleted": "#d84a4f",
+            "version_control.ignored": "#595959",
+            "version_control.modified": "#d7c20a",
+            "version_control.renamed": "#d7c20a",
+            "warning": "#000000",
+            "warning.background": "#f3d000",
+            "warning.border": "#595959"
+         }
+      },
+      {
+         "appearance": "light",
+         "name": "Modus Operandi Deuteranopia",
+         "style": {
+            "accents": [
+               "#0031a9",
+               "#695500",
+               "#3548cf",
+               "#77492f",
+               "#0000b0",
+               "#973300",
+               "#003497",
+               "#624416"
+            ],
+            "background": "#ffffff",
+            "border": "#595959",
+            "border.variant": "#595959",
+            "conflict": "#7f0f9f",
+            "conflict.background": "#eecfdf",
+            "conflict.border": "#595959",
+            "created": "#0303cc",
+            "created.background": "#d5d7ff",
+            "created.border": "#595959",
+            "debugger.accent": "#973300",
+            "deleted": "#7f6f00",
+            "deleted.background": "#f4f099",
+            "deleted.border": "#595959",
+            "drop_target.background": "#c4c4c48c",
+            "editor.active_line.background": "#dae5ec",
+            "editor.active_line_number": "#000000",
+            "editor.background": "#ffffff",
+            "editor.debugger_active_line.background": "#dae5ec",
+            "editor.document_highlight.bracket_background": "#5fcfff8c",
+            "editor.document_highlight.read_background": "#f2f2f2",
+            "editor.document_highlight.write_background": "#b2e4dc",
+            "editor.foreground": "#000000",
+            "editor.gutter.background": "#f2f2f2",
+            "editor.highlighted_line.background": "#dae5ec",
+            "editor.invisible": "#595959",
+            "editor.line_number": "#595959",
+            "editor.subheader.background": "#d0d6ff",
+            "element.active": "#c4c4c4",
+            "element.background": "#f2f2f2",
+            "element.disabled": "#f2f2f2",
+            "element.hover": "#b2e4dc",
+            "element.selected": "#c4c4c4",
+            "elevated_surface.background": "#f2f2f2",
+            "error": "#973300",
+            "error.background": "#f3d000",
+            "error.border": "#595959",
+            "ghost_element.active": "#c4c4c4",
+            "ghost_element.background": "#f2f2f2",
+            "ghost_element.disabled": "#f2f2f2",
+            "ghost_element.hover": "#b2e4dc",
+            "ghost_element.selected": "#c4c4c4",
+            "hint": "#595959",
+            "hint.background": "#f2f2f2",
+            "hint.border": "#595959",
+            "icon": "#000000",
+            "icon.accent": "#0000b0",
+            "icon.disabled": "#595959",
+            "icon.muted": "#193668",
+            "icon.placeholder": "#595959",
+            "info": "#0031a9",
+            "info.background": "#bfc9ff",
+            "info.border": "#595959",
+            "modified": "#7f0f9f",
+            "modified.background": "#eecfdf",
+            "modified.border": "#595959",
+            "panel.background": "#ffffff",
+            "players": [
+               {
+                  "background": "#bdbdbd",
+                  "cursor": "#0000ff",
+                  "selection": "#0000003d"
+               },
+               {
+                  "background": "#695500",
+                  "cursor": "#695500",
+                  "selection": "#6955003d"
+               },
+               {
+                  "background": "#3548cf",
+                  "cursor": "#3548cf",
+                  "selection": "#3548cf3d"
+               },
+               {
+                  "background": "#77492f",
+                  "cursor": "#77492f",
+                  "selection": "#77492f3d"
+               },
+               {
+                  "background": "#0000b0",
+                  "cursor": "#0000b0",
+                  "selection": "#0000b03d"
+               },
+               {
+                  "background": "#973300",
+                  "cursor": "#973300",
+                  "selection": "#9733003d"
+               },
+               {
+                  "background": "#003497",
+                  "cursor": "#003497",
+                  "selection": "#0034973d"
+               }
+            ],
+            "predictive": "#595959",
+            "predictive.background": null,
+            "predictive.border": "#595959",
+            "renamed": "#7f0f9f",
+            "renamed.background": "#eecfdf",
+            "renamed.border": "#595959",
+            "scrollbar.thumb.background": "#d0d6ff8c",
+            "scrollbar.thumb.border": "#595959",
+            "scrollbar.thumb.hover_background": "#c4c4c4",
+            "scrollbar.track.background": "#f2f2f2",
+            "scrollbar.track.border": "#595959",
+            "search.match_background": "#bfc9ff",
+            "status_bar.background": "#d0d6ff",
+            "success": "#000000",
+            "success.background": "#a4d5f9",
+            "success.border": "#595959",
+            "surface.background": "#f2f2f2",
+            "syntax": {
+               "attribute": {
+                  "color": "#531ab6"
+               },
+               "boolean": {
+                  "color": "#003497"
+               },
+               "comment": {
+                  "color": "#77492f",
+                  "font_style": "italic"
+               },
+               "constant": {
+                  "color": "#003497"
+               },
+               "constructor": {
+                  "color": "#973300"
+               },
+               "embedded": {
+                  "color": "#531ab6"
+               },
+               "function": {
+                  "color": "#973300"
+               },
+               "keyword": {
+                  "color": "#0000b0"
+               },
+               "number": {
+                  "color": "#000000"
+               },
+               "operator": {
+                  "color": "#973300"
+               },
+               "property": {
+                  "color": "#005e8b"
+               },
+               "string": {
+                  "color": "#3548cf"
+               },
+               "string.escape": {
+                  "color": "#3548cf"
+               },
+               "string.regex": {
+                  "color": "#3548cf"
+               },
+               "string.special": {
+                  "color": "#3548cf"
+               },
+               "string.special.symbol": {
+                  "color": "#3548cf"
+               },
+               "tag": {
+                  "color": "#003497"
+               },
+               "text.literal": {
+                  "color": "#005f5f"
+               },
+               "title": {
+                  "color": "#624416"
+               },
+               "type": {
+                  "color": "#005f5f"
+               },
+               "variable": {
+                  "color": "#005e8b"
+               },
+               "variable.special": {
+                  "color": "#0000b0"
+               }
+            },
+            "tab.active_background": "#ffffff",
+            "tab.inactive_background": "#c2c2c2",
+            "tab_bar.background": "#dfdfdf",
+            "terminal.ansi.black": "#000000",
+            "terminal.ansi.blue": "#0031a9",
+            "terminal.ansi.bright_black": "#595959",
+            "terminal.ansi.bright_blue": "#3548cf",
+            "terminal.ansi.bright_cyan": "#005f5f",
+            "terminal.ansi.bright_green": "#00663f",
+            "terminal.ansi.bright_magenta": "#531ab6",
+            "terminal.ansi.bright_red": "#972500",
+            "terminal.ansi.bright_white": "#ffffff",
+            "terminal.ansi.bright_yellow": "#973300",
+            "terminal.ansi.cyan": "#005e8b",
+            "terminal.ansi.dim_black": null,
+            "terminal.ansi.dim_blue": null,
+            "terminal.ansi.dim_cyan": null,
+            "terminal.ansi.dim_green": null,
+            "terminal.ansi.dim_magenta": null,
+            "terminal.ansi.dim_red": null,
+            "terminal.ansi.dim_white": null,
+            "terminal.ansi.dim_yellow": null,
+            "terminal.ansi.green": "#006800",
+            "terminal.ansi.magenta": "#721045",
+            "terminal.ansi.red": "#a60000",
+            "terminal.ansi.white": "#a6a6a6",
+            "terminal.ansi.yellow": "#695500",
+            "terminal.background": "#ffffff",
+            "terminal.bright_foreground": "#193668",
+            "terminal.dim_foreground": "#595959",
+            "terminal.foreground": "#000000",
+            "text": "#000000",
+            "text.accent": "#0000b0",
+            "text.disabled": "#595959",
+            "text.muted": "#193668",
+            "text.placeholder": "#595959",
+            "title_bar.background": "#ffffff",
+            "title_bar.inactive_background": "#f2f2f2",
+            "toolbar.background": "#ffffff",
+            "unreachable": "#595959",
+            "unreachable.background": "#f2f2f2",
+            "unreachable.border": "#595959",
+            "version_control.added": "#275acc",
+            "version_control.conflict": "#9f6ab0",
+            "version_control.conflict_marker.ours": "#f4f099",
+            "version_control.conflict_marker.theirs": "#d5d7ff",
+            "version_control.deleted": "#c0b200",
+            "version_control.ignored": "#595959",
+            "version_control.modified": "#9f6ab0",
+            "version_control.renamed": "#9f6ab0",
+            "warning": "#000000",
+            "warning.background": "#dfa0f0",
+            "warning.border": "#595959"
+         }
+      },
+      {
+         "appearance": "light",
+         "name": "Modus Operandi Tinted",
+         "style": {
+            "accents": [
+               "#000000",
+               "#dd22dd",
+               "#008899",
+               "#972500",
+               "#808000",
+               "#531ab6",
+               "#008900",
+               "#3546c2"
+            ],
+            "background": "#fbf7f0",
+            "border": "#545454",
+            "border.variant": "#545454",
+            "conflict": "#655000",
+            "conflict.background": "#ffdfa9",
+            "conflict.border": "#545454",
+            "created": "#006700",
+            "created.background": "#c3ebc1",
+            "created.border": "#545454",
+            "debugger.accent": "#a60000",
+            "deleted": "#aa2222",
+            "deleted.background": "#f4d0cf",
+            "deleted.border": "#545454",
+            "drop_target.background": "#c9b9b08c",
+            "editor.active_line.background": "#f1d5d0",
+            "editor.active_line_number": "#000000",
+            "editor.background": "#fbf7f0",
+            "editor.debugger_active_line.background": "#f1d5d0",
+            "editor.document_highlight.bracket_background": "#7fdfcf8c",
+            "editor.document_highlight.read_background": "#efe9dd",
+            "editor.document_highlight.write_background": "#b2e4dc",
+            "editor.foreground": "#000000",
+            "editor.gutter.background": "#efe9dd",
+            "editor.highlighted_line.background": "#f1d5d0",
+            "editor.invisible": "#545454",
+            "editor.line_number": "#545454",
+            "editor.subheader.background": "#cab9b2",
+            "element.active": "#c9b9b0",
+            "element.background": "#efe9dd",
+            "element.disabled": "#efe9dd",
+            "element.hover": "#b2e4dc",
+            "element.selected": "#c9b9b0",
+            "elevated_surface.background": "#efe9dd",
+            "error": "#a60000",
+            "error.background": "#ff8f88",
+            "error.border": "#545454",
+            "ghost_element.active": "#c9b9b0",
+            "ghost_element.background": "#efe9dd",
+            "ghost_element.disabled": "#efe9dd",
+            "ghost_element.hover": "#b2e4dc",
+            "ghost_element.selected": "#c9b9b0",
+            "hint": "#545454",
+            "hint.background": "#efe9dd",
+            "hint.border": "#545454",
+            "icon": "#000000",
+            "icon.accent": "#0000b0",
+            "icon.disabled": "#545454",
+            "icon.muted": "#193668",
+            "icon.placeholder": "#545454",
+            "info": "#006300",
+            "info.background": "#bfc9ff",
+            "info.border": "#545454",
+            "modified": "#655000",
+            "modified.background": "#ffdfa9",
+            "modified.border": "#545454",
+            "panel.background": "#fbf7f0",
+            "players": [
+               {
+                  "background": "#c2bcb5",
+                  "cursor": "#d00000",
+                  "selection": "#0000003d"
+               },
+               {
+                  "background": "#dd22dd",
+                  "cursor": "#dd22dd",
+                  "selection": "#dd22dd3d"
+               },
+               {
+                  "background": "#008899",
+                  "cursor": "#008899",
+                  "selection": "#0088993d"
+               },
+               {
+                  "background": "#972500",
+                  "cursor": "#972500",
+                  "selection": "#9725003d"
+               },
+               {
+                  "background": "#808000",
+                  "cursor": "#808000",
+                  "selection": "#8080003d"
+               },
+               {
+                  "background": "#531ab6",
+                  "cursor": "#531ab6",
+                  "selection": "#531ab63d"
+               },
+               {
+                  "background": "#008900",
+                  "cursor": "#008900",
+                  "selection": "#0089003d"
+               }
+            ],
+            "predictive": "#545454",
+            "predictive.background": null,
+            "predictive.border": "#545454",
+            "renamed": "#655000",
+            "renamed.background": "#ffdfa9",
+            "renamed.border": "#545454",
+            "scrollbar.thumb.background": "#cab9b28c",
+            "scrollbar.thumb.border": "#545454",
+            "scrollbar.thumb.hover_background": "#c9b9b0",
+            "scrollbar.track.background": "#efe9dd",
+            "scrollbar.track.border": "#545454",
+            "search.match_background": "#a4d5f9",
+            "status_bar.background": "#cab9b2",
+            "success": "#000000",
+            "success.background": "#a4d5f9",
+            "success.border": "#545454",
+            "surface.background": "#efe9dd",
+            "syntax": {
+               "attribute": {
+                  "color": "#894000"
+               },
+               "boolean": {
+                  "color": "#531ab6"
+               },
+               "comment": {
+                  "color": "#7f0000",
+                  "font_style": "italic"
+               },
+               "constant": {
+                  "color": "#531ab6"
+               },
+               "constructor": {
+                  "color": "#602938"
+               },
+               "embedded": {
+                  "color": "#894000"
+               },
+               "function": {
+                  "color": "#602938"
+               },
+               "keyword": {
+                  "color": "#0031a9"
+               },
+               "number": {
+                  "color": "#000000"
+               },
+               "operator": {
+                  "color": "#602938"
+               },
+               "property": {
+                  "color": "#00603f"
+               },
+               "string": {
+                  "color": "#00598b"
+               },
+               "string.escape": {
+                  "color": "#00598b"
+               },
+               "string.regex": {
+                  "color": "#00598b"
+               },
+               "string.special": {
+                  "color": "#00598b"
+               },
+               "string.special.symbol": {
+                  "color": "#00598b"
+               },
+               "tag": {
+                  "color": "#531ab6"
+               },
+               "text.literal": {
+                  "color": "#00603f"
+               },
+               "title": {
+                  "color": "#574316"
+               },
+               "type": {
+                  "color": "#306010"
+               },
+               "variable": {
+                  "color": "#00603f"
+               },
+               "variable.special": {
+                  "color": "#0031a9"
+               }
+            },
+            "tab.active_background": "#fbf7f0",
+            "tab.inactive_background": "#c8b8b2",
+            "tab_bar.background": "#e0d4ce",
+            "terminal.ansi.black": "#000000",
+            "terminal.ansi.blue": "#0031a9",
+            "terminal.ansi.bright_black": "#595959",
+            "terminal.ansi.bright_blue": "#3546c2",
+            "terminal.ansi.bright_cyan": "#005f5f",
+            "terminal.ansi.bright_green": "#00603f",
+            "terminal.ansi.bright_magenta": "#531ab6",
+            "terminal.ansi.bright_red": "#972500",
+            "terminal.ansi.bright_white": "#ffffff",
+            "terminal.ansi.bright_yellow": "#894000",
+            "terminal.ansi.cyan": "#00598b",
+            "terminal.ansi.dim_black": null,
+            "terminal.ansi.dim_blue": null,
+            "terminal.ansi.dim_cyan": null,
+            "terminal.ansi.dim_green": null,
+            "terminal.ansi.dim_magenta": null,
+            "terminal.ansi.dim_red": null,
+            "terminal.ansi.dim_white": null,
+            "terminal.ansi.dim_yellow": null,
+            "terminal.ansi.green": "#006300",
+            "terminal.ansi.magenta": "#721045",
+            "terminal.ansi.red": "#a60000",
+            "terminal.ansi.white": "#a6a6a6",
+            "terminal.ansi.yellow": "#6d5000",
+            "terminal.background": "#fbf7f0",
+            "terminal.bright_foreground": "#193668",
+            "terminal.dim_foreground": "#545454",
+            "terminal.foreground": "#000000",
+            "text": "#000000",
+            "text.accent": "#0000b0",
+            "text.disabled": "#545454",
+            "text.muted": "#193668",
+            "text.placeholder": "#545454",
+            "title_bar.background": "#fbf7f0",
+            "title_bar.inactive_background": "#efe9dd",
+            "toolbar.background": "#fbf7f0",
+            "unreachable": "#545454",
+            "unreachable.background": "#efe9dd",
+            "unreachable.border": "#545454",
+            "version_control.added": "#6cc06c",
+            "version_control.conflict": "#c0b200",
+            "version_control.conflict_marker.ours": "#f4d0cf",
+            "version_control.conflict_marker.theirs": "#c3ebc1",
+            "version_control.deleted": "#d84a4f",
+            "version_control.ignored": "#545454",
+            "version_control.modified": "#c0b200",
+            "version_control.renamed": "#c0b200",
+            "warning": "#000000",
+            "warning.background": "#f3d000",
+            "warning.border": "#545454"
+         }
+      },
+      {
+         "appearance": "light",
+         "name": "Modus Operandi Tritanopia",
+         "style": {
+            "accents": [
+               "#005e8b",
+               "#a60000",
+               "#3f578f",
+               "#a0132f",
+               "#005f5f",
+               "#721045",
+               "#004f5f",
+               "#7c318f"
+            ],
+            "background": "#ffffff",
+            "border": "#595959",
+            "border.variant": "#595959",
+            "conflict": "#7f0f9f",
+            "conflict.background": "#eecfdf",
+            "conflict.border": "#595959",
+            "created": "#0043aa",
+            "created.background": "#b5e7ff",
+            "created.border": "#595959",
+            "debugger.accent": "#b21100",
+            "deleted": "#aa2222",
+            "deleted.background": "#ffd8d5",
+            "deleted.border": "#595959",
+            "drop_target.background": "#c4c4c48c",
+            "editor.active_line.background": "#dfeaec",
+            "editor.active_line_number": "#000000",
+            "editor.background": "#ffffff",
+            "editor.debugger_active_line.background": "#dfeaec",
+            "editor.document_highlight.bracket_background": "#5fcfff8c",
+            "editor.document_highlight.read_background": "#f2f2f2",
+            "editor.document_highlight.write_background": "#ffafbc",
+            "editor.foreground": "#000000",
+            "editor.gutter.background": "#f2f2f2",
+            "editor.highlighted_line.background": "#dfeaec",
+            "editor.invisible": "#595959",
+            "editor.line_number": "#595959",
+            "editor.subheader.background": "#afe0f2",
+            "element.active": "#c4c4c4",
+            "element.background": "#f2f2f2",
+            "element.disabled": "#f2f2f2",
+            "element.hover": "#ffafbc",
+            "element.selected": "#c4c4c4",
+            "elevated_surface.background": "#f2f2f2",
+            "error": "#b21100",
+            "error.background": "#ff8f88",
+            "error.border": "#595959",
+            "ghost_element.active": "#c4c4c4",
+            "ghost_element.background": "#f2f2f2",
+            "ghost_element.disabled": "#f2f2f2",
+            "ghost_element.hover": "#ffafbc",
+            "ghost_element.selected": "#c4c4c4",
+            "hint": "#595959",
+            "hint.background": "#f2f2f2",
+            "hint.border": "#595959",
+            "icon": "#000000",
+            "icon.accent": "#0000b0",
+            "icon.disabled": "#595959",
+            "icon.muted": "#224960",
+            "icon.placeholder": "#595959",
+            "info": "#005e8b",
+            "info.background": "#bfc9ff",
+            "info.border": "#595959",
+            "modified": "#7f0f9f",
+            "modified.background": "#eecfdf",
+            "modified.border": "#595959",
+            "panel.background": "#ffffff",
+            "players": [
+               {
+                  "background": "#bdbdbd",
+                  "cursor": "#d00000",
+                  "selection": "#0000003d"
+               },
+               {
+                  "background": "#a60000",
+                  "cursor": "#a60000",
+                  "selection": "#a600003d"
+               },
+               {
+                  "background": "#3f578f",
+                  "cursor": "#3f578f",
+                  "selection": "#3f578f3d"
+               },
+               {
+                  "background": "#a0132f",
+                  "cursor": "#a0132f",
+                  "selection": "#a0132f3d"
+               },
+               {
+                  "background": "#005f5f",
+                  "cursor": "#005f5f",
+                  "selection": "#005f5f3d"
+               },
+               {
+                  "background": "#721045",
+                  "cursor": "#721045",
+                  "selection": "#7210453d"
+               },
+               {
+                  "background": "#004f5f",
+                  "cursor": "#004f5f",
+                  "selection": "#004f5f3d"
+               }
+            ],
+            "predictive": "#595959",
+            "predictive.background": null,
+            "predictive.border": "#595959",
+            "renamed": "#7f0f9f",
+            "renamed.background": "#eecfdf",
+            "renamed.border": "#595959",
+            "scrollbar.thumb.background": "#afe0f28c",
+            "scrollbar.thumb.border": "#595959",
+            "scrollbar.thumb.hover_background": "#c4c4c4",
+            "scrollbar.track.background": "#f2f2f2",
+            "scrollbar.track.border": "#595959",
+            "search.match_background": "#a4d5f9",
+            "status_bar.background": "#afe0f2",
+            "success": "#000000",
+            "success.background": "#a4d5f9",
+            "success.border": "#595959",
+            "surface.background": "#f2f2f2",
+            "syntax": {
+               "attribute": {
+                  "color": "#b21100"
+               },
+               "boolean": {
+                  "color": "#00663f"
+               },
+               "comment": {
+                  "color": "#702000",
+                  "font_style": "italic"
+               },
+               "constant": {
+                  "color": "#00663f"
+               },
+               "constructor": {
+                  "color": "#3f578f"
+               },
+               "embedded": {
+                  "color": "#b21100"
+               },
+               "function": {
+                  "color": "#3f578f"
+               },
+               "keyword": {
+                  "color": "#a0132f"
+               },
+               "number": {
+                  "color": "#000000"
+               },
+               "operator": {
+                  "color": "#3f578f"
+               },
+               "property": {
+                  "color": "#005f5f"
+               },
+               "string": {
+                  "color": "#005e8b"
+               },
+               "string.escape": {
+                  "color": "#005e8b"
+               },
+               "string.regex": {
+                  "color": "#005e8b"
+               },
+               "string.special": {
+                  "color": "#005e8b"
+               },
+               "string.special.symbol": {
+                  "color": "#005e8b"
+               },
+               "tag": {
+                  "color": "#00663f"
+               },
+               "text.literal": {
+                  "color": "#005e8b"
+               },
+               "title": {
+                  "color": "#702000"
+               },
+               "type": {
+                  "color": "#3548cf"
+               },
+               "variable": {
+                  "color": "#005f5f"
+               },
+               "variable.special": {
+                  "color": "#a0132f"
+               }
+            },
+            "tab.active_background": "#ffffff",
+            "tab.inactive_background": "#c2c2c2",
+            "tab_bar.background": "#dfdfdf",
+            "terminal.ansi.black": "#000000",
+            "terminal.ansi.blue": "#0031a9",
+            "terminal.ansi.bright_black": "#595959",
+            "terminal.ansi.bright_blue": "#3548cf",
+            "terminal.ansi.bright_cyan": "#005f5f",
+            "terminal.ansi.bright_green": "#00663f",
+            "terminal.ansi.bright_magenta": "#531ab6",
+            "terminal.ansi.bright_red": "#b21100",
+            "terminal.ansi.bright_white": "#ffffff",
+            "terminal.ansi.bright_yellow": "#973300",
+            "terminal.ansi.cyan": "#005e8b",
+            "terminal.ansi.dim_black": null,
+            "terminal.ansi.dim_blue": null,
+            "terminal.ansi.dim_cyan": null,
+            "terminal.ansi.dim_green": null,
+            "terminal.ansi.dim_magenta": null,
+            "terminal.ansi.dim_red": null,
+            "terminal.ansi.dim_white": null,
+            "terminal.ansi.dim_yellow": null,
+            "terminal.ansi.green": "#006800",
+            "terminal.ansi.magenta": "#721045",
+            "terminal.ansi.red": "#a60000",
+            "terminal.ansi.white": "#a6a6a6",
+            "terminal.ansi.yellow": "#695500",
+            "terminal.background": "#ffffff",
+            "terminal.bright_foreground": "#224960",
+            "terminal.dim_foreground": "#595959",
+            "terminal.foreground": "#000000",
+            "text": "#000000",
+            "text.accent": "#0000b0",
+            "text.disabled": "#595959",
+            "text.muted": "#224960",
+            "text.placeholder": "#595959",
+            "title_bar.background": "#ffffff",
+            "title_bar.inactive_background": "#f2f2f2",
+            "toolbar.background": "#ffffff",
+            "unreachable": "#595959",
+            "unreachable.background": "#f2f2f2",
+            "unreachable.border": "#595959",
+            "version_control.added": "#1782cc",
+            "version_control.conflict": "#9f6ab0",
+            "version_control.conflict_marker.ours": "#ffd8d5",
+            "version_control.conflict_marker.theirs": "#b5e7ff",
+            "version_control.deleted": "#d84a4f",
+            "version_control.ignored": "#595959",
+            "version_control.modified": "#9f6ab0",
+            "version_control.renamed": "#9f6ab0",
+            "warning": "#000000",
+            "warning.background": "#dfa0f0",
+            "warning.border": "#595959"
+         }
+      },
+      {
+         "appearance": "dark",
+         "name": "Modus Vivendi",
+         "style": {
+            "accents": [
+               "#ffffff",
+               "#ff66ff",
+               "#00eff0",
+               "#ff6b55",
+               "#efef00",
+               "#b6a0ff",
+               "#44df44",
+               "#79a8ff"
+            ],
+            "background": "#000000",
+            "border": "#989898",
+            "border.variant": "#989898",
+            "conflict": "#c0b05f",
+            "conflict.background": "#363300",
+            "conflict.border": "#989898",
+            "created": "#80e080",
+            "created.background": "#00381f",
+            "created.border": "#989898",
+            "debugger.accent": "#ff5f59",
+            "deleted": "#ff9095",
+            "deleted.background": "#4f1119",
+            "deleted.border": "#989898",
+            "drop_target.background": "#5353538c",
+            "editor.active_line.background": "#2f3849",
+            "editor.active_line_number": "#ffffff",
+            "editor.background": "#000000",
+            "editor.debugger_active_line.background": "#2f3849",
+            "editor.document_highlight.bracket_background": "#2f7f9f8c",
+            "editor.document_highlight.read_background": "#1e1e1e",
+            "editor.document_highlight.write_background": "#45605e",
+            "editor.foreground": "#ffffff",
+            "editor.gutter.background": "#1e1e1e",
+            "editor.highlighted_line.background": "#2f3849",
+            "editor.invisible": "#989898",
+            "editor.line_number": "#989898",
+            "editor.subheader.background": "#505050",
+            "element.active": "#535353",
+            "element.background": "#1e1e1e",
+            "element.disabled": "#1e1e1e",
+            "element.hover": "#45605e",
+            "element.selected": "#535353",
+            "elevated_surface.background": "#1e1e1e",
+            "error": "#ff5f59",
+            "error.background": "#9d1f1f",
+            "error.border": "#989898",
+            "ghost_element.active": "#535353",
+            "ghost_element.background": "#1e1e1e",
+            "ghost_element.disabled": "#1e1e1e",
+            "ghost_element.hover": "#45605e",
+            "ghost_element.selected": "#535353",
+            "hint": "#989898",
+            "hint.background": "#1e1e1e",
+            "hint.border": "#989898",
+            "icon": "#ffffff",
+            "icon.accent": "#00bcff",
+            "icon.disabled": "#989898",
+            "icon.muted": "#c6daff",
+            "icon.placeholder": "#989898",
+            "info": "#6ae4b9",
+            "info.background": "#1640b0",
+            "info.border": "#989898",
+            "modified": "#c0b05f",
+            "modified.background": "#363300",
+            "modified.border": "#989898",
+            "panel.background": "#000000",
+            "players": [
+               {
+                  "background": "#5a5a5a",
+                  "cursor": "#ffffff",
+                  "selection": "#ffffff3d"
+               },
+               {
+                  "background": "#ff66ff",
+                  "cursor": "#ff66ff",
+                  "selection": "#ff66ff3d"
+               },
+               {
+                  "background": "#00eff0",
+                  "cursor": "#00eff0",
+                  "selection": "#00eff03d"
+               },
+               {
+                  "background": "#ff6b55",
+                  "cursor": "#ff6b55",
+                  "selection": "#ff6b553d"
+               },
+               {
+                  "background": "#efef00",
+                  "cursor": "#efef00",
+                  "selection": "#efef003d"
+               },
+               {
+                  "background": "#b6a0ff",
+                  "cursor": "#b6a0ff",
+                  "selection": "#b6a0ff3d"
+               },
+               {
+                  "background": "#44df44",
+                  "cursor": "#44df44",
+                  "selection": "#44df443d"
+               }
+            ],
+            "predictive": "#989898",
+            "predictive.background": null,
+            "predictive.border": "#989898",
+            "renamed": "#c0b05f",
+            "renamed.background": "#363300",
+            "renamed.border": "#989898",
+            "scrollbar.thumb.background": "#5050508c",
+            "scrollbar.thumb.border": "#989898",
+            "scrollbar.thumb.hover_background": "#535353",
+            "scrollbar.track.background": "#1e1e1e",
+            "scrollbar.track.border": "#989898",
+            "search.match_background": "#2266ae",
+            "status_bar.background": "#505050",
+            "success": "#ffffff",
+            "success.background": "#2266ae",
+            "success.border": "#989898",
+            "surface.background": "#1e1e1e",
+            "syntax": {
+               "attribute": {
+                  "color": "#ff7f86"
+               },
+               "boolean": {
+                  "color": "#00bcff"
+               },
+               "comment": {
+                  "color": "#989898",
+                  "font_style": "italic"
+               },
+               "constant": {
+                  "color": "#00bcff"
+               },
+               "constructor": {
+                  "color": "#feacd0"
+               },
+               "embedded": {
+                  "color": "#ff7f86"
+               },
+               "function": {
+                  "color": "#feacd0"
+               },
+               "keyword": {
+                  "color": "#b6a0ff"
+               },
+               "number": {
+                  "color": "#ffffff"
+               },
+               "operator": {
+                  "color": "#feacd0"
+               },
+               "property": {
+                  "color": "#00d3d0"
+               },
+               "string": {
+                  "color": "#79a8ff"
+               },
+               "string.escape": {
+                  "color": "#79a8ff"
+               },
+               "string.regex": {
+                  "color": "#79a8ff"
+               },
+               "string.special": {
+                  "color": "#79a8ff"
+               },
+               "string.special.symbol": {
+                  "color": "#79a8ff"
+               },
+               "tag": {
+                  "color": "#00bcff"
+               },
+               "text.literal": {
+                  "color": "#6ae4b9"
+               },
+               "title": {
+                  "color": "#d2b580"
+               },
+               "type": {
+                  "color": "#6ae4b9"
+               },
+               "variable": {
+                  "color": "#00d3d0"
+               },
+               "variable.special": {
+                  "color": "#b6a0ff"
+               }
+            },
+            "tab.active_background": "#000000",
+            "tab.inactive_background": "#545454",
+            "tab_bar.background": "#313131",
+            "terminal.ansi.black": "#000000",
+            "terminal.ansi.blue": "#2fafff",
+            "terminal.ansi.bright_black": "#595959",
+            "terminal.ansi.bright_blue": "#79a8ff",
+            "terminal.ansi.bright_cyan": "#6ae4b9",
+            "terminal.ansi.bright_green": "#00c06f",
+            "terminal.ansi.bright_magenta": "#b6a0ff",
+            "terminal.ansi.bright_red": "#ff6b55",
+            "terminal.ansi.bright_white": "#ffffff",
+            "terminal.ansi.bright_yellow": "#fec43f",
+            "terminal.ansi.cyan": "#00d3d0",
+            "terminal.ansi.dim_black": null,
+            "terminal.ansi.dim_blue": null,
+            "terminal.ansi.dim_cyan": null,
+            "terminal.ansi.dim_green": null,
+            "terminal.ansi.dim_magenta": null,
+            "terminal.ansi.dim_red": null,
+            "terminal.ansi.dim_white": null,
+            "terminal.ansi.dim_yellow": null,
+            "terminal.ansi.green": "#44bc44",
+            "terminal.ansi.magenta": "#feacd0",
+            "terminal.ansi.red": "#ff5f59",
+            "terminal.ansi.white": "#a6a6a6",
+            "terminal.ansi.yellow": "#d0bc00",
+            "terminal.background": "#000000",
+            "terminal.bright_foreground": "#c6daff",
+            "terminal.dim_foreground": "#989898",
+            "terminal.foreground": "#ffffff",
+            "text": "#ffffff",
+            "text.accent": "#00bcff",
+            "text.disabled": "#989898",
+            "text.muted": "#c6daff",
+            "text.placeholder": "#989898",
+            "title_bar.background": "#000000",
+            "title_bar.inactive_background": "#1e1e1e",
+            "toolbar.background": "#000000",
+            "unreachable": "#989898",
+            "unreachable.background": "#1e1e1e",
+            "unreachable.border": "#989898",
+            "version_control.added": "#237f3f",
+            "version_control.conflict": "#8a7a00",
+            "version_control.conflict_marker.ours": "#4f1119",
+            "version_control.conflict_marker.theirs": "#00381f",
+            "version_control.deleted": "#b81a1f",
+            "version_control.ignored": "#989898",
+            "version_control.modified": "#8a7a00",
+            "version_control.renamed": "#8a7a00",
+            "warning": "#ffffff",
+            "warning.background": "#7a6100",
+            "warning.border": "#989898"
+         }
+      },
+      {
+         "appearance": "dark",
+         "name": "Modus Vivendi Deuteranopia",
+         "style": {
+            "accents": [
+               "#ffa00f",
+               "#2fafff",
+               "#d8af7a",
+               "#79a8ff",
+               "#cabf00",
+               "#4ae2f0",
+               "#d2b580",
+               "#82b0ec"
+            ],
+            "background": "#000000",
+            "border": "#989898",
+            "border.variant": "#989898",
+            "conflict": "#cf9fe2",
+            "conflict.background": "#2f123f",
+            "conflict.border": "#989898",
+            "created": "#8080ff",
+            "created.background": "#003066",
+            "created.border": "#989898",
+            "debugger.accent": "#ffa00f",
+            "deleted": "#d0b05f",
+            "deleted.background": "#3d3d00",
+            "deleted.border": "#989898",
+            "drop_target.background": "#5353538c",
+            "editor.active_line.background": "#2f3849",
+            "editor.active_line_number": "#ffffff",
+            "editor.background": "#000000",
+            "editor.debugger_active_line.background": "#2f3849",
+            "editor.document_highlight.bracket_background": "#2f7f9f8c",
+            "editor.document_highlight.read_background": "#1e1e1e",
+            "editor.document_highlight.write_background": "#45605e",
+            "editor.foreground": "#ffffff",
+            "editor.gutter.background": "#1e1e1e",
+            "editor.highlighted_line.background": "#2f3849",
+            "editor.invisible": "#989898",
+            "editor.line_number": "#989898",
+            "editor.subheader.background": "#2a2a6a",
+            "element.active": "#535353",
+            "element.background": "#1e1e1e",
+            "element.disabled": "#1e1e1e",
+            "element.hover": "#45605e",
+            "element.selected": "#535353",
+            "elevated_surface.background": "#1e1e1e",
+            "error": "#ffa00f",
+            "error.background": "#7a6100",
+            "error.border": "#989898",
+            "ghost_element.active": "#535353",
+            "ghost_element.background": "#1e1e1e",
+            "ghost_element.disabled": "#1e1e1e",
+            "ghost_element.hover": "#45605e",
+            "ghost_element.selected": "#535353",
+            "hint": "#989898",
+            "hint.background": "#1e1e1e",
+            "hint.border": "#989898",
+            "icon": "#ffffff",
+            "icon.accent": "#00bcff",
+            "icon.disabled": "#989898",
+            "icon.muted": "#c6daff",
+            "icon.placeholder": "#989898",
+            "info": "#2fafff",
+            "info.background": "#1640b0",
+            "info.border": "#989898",
+            "modified": "#cf9fe2",
+            "modified.background": "#2f123f",
+            "modified.border": "#989898",
+            "panel.background": "#000000",
+            "players": [
+               {
+                  "background": "#5a5a5a",
+                  "cursor": "#efef00",
+                  "selection": "#ffffff3d"
+               },
+               {
+                  "background": "#2fafff",
+                  "cursor": "#2fafff",
+                  "selection": "#2fafff3d"
+               },
+               {
+                  "background": "#d8af7a",
+                  "cursor": "#d8af7a",
+                  "selection": "#d8af7a3d"
+               },
+               {
+                  "background": "#79a8ff",
+                  "cursor": "#79a8ff",
+                  "selection": "#79a8ff3d"
+               },
+               {
+                  "background": "#cabf00",
+                  "cursor": "#cabf00",
+                  "selection": "#cabf003d"
+               },
+               {
+                  "background": "#4ae2f0",
+                  "cursor": "#4ae2f0",
+                  "selection": "#4ae2f03d"
+               },
+               {
+                  "background": "#d2b580",
+                  "cursor": "#d2b580",
+                  "selection": "#d2b5803d"
+               }
+            ],
+            "predictive": "#989898",
+            "predictive.background": null,
+            "predictive.border": "#989898",
+            "renamed": "#cf9fe2",
+            "renamed.background": "#2f123f",
+            "renamed.border": "#989898",
+            "scrollbar.thumb.background": "#2a2a6a8c",
+            "scrollbar.thumb.border": "#989898",
+            "scrollbar.thumb.hover_background": "#535353",
+            "scrollbar.track.background": "#1e1e1e",
+            "scrollbar.track.border": "#989898",
+            "search.match_background": "#1640b0",
+            "status_bar.background": "#2a2a6a",
+            "success": "#ffffff",
+            "success.background": "#2266ae",
+            "success.border": "#989898",
+            "surface.background": "#1e1e1e",
+            "syntax": {
+               "attribute": {
+                  "color": "#b6a0ff"
+               },
+               "boolean": {
+                  "color": "#82b0ec"
+               },
+               "comment": {
+                  "color": "#d8af7a",
+                  "font_style": "italic"
+               },
+               "constant": {
+                  "color": "#82b0ec"
+               },
+               "constructor": {
+                  "color": "#ffa00f"
+               },
+               "embedded": {
+                  "color": "#b6a0ff"
+               },
+               "function": {
+                  "color": "#ffa00f"
+               },
+               "keyword": {
+                  "color": "#00bcff"
+               },
+               "number": {
+                  "color": "#ffffff"
+               },
+               "operator": {
+                  "color": "#ffa00f"
+               },
+               "property": {
+                  "color": "#00d3d0"
+               },
+               "string": {
+                  "color": "#79a8ff"
+               },
+               "string.escape": {
+                  "color": "#79a8ff"
+               },
+               "string.regex": {
+                  "color": "#79a8ff"
+               },
+               "string.special": {
+                  "color": "#79a8ff"
+               },
+               "string.special.symbol": {
+                  "color": "#79a8ff"
+               },
+               "tag": {
+                  "color": "#82b0ec"
+               },
+               "text.literal": {
+                  "color": "#6ae4b9"
+               },
+               "title": {
+                  "color": "#d2b580"
+               },
+               "type": {
+                  "color": "#6ae4b9"
+               },
+               "variable": {
+                  "color": "#00d3d0"
+               },
+               "variable.special": {
+                  "color": "#00bcff"
+               }
+            },
+            "tab.active_background": "#000000",
+            "tab.inactive_background": "#545454",
+            "tab_bar.background": "#313131",
+            "terminal.ansi.black": "#000000",
+            "terminal.ansi.blue": "#2fafff",
+            "terminal.ansi.bright_black": "#595959",
+            "terminal.ansi.bright_blue": "#79a8ff",
+            "terminal.ansi.bright_cyan": "#6ae4b9",
+            "terminal.ansi.bright_green": "#00c06f",
+            "terminal.ansi.bright_magenta": "#b6a0ff",
+            "terminal.ansi.bright_red": "#ff6b55",
+            "terminal.ansi.bright_white": "#ffffff",
+            "terminal.ansi.bright_yellow": "#ffa00f",
+            "terminal.ansi.cyan": "#00d3d0",
+            "terminal.ansi.dim_black": null,
+            "terminal.ansi.dim_blue": null,
+            "terminal.ansi.dim_cyan": null,
+            "terminal.ansi.dim_green": null,
+            "terminal.ansi.dim_magenta": null,
+            "terminal.ansi.dim_red": null,
+            "terminal.ansi.dim_white": null,
+            "terminal.ansi.dim_yellow": null,
+            "terminal.ansi.green": "#44bc44",
+            "terminal.ansi.magenta": "#feacd0",
+            "terminal.ansi.red": "#ff5f59",
+            "terminal.ansi.white": "#a6a6a6",
+            "terminal.ansi.yellow": "#cabf00",
+            "terminal.background": "#000000",
+            "terminal.bright_foreground": "#c6daff",
+            "terminal.dim_foreground": "#989898",
+            "terminal.foreground": "#ffffff",
+            "text": "#ffffff",
+            "text.accent": "#00bcff",
+            "text.disabled": "#989898",
+            "text.muted": "#c6daff",
+            "text.placeholder": "#989898",
+            "title_bar.background": "#000000",
+            "title_bar.inactive_background": "#1e1e1e",
+            "toolbar.background": "#000000",
+            "unreachable": "#989898",
+            "unreachable.background": "#1e1e1e",
+            "unreachable.border": "#989898",
+            "version_control.added": "#006fff",
+            "version_control.conflict": "#7f55a0",
+            "version_control.conflict_marker.ours": "#3d3d00",
+            "version_control.conflict_marker.theirs": "#003066",
+            "version_control.deleted": "#d0c03f",
+            "version_control.ignored": "#989898",
+            "version_control.modified": "#7f55a0",
+            "version_control.renamed": "#7f55a0",
+            "warning": "#ffffff",
+            "warning.background": "#7030af",
+            "warning.border": "#989898"
+         }
+      },
+      {
+         "appearance": "dark",
+         "name": "Modus Vivendi Tinted",
+         "style": {
+            "accents": [
+               "#ffffff",
+               "#ff66ff",
+               "#00eff0",
+               "#ff6b55",
+               "#efef00",
+               "#b6a0ff",
+               "#44df44",
+               "#79a8ff"
+            ],
+            "background": "#0d0e1c",
+            "border": "#989898",
+            "border.variant": "#989898",
+            "conflict": "#c0b05f",
+            "conflict.background": "#363300",
+            "conflict.border": "#989898",
+            "created": "#80e080",
+            "created.background": "#003a2f",
+            "created.border": "#989898",
+            "debugger.accent": "#ff5f59",
+            "deleted": "#ff9095",
+            "deleted.background": "#4f1127",
+            "deleted.border": "#989898",
+            "drop_target.background": "#4a4f698c",
+            "editor.active_line.background": "#303a6f",
+            "editor.active_line_number": "#ffffff",
+            "editor.background": "#0d0e1c",
+            "editor.debugger_active_line.background": "#303a6f",
+            "editor.document_highlight.bracket_background": "#4f7f9f8c",
+            "editor.document_highlight.read_background": "#1d2235",
+            "editor.document_highlight.write_background": "#45605e",
+            "editor.foreground": "#ffffff",
+            "editor.gutter.background": "#1d2235",
+            "editor.highlighted_line.background": "#303a6f",
+            "editor.invisible": "#989898",
+            "editor.line_number": "#989898",
+            "editor.subheader.background": "#484d67",
+            "element.active": "#4a4f69",
+            "element.background": "#1d2235",
+            "element.disabled": "#1d2235",
+            "element.hover": "#45605e",
+            "element.selected": "#4a4f69",
+            "elevated_surface.background": "#1d2235",
+            "error": "#ff5f59",
+            "error.background": "#9d1f1f",
+            "error.border": "#989898",
+            "ghost_element.active": "#4a4f69",
+            "ghost_element.background": "#1d2235",
+            "ghost_element.disabled": "#1d2235",
+            "ghost_element.hover": "#45605e",
+            "ghost_element.selected": "#4a4f69",
+            "hint": "#989898",
+            "hint.background": "#1d2235",
+            "hint.border": "#989898",
+            "icon": "#ffffff",
+            "icon.accent": "#00bcff",
+            "icon.disabled": "#989898",
+            "icon.muted": "#c6daff",
+            "icon.placeholder": "#989898",
+            "info": "#11c777",
+            "info.background": "#1640b0",
+            "info.border": "#989898",
+            "modified": "#c0b05f",
+            "modified.background": "#363300",
+            "modified.border": "#989898",
+            "panel.background": "#0d0e1c",
+            "players": [
+               {
+                  "background": "#555a66",
+                  "cursor": "#ff66ff",
+                  "selection": "#ffffff3d"
+               },
+               {
+                  "background": "#ff66ff",
+                  "cursor": "#ff66ff",
+                  "selection": "#ff66ff3d"
+               },
+               {
+                  "background": "#00eff0",
+                  "cursor": "#00eff0",
+                  "selection": "#00eff03d"
+               },
+               {
+                  "background": "#ff6b55",
+                  "cursor": "#ff6b55",
+                  "selection": "#ff6b553d"
+               },
+               {
+                  "background": "#efef00",
+                  "cursor": "#efef00",
+                  "selection": "#efef003d"
+               },
+               {
+                  "background": "#b6a0ff",
+                  "cursor": "#b6a0ff",
+                  "selection": "#b6a0ff3d"
+               },
+               {
+                  "background": "#44df44",
+                  "cursor": "#44df44",
+                  "selection": "#44df443d"
+               }
+            ],
+            "predictive": "#989898",
+            "predictive.background": null,
+            "predictive.border": "#989898",
+            "renamed": "#c0b05f",
+            "renamed.background": "#363300",
+            "renamed.border": "#989898",
+            "scrollbar.thumb.background": "#484d678c",
+            "scrollbar.thumb.border": "#989898",
+            "scrollbar.thumb.hover_background": "#4a4f69",
+            "scrollbar.track.background": "#1d2235",
+            "scrollbar.track.border": "#989898",
+            "search.match_background": "#2266ae",
+            "status_bar.background": "#484d67",
+            "success": "#ffffff",
+            "success.background": "#2266ae",
+            "success.border": "#989898",
+            "surface.background": "#1d2235",
+            "syntax": {
+               "attribute": {
+                  "color": "#ff7f86"
+               },
+               "boolean": {
+                  "color": "#b6a0ff"
+               },
+               "comment": {
+                  "color": "#ef8386",
+                  "font_style": "italic"
+               },
+               "constant": {
+                  "color": "#b6a0ff"
+               },
+               "constructor": {
+                  "color": "#f78fe7"
+               },
+               "embedded": {
+                  "color": "#ff7f86"
+               },
+               "function": {
+                  "color": "#f78fe7"
+               },
+               "keyword": {
+                  "color": "#79a8ff"
+               },
+               "number": {
+                  "color": "#ffffff"
+               },
+               "operator": {
+                  "color": "#f78fe7"
+               },
+               "property": {
+                  "color": "#4ae2f0"
+               },
+               "string": {
+                  "color": "#2fafff"
+               },
+               "string.escape": {
+                  "color": "#2fafff"
+               },
+               "string.regex": {
+                  "color": "#2fafff"
+               },
+               "string.special": {
+                  "color": "#2fafff"
+               },
+               "string.special.symbol": {
+                  "color": "#2fafff"
+               },
+               "tag": {
+                  "color": "#b6a0ff"
+               },
+               "text.literal": {
+                  "color": "#6ae4b9"
+               },
+               "title": {
+                  "color": "#d2b580"
+               },
+               "type": {
+                  "color": "#11c777"
+               },
+               "variable": {
+                  "color": "#4ae2f0"
+               },
+               "variable.special": {
+                  "color": "#79a8ff"
+               }
+            },
+            "tab.active_background": "#0d0e1c",
+            "tab.inactive_background": "#4a4f6a",
+            "tab_bar.background": "#2c3045",
+            "terminal.ansi.black": "#000000",
+            "terminal.ansi.blue": "#2fafff",
+            "terminal.ansi.bright_black": "#595959",
+            "terminal.ansi.bright_blue": "#79a8ff",
+            "terminal.ansi.bright_cyan": "#6ae4b9",
+            "terminal.ansi.bright_green": "#11c777",
+            "terminal.ansi.bright_magenta": "#b6a0ff",
+            "terminal.ansi.bright_red": "#ff6b55",
+            "terminal.ansi.bright_white": "#ffffff",
+            "terminal.ansi.bright_yellow": "#fec43f",
+            "terminal.ansi.cyan": "#00d3d0",
+            "terminal.ansi.dim_black": null,
+            "terminal.ansi.dim_blue": null,
+            "terminal.ansi.dim_cyan": null,
+            "terminal.ansi.dim_green": null,
+            "terminal.ansi.dim_magenta": null,
+            "terminal.ansi.dim_red": null,
+            "terminal.ansi.dim_white": null,
+            "terminal.ansi.dim_yellow": null,
+            "terminal.ansi.green": "#44bc44",
+            "terminal.ansi.magenta": "#feacd0",
+            "terminal.ansi.red": "#ff5f59",
+            "terminal.ansi.white": "#a6a6a6",
+            "terminal.ansi.yellow": "#d0bc00",
+            "terminal.background": "#0d0e1c",
+            "terminal.bright_foreground": "#c6daff",
+            "terminal.dim_foreground": "#989898",
+            "terminal.foreground": "#ffffff",
+            "text": "#ffffff",
+            "text.accent": "#00bcff",
+            "text.disabled": "#989898",
+            "text.muted": "#c6daff",
+            "text.placeholder": "#989898",
+            "title_bar.background": "#0d0e1c",
+            "title_bar.inactive_background": "#1d2235",
+            "toolbar.background": "#0d0e1c",
+            "unreachable": "#989898",
+            "unreachable.background": "#1d2235",
+            "unreachable.border": "#989898",
+            "version_control.added": "#23884f",
+            "version_control.conflict": "#8f7a30",
+            "version_control.conflict_marker.ours": "#4f1127",
+            "version_control.conflict_marker.theirs": "#003a2f",
+            "version_control.deleted": "#b81a26",
+            "version_control.ignored": "#989898",
+            "version_control.modified": "#8f7a30",
+            "version_control.renamed": "#8f7a30",
+            "warning": "#ffffff",
+            "warning.background": "#7a6100",
+            "warning.border": "#989898"
+         }
+      },
+      {
+         "appearance": "dark",
+         "name": "Modus Vivendi Tritanopia",
+         "style": {
+            "accents": [
+               "#00d3d0",
+               "#ff5f59",
+               "#4ae2ff",
+               "#ff7f86",
+               "#6ae4b9",
+               "#feacd0",
+               "#7fdbdf",
+               "#caa6df"
+            ],
+            "background": "#000000",
+            "border": "#989898",
+            "border.variant": "#989898",
+            "conflict": "#cf9fe2",
+            "conflict.background": "#2f123f",
+            "conflict.border": "#989898",
+            "created": "#50c0ef",
+            "created.background": "#004254",
+            "created.border": "#989898",
+            "debugger.accent": "#ff6740",
+            "deleted": "#ff9095",
+            "deleted.background": "#4f1119",
+            "deleted.border": "#989898",
+            "drop_target.background": "#5353538c",
+            "editor.active_line.background": "#2f3849",
+            "editor.active_line_number": "#ffffff",
+            "editor.background": "#000000",
+            "editor.debugger_active_line.background": "#2f3849",
+            "editor.document_highlight.bracket_background": "#2f7f9f8c",
+            "editor.document_highlight.read_background": "#1e1e1e",
+            "editor.document_highlight.write_background": "#8e3e3b",
+            "editor.foreground": "#ffffff",
+            "editor.gutter.background": "#1e1e1e",
+            "editor.highlighted_line.background": "#2f3849",
+            "editor.invisible": "#989898",
+            "editor.line_number": "#989898",
+            "editor.subheader.background": "#003c52",
+            "element.active": "#535353",
+            "element.background": "#1e1e1e",
+            "element.disabled": "#1e1e1e",
+            "element.hover": "#8e3e3b",
+            "element.selected": "#535353",
+            "elevated_surface.background": "#1e1e1e",
+            "error": "#ff6740",
+            "error.background": "#9d1f1f",
+            "error.border": "#989898",
+            "ghost_element.active": "#535353",
+            "ghost_element.background": "#1e1e1e",
+            "ghost_element.disabled": "#1e1e1e",
+            "ghost_element.hover": "#8e3e3b",
+            "ghost_element.selected": "#535353",
+            "hint": "#989898",
+            "hint.background": "#1e1e1e",
+            "hint.border": "#989898",
+            "icon": "#ffffff",
+            "icon.accent": "#00bcff",
+            "icon.disabled": "#989898",
+            "icon.muted": "#a0d7f2",
+            "icon.placeholder": "#989898",
+            "info": "#00d3d0",
+            "info.background": "#1640b0",
+            "info.border": "#989898",
+            "modified": "#cf9fe2",
+            "modified.background": "#2f123f",
+            "modified.border": "#989898",
+            "panel.background": "#000000",
+            "players": [
+               {
+                  "background": "#5a5a5a",
+                  "cursor": "#ff5f5f",
+                  "selection": "#ffffff3d"
+               },
+               {
+                  "background": "#ff5f59",
+                  "cursor": "#ff5f59",
+                  "selection": "#ff5f593d"
+               },
+               {
+                  "background": "#4ae2ff",
+                  "cursor": "#4ae2ff",
+                  "selection": "#4ae2ff3d"
+               },
+               {
+                  "background": "#ff7f86",
+                  "cursor": "#ff7f86",
+                  "selection": "#ff7f863d"
+               },
+               {
+                  "background": "#6ae4b9",
+                  "cursor": "#6ae4b9",
+                  "selection": "#6ae4b93d"
+               },
+               {
+                  "background": "#feacd0",
+                  "cursor": "#feacd0",
+                  "selection": "#feacd03d"
+               },
+               {
+                  "background": "#7fdbdf",
+                  "cursor": "#7fdbdf",
+                  "selection": "#7fdbdf3d"
+               }
+            ],
+            "predictive": "#989898",
+            "predictive.background": null,
+            "predictive.border": "#989898",
+            "renamed": "#cf9fe2",
+            "renamed.background": "#2f123f",
+            "renamed.border": "#989898",
+            "scrollbar.thumb.background": "#003c528c",
+            "scrollbar.thumb.border": "#989898",
+            "scrollbar.thumb.hover_background": "#535353",
+            "scrollbar.track.background": "#1e1e1e",
+            "scrollbar.track.border": "#989898",
+            "search.match_background": "#2266ae",
+            "status_bar.background": "#003c52",
+            "success": "#ffffff",
+            "success.background": "#2266ae",
+            "success.border": "#989898",
+            "surface.background": "#1e1e1e",
+            "syntax": {
+               "attribute": {
+                  "color": "#ff6740"
+               },
+               "boolean": {
+                  "color": "#88ca9f"
+               },
+               "comment": {
+                  "color": "#ff9070",
+                  "font_style": "italic"
+               },
+               "constant": {
+                  "color": "#88ca9f"
+               },
+               "constructor": {
+                  "color": "#4ae2ff"
+               },
+               "embedded": {
+                  "color": "#ff6740"
+               },
+               "function": {
+                  "color": "#4ae2ff"
+               },
+               "keyword": {
+                  "color": "#ff7f86"
+               },
+               "number": {
+                  "color": "#ffffff"
+               },
+               "operator": {
+                  "color": "#4ae2ff"
+               },
+               "property": {
+                  "color": "#6ae4b9"
+               },
+               "string": {
+                  "color": "#00d3d0"
+               },
+               "string.escape": {
+                  "color": "#00d3d0"
+               },
+               "string.regex": {
+                  "color": "#00d3d0"
+               },
+               "string.special": {
+                  "color": "#00d3d0"
+               },
+               "string.special.symbol": {
+                  "color": "#00d3d0"
+               },
+               "tag": {
+                  "color": "#88ca9f"
+               },
+               "text.literal": {
+                  "color": "#00d3d0"
+               },
+               "title": {
+                  "color": "#ff9070"
+               },
+               "type": {
+                  "color": "#79a8ff"
+               },
+               "variable": {
+                  "color": "#6ae4b9"
+               },
+               "variable.special": {
+                  "color": "#ff7f86"
+               }
+            },
+            "tab.active_background": "#000000",
+            "tab.inactive_background": "#545454",
+            "tab_bar.background": "#313131",
+            "terminal.ansi.black": "#000000",
+            "terminal.ansi.blue": "#2fafff",
+            "terminal.ansi.bright_black": "#595959",
+            "terminal.ansi.bright_blue": "#79a8ff",
+            "terminal.ansi.bright_cyan": "#6ae4b9",
+            "terminal.ansi.bright_green": "#00c06f",
+            "terminal.ansi.bright_magenta": "#b6a0ff",
+            "terminal.ansi.bright_red": "#ff6740",
+            "terminal.ansi.bright_white": "#ffffff",
+            "terminal.ansi.bright_yellow": "#ffa00f",
+            "terminal.ansi.cyan": "#00d3d0",
+            "terminal.ansi.dim_black": null,
+            "terminal.ansi.dim_blue": null,
+            "terminal.ansi.dim_cyan": null,
+            "terminal.ansi.dim_green": null,
+            "terminal.ansi.dim_magenta": null,
+            "terminal.ansi.dim_red": null,
+            "terminal.ansi.dim_white": null,
+            "terminal.ansi.dim_yellow": null,
+            "terminal.ansi.green": "#44bc44",
+            "terminal.ansi.magenta": "#feacd0",
+            "terminal.ansi.red": "#ff5f59",
+            "terminal.ansi.white": "#a6a6a6",
+            "terminal.ansi.yellow": "#cabf00",
+            "terminal.background": "#000000",
+            "terminal.bright_foreground": "#a0d7f2",
+            "terminal.dim_foreground": "#989898",
+            "terminal.foreground": "#ffffff",
+            "text": "#ffffff",
+            "text.accent": "#00bcff",
+            "text.disabled": "#989898",
+            "text.muted": "#a0d7f2",
+            "text.placeholder": "#989898",
+            "title_bar.background": "#000000",
+            "title_bar.inactive_background": "#1e1e1e",
+            "toolbar.background": "#000000",
+            "unreachable": "#989898",
+            "unreachable.background": "#1e1e1e",
+            "unreachable.border": "#989898",
+            "version_control.added": "#008fcf",
+            "version_control.conflict": "#7f55a0",
+            "version_control.conflict_marker.ours": "#4f1119",
+            "version_control.conflict_marker.theirs": "#004254",
+            "version_control.deleted": "#b81a1f",
+            "version_control.ignored": "#989898",
+            "version_control.modified": "#7f55a0",
+            "version_control.renamed": "#7f55a0",
+            "warning": "#ffffff",
+            "warning.background": "#7030af",
+            "warning.border": "#989898"
+         }
+      }
+   ]
+}

--- a/themes/monokai.json
+++ b/themes/monokai.json
@@ -1,0 +1,276 @@
+{
+  "$schema": "https://zed.dev/schema/themes/v0.1.0.json",
+  "name": "Monokai",
+  "author": "Eric Moyer (epmoyer)",
+  "themes": [
+    {
+      "name": "Monokai",
+      "appearance": "dark",
+      "style": {
+        "border": "#414339",
+        "border.variant": "#414339",
+        "border.focused": "#75715E",
+        "border.selected": "#414339",
+        "border.transparent": "#414339",
+        "border.disabled": "#414339",
+        "elevated_surface.background": "#414339",
+        "surface.background": null,
+        "background": "#1D1D1A",
+        "element.background": "#75715E",
+        "element.hover": "#272822",
+        "element.active": null,
+        "element.selected": "#75715E",
+        "element.disabled": null,
+        "drop_target.background": "#414339",
+        "ghost_element.background": null,
+        "ghost_element.hover": "#272822",
+        "ghost_element.active": null,
+        "ghost_element.selected": "#75715E",
+        "ghost_element.disabled": null,
+        "text": "#F8F8F2",
+        "text.muted": "#ccccc7",
+        "text.placeholder": null,
+        "text.disabled": null,
+        "text.accent": null,
+        "icon": null,
+        "icon.muted": null,
+        "icon.disabled": null,
+        "icon.placeholder": null,
+        "icon.accent": null,
+        "status_bar.background": "#414339",
+        "title_bar.background": "#1e1f1c",
+        "toolbar.background": "#272822",
+        "tab_bar.background": "#1e1f1c",
+        "tab.inactive_background": "#414339",
+        "tab.active_background": "#414339",
+        "search.match_background": "#535C69",
+        "panel.background": "#101010",
+        "panel.focused_border": null,
+        "pane.focused_border": null,
+        "scrollbar_thumb.background": null,
+        "scrollbar.thumb.hover_background": null,
+        "scrollbar.thumb.border": null,
+        "scrollbar.track.background": "#272822",
+        "scrollbar.track.border": null,
+        "editor.foreground": "#f8f8f2",
+        "editor.background": "#1D1D1A",
+        "editor.gutter.background": "#202020",
+        "editor.subheader.background": null,
+        "editor.active_line.background": "#3E3D33b0",
+        "editor.highlighted_line.background": null,
+        "editor.line_number": "#90908a",
+        "editor.active_line_number": "#f8f8f2",
+        "editor.invisible": null,
+        "editor.wrap_guide": "#414339",
+        "editor.active_wrap_guide": "#414339",
+        "editor.document_highlight.read_background": null,
+        "editor.document_highlight.write_background": null,
+        "terminal.background": null,
+        "terminal.foreground": null,
+        "terminal.bright_foreground": null,
+        "terminal.dim_foreground": null,
+        "terminal.ansi.black": "#333333",
+        "terminal.ansi.bright_black": "#666666",
+        "terminal.ansi.dim_black": null,
+        "terminal.ansi.red": "#C4265E",
+        "terminal.ansi.bright_red": "#f92672",
+        "terminal.ansi.dim_red": null,
+        "terminal.ansi.green": "#86B42B",
+        "terminal.ansi.bright_green": "#A6E22E",
+        "terminal.ansi.dim_green": null,
+        "terminal.ansi.yellow": "#B3B42B",
+        "terminal.ansi.bright_yellow": "#e2e22e",
+        "terminal.ansi.dim_yellow": null,
+        "terminal.ansi.blue": "#6A7EC8",
+        "terminal.ansi.bright_blue": "#819aff",
+        "terminal.ansi.dim_blue": null,
+        "terminal.ansi.magenta": "#8C6BC8",
+        "terminal.ansi.bright_magenta": "#AE81FF",
+        "terminal.ansi.dim_magenta": null,
+        "terminal.ansi.cyan": "#56ADBC",
+        "terminal.ansi.bright_cyan": "#66D9EF",
+        "terminal.ansi.dim_cyan": null,
+        "terminal.ansi.white": "#e3e3dd",
+        "terminal.ansi.bright_white": "#f8f8f2",
+        "terminal.ansi.dim_white": null,
+        "link_text.hover": null,
+        "conflict": null,
+        "conflict.background": null,
+        "conflict.border": null,
+        "created": null,
+        "created.background": null,
+        "created.border": null,
+        "deleted": null,
+        "deleted.background": null,
+        "deleted.border": null,
+        "error": null,
+        "error.background": null,
+        "error.border": null,
+        "hidden": "#ccccc7",
+        "hidden.background": null,
+        "hidden.border": null,
+        "hint": "#969696ff",
+        "hint.background": null,
+        "hint.border": null,
+        "ignored": null,
+        "ignored.background": null,
+        "ignored.border": null,
+        "info": null,
+        "info.background": null,
+        "info.border": null,
+        "modified": "#a6e22e",
+        "modified.background": null,
+        "modified.border": null,
+        "predictive": null,
+        "predictive.background": null,
+        "predictive.border": null,
+        "renamed": null,
+        "renamed.background": null,
+        "renamed.border": null,
+        "success": null,
+        "success.background": null,
+        "success.border": null,
+        "unreachable": null,
+        "unreachable.background": null,
+        "unreachable.border": null,
+        "warning": null,
+        "warning.background": null,
+        "warning.border": null,
+        "players": [
+          {
+            "cursor": "#566ddaff",
+            "background": "#566ddaff",
+            "selection": "#566dda3d"
+          },
+          {
+            "cursor": "#bf41bfff",
+            "background": "#bf41bfff",
+            "selection": "#bf41bf3d"
+          },
+          {
+            "cursor": "#aa563bff",
+            "background": "#aa563bff",
+            "selection": "#aa563b3d"
+          },
+          {
+            "cursor": "#955ae6ff",
+            "background": "#955ae6ff",
+            "selection": "#955ae63d"
+          },
+          {
+            "cursor": "#3a8bc6ff",
+            "background": "#3a8bc6ff",
+            "selection": "#3a8bc63d"
+          },
+          {
+            "cursor": "#be4677ff",
+            "background": "#be4677ff",
+            "selection": "#be46773d"
+          },
+          {
+            "cursor": "#a06d3aff",
+            "background": "#a06d3aff",
+            "selection": "#a06d3a3d"
+          },
+          {
+            "cursor": "#2b9292ff",
+            "background": "#2b9292ff",
+            "selection": "#2b92923d"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": "#A6E22E",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#AE81FF",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#75715E",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#75715E",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#AE81FF",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function": {
+            "color": "#66d9ef",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword": {
+            "color": "#F92672",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#F92672",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#AE81FF",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#E6DB74",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#E6DB74",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#E6DB74",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#E6DB74",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#E6DB74",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#E6DB74",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#F8F8F2",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#FD971F",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "type": {
+            "color": "#a6e22e",
+            "font_style": "italic",
+            "font_weight": null
+          }
+        }
+      }
+    }
+  ]
+}

--- a/themes/monokai_st3.json
+++ b/themes/monokai_st3.json
@@ -1,0 +1,235 @@
+{
+    "$schema": "https://zed.dev/schema/themes/v0.1.0.json",
+    "name": "One Monokai",
+    "author": "Andrey Volosovich (volosovich), converted by Eric Moyer (epmoyer)",
+    "themes": [
+        {
+            "name": "Monokai-ST3",
+            "appearance": "dark",
+            "style": {
+                "border": "#414339",
+                "border.variant": "#414339",
+                "border.focused": "#75715E",
+                "border.selected": "#414339",
+                "border.transparent": "#414339",
+                "border.disabled": "#414339",
+                "elevated_surface.background": "#414339",
+                "surface.background": null,
+                "background": "#272822",
+                "element.background": "#75715E",
+                "element.hover": "#272822",
+                "element.active": null,
+                "element.selected": "#75715E",
+                "element.disabled": null,
+                "drop_target.background": "#414339",
+                "ghost_element.background": null,
+                "ghost_element.hover": "#272822",
+                "ghost_element.active": null,
+                "ghost_element.selected": "#75715E",
+                "ghost_element.disabled": null,
+                "text": "#F8F8F2",
+                "text.muted": "#ccccc7",
+                "text.placeholder": null,
+                "text.disabled": null,
+                "text.accent": null,
+                "icon": null,
+                "icon.muted": null,
+                "icon.disabled": null,
+                "icon.placeholder": null,
+                "icon.accent": null,
+                "status_bar.background": "#414339",
+                "title_bar.background": "#1e1f1c",
+                "toolbar.background": "#272822",
+                "tab_bar.background": "#1e1f1c",
+                "tab.inactive_background": "#414339",
+                "tab.active_background": "#414339",
+                "search.match_background": null,
+                "panel.background": null,
+                "panel.focused_border": null,
+                "pane.focused_border": null,
+                "scrollbar_thumb.background": null,
+                "scrollbar.thumb.hover_background": null,
+                "scrollbar.thumb.border": null,
+                "scrollbar.track.background": "#272822",
+                "scrollbar.track.border": null,
+                "editor.foreground": "#f8f8f2",
+                "editor.background": "#272822",
+                "editor.gutter.background": "#272822",
+                "editor.subheader.background": null,
+                "editor.active_line.background": "#3e3d32",
+                "editor.highlighted_line.background": null,
+                "editor.line_number": "#90908a",
+                "editor.active_line_number": "#f8f8f2",
+                "editor.invisible": null,
+                "editor.wrap_guide": "#414339",
+                "editor.active_wrap_guide": "#414339",
+                "editor.document_highlight.read_background": null,
+                "editor.document_highlight.write_background": null,
+                "terminal.background": null,
+                "terminal.foreground": null,
+                "terminal.bright_foreground": null,
+                "terminal.dim_foreground": null,
+                "terminal.ansi.black": "#333333",
+                "terminal.ansi.bright_black": "#666666",
+                "terminal.ansi.dim_black": null,
+                "terminal.ansi.red": "#C4265E",
+                "terminal.ansi.bright_red": "#f92672",
+                "terminal.ansi.dim_red": null,
+                "terminal.ansi.green": "#86B42B",
+                "terminal.ansi.bright_green": "#A6E22E",
+                "terminal.ansi.dim_green": null,
+                "terminal.ansi.yellow": "#B3B42B",
+                "terminal.ansi.bright_yellow": "#e2e22e",
+                "terminal.ansi.dim_yellow": null,
+                "terminal.ansi.blue": "#6A7EC8",
+                "terminal.ansi.bright_blue": "#819aff",
+                "terminal.ansi.dim_blue": null,
+                "terminal.ansi.magenta": "#8C6BC8",
+                "terminal.ansi.bright_magenta": "#AE81FF",
+                "terminal.ansi.dim_magenta": null,
+                "terminal.ansi.cyan": "#56ADBC",
+                "terminal.ansi.bright_cyan": "#66D9EF",
+                "terminal.ansi.dim_cyan": null,
+                "terminal.ansi.white": "#e3e3dd",
+                "terminal.ansi.bright_white": "#f8f8f2",
+                "terminal.ansi.dim_white": null,
+                "link_text.hover": null,
+                "conflict": null,
+                "conflict.background": null,
+                "conflict.border": null,
+                "created": null,
+                "created.background": null,
+                "created.border": null,
+                "deleted": null,
+                "deleted.background": null,
+                "deleted.border": null,
+                "error": null,
+                "error.background": null,
+                "error.border": null,
+                "hidden": "#ccccc7",
+                "hidden.background": null,
+                "hidden.border": null,
+                "hint": "#969696ff",
+                "hint.background": null,
+                "hint.border": null,
+                "ignored": null,
+                "ignored.background": null,
+                "ignored.border": null,
+                "info": null,
+                "info.background": null,
+                "info.border": null,
+                "modified": null,
+                "modified.background": null,
+                "modified.border": null,
+                "predictive": null,
+                "predictive.background": null,
+                "predictive.border": null,
+                "renamed": null,
+                "renamed.background": null,
+                "renamed.border": null,
+                "success": null,
+                "success.background": null,
+                "success.border": null,
+                "unreachable": null,
+                "unreachable.background": null,
+                "unreachable.border": null,
+                "warning": null,
+                "warning.background": null,
+                "warning.border": null,
+                "players": [],
+                "syntax": {
+                    "attribute": {
+                        "color": "#A6E22E",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "boolean": {
+                        "color": "#AE81FF",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "comment": {
+                        "color": "#75715E",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "comment.doc": {
+                        "color": "#75715E",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "constant": {
+                        "color": "#AE81FF",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "function": {
+                        "color": "#A6E22E",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "keyword": {
+                        "color": "#F92672",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "tag": {
+                        "color": "#F92672",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "number": {
+                        "color": "#AE81FF",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "string": {
+                        "color": "#E6DB74",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "string.escape": {
+                        "color": "#E6DB74",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "string.regex": {
+                        "color": "#E6DB74",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "string.special": {
+                        "color": "#E6DB74",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "string.special.symbol": {
+                        "color": "#E6DB74",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "text.literal": {
+                        "color": "#E6DB74",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "variable": {
+                        "color": "#F8F8F2",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "variable.special": {
+                        "color": "#FD971F",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "type": {
+                        "color": "#a6e22e",
+                        "font_style": "italic",
+                        "font_weight": null
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/themes/mqual_blue_zed.json
+++ b/themes/mqual_blue_zed.json
@@ -1,0 +1,365 @@
+{
+  "author": "Steven Vertigan (Original), Ported to Zed",
+  "name": "Mqual Blue",
+  "themes": [
+    {
+      "appearance": "dark",
+      "name": "Mqual Blue",
+      "style": {
+        "background": "#000087",
+        "foreground": "#ffd700",
+        
+        "border": "#008787",
+        "border.variant": "#005faf",
+        "border.focused": "#5fffff",
+        "border.selected": "#ffd700",
+        "border.transparent": "#00000000",
+        "border.disabled": "#878787",
+        
+        "elevated_surface.background": "#000087",
+        "surface.background": "#000087",
+        "panel.background": "#000087",
+        
+        "element.background": "#005faf",
+        "element.hover": "#008787",
+        "element.active": "#5fffff",
+        "element.selected": "#008787",
+        "element.disabled": "#878787",
+        
+        "ghost_element.background": "#00000000",
+        "ghost_element.hover": "#005faf",
+        "ghost_element.active": "#008787",
+        "ghost_element.selected": "#008787",
+        "ghost_element.disabled": "#878787",
+        
+        "drop_target.background": "#005faf80",
+        
+        "text": "#ffd700",
+        "text.muted": "#878787",
+        "text.placeholder": "#878787",
+        "text.disabled": "#878787",
+        "text.accent": "#5fffff",
+        
+        "icon": "#ffd700",
+        "icon.muted": "#878787",
+        "icon.disabled": "#878787",
+        "icon.placeholder": "#878787",
+        "icon.accent": "#5fffff",
+        
+        "status_bar.background": "#000087",
+        "title_bar.background": "#000087",
+        "title_bar.inactive_background": "#000087",
+        "toolbar.background": "#000087",
+        
+        "tab_bar.background": "#000087",
+        "tab.inactive_background": "#000087",
+        "tab.active_background": "#005faf",
+        
+        "search.match_background": "#ffd700",
+        
+        "panel.focused_border": "#5fffff",
+        "pane.focused_border": "#5fffff",
+        "pane_group.border": "#008787",
+        
+        "scrollbar.thumb.background": "#008787",
+        "scrollbar.thumb.hover_background": "#5fffff",
+        "scrollbar.thumb.border": "#000087",
+        "scrollbar.track.background": "#000087",
+        "scrollbar.track.border": "#000087",
+        
+        "editor.foreground": "#ffd700",
+        "editor.background": "#000087",
+        "editor.gutter.background": "#000087",
+        "editor.subheader.background": "#005faf",
+        "editor.active_line.background": "#005faf",  // vim CursorLine background
+        "editor.highlighted_line.background": "#005faf",
+        "editor.line_number": "#5fffff",  // vim LineNr
+        "editor.active_line_number": "#ffd700",  // vim CursorLineNr: gold on blue, bold
+        "editor.invisible": "#d787d7",
+        "editor.wrap_guide": "#008787",
+        "editor.active_wrap_guide": "#5fffff",
+        "editor.document_highlight.read_background": "#00878740",
+        "editor.document_highlight.write_background": "#5fffff40",
+        "editor.document_highlight.bracket_background": "#d787d740",
+        "editor.indent_guide": "#008787",
+        "editor.indent_guide_active": "#5fffff",
+        
+        "panel.indent_guide": "#008787",
+        "panel.indent_guide_active": "#5fffff",
+        "panel.indent_guide_hover": "#5fffff",
+        
+        "link_text.hover": "#5fffff",
+        
+        "conflict": "#d787d7",
+        "conflict.background": "#d787d740",
+        "conflict.border": "#d787d7",
+        
+        "created": "#00ff00",
+        "created.background": "#00ff0040",
+        "created.border": "#00ff00",
+        
+        "deleted": "#ff0000",
+        "deleted.background": "#ff000040",
+        "deleted.border": "#ff0000",
+        
+        "error": "#ff7f50",
+        "error.background": "#ff7f5040",
+        "error.border": "#ff7f50",
+        
+        "hidden": "#878787",
+        "hidden.background": "#87878740",
+        "hidden.border": "#878787",
+        
+        "hint": "#00ff00",
+        "hint.background": "#00ff0040",
+        "hint.border": "#00ff00",
+        
+        "ignored": "#878787",
+        "ignored.background": "#87878740",
+        "ignored.border": "#878787",
+        
+        "info": "#5fffff",
+        "info.background": "#5fffff40",
+        "info.border": "#5fffff",
+        
+        "modified": "#ffd700",
+        "modified.background": "#ffd70040",
+        "modified.border": "#ffd700",
+        
+        "predictive": "#bcbcbc",
+        "predictive.background": "#bcbcbc40",
+        "predictive.border": "#bcbcbc",
+        
+        "renamed": "#ffa500",
+        "renamed.background": "#ffa50040",
+        "renamed.border": "#ffa500",
+        
+        "success": "#00ff00",
+        "success.background": "#00ff0040",
+        "success.border": "#00ff00",
+        
+        "unreachable": "#878787",
+        "unreachable.background": "#87878740",
+        "unreachable.border": "#878787",
+        
+        "warning": "#d787d7",
+        "warning.background": "#d787d740",
+        "warning.border": "#d787d7",
+        
+        "players": [
+          {
+            "cursor": "#00ff00",
+            "background": "#00ff0030",
+            "selection": "#00ff0020"
+          },
+          {
+            "cursor": "#ffd700",
+            "background": "#ffd70030",
+            "selection": "#ffd70020"
+          },
+          {
+            "cursor": "#5fffff",
+            "background": "#5fffff30",
+            "selection": "#5fffff20"
+          },
+          {
+            "cursor": "#d787d7",
+            "background": "#d787d730",
+            "selection": "#d787d720"
+          },
+          {
+            "cursor": "#00ff00",
+            "background": "#00ff0030",
+            "selection": "#00ff0020"
+          },
+          {
+            "cursor": "#ff7f50",
+            "background": "#ff7f5030",
+            "selection": "#ff7f5020"
+          },
+          {
+            "cursor": "#ffa500",
+            "background": "#ffa50030",
+            "selection": "#ffa50020"
+          },
+          {
+            "cursor": "#ffffff",
+            "background": "#ffffff30",
+            "selection": "#ffffff20"
+          }
+        ],
+        
+        "syntax": {
+          "comment": {
+            "color": "#878787",
+            "font_style": "italic"
+          },
+          "comment.doc": {
+            "color": "#878787",
+            "font_style": "italic"
+          },
+          "constant": {
+            "color": "#5fffff"
+          },
+          "constant.builtin": {
+            "color": "#5fffff"
+          },
+          "constant.builtin.boolean": {
+            "color": "#5fffff"
+          },
+          "constant.character": {
+            "color": "#5fffff"
+          },
+          "constant.character.escape": {
+            "color": "#d787d7"
+          },
+          "constant.numeric": {
+            "color": "#5fffff"
+          },
+          "constructor": {
+            "color": "#ffa500",
+            "font_weight": 700
+          },
+          "embedded": {
+            "color": "#ffd700"
+          },
+          "emphasis": {
+            "color": "#5fffff"
+          },
+          "emphasis.strong": {
+            "color": "#5fffff",
+            "font_weight": 700
+          },
+          "function": {
+            "color": "#bcbcbc"
+          },
+          "function.builtin": {
+            "color": "#bcbcbc"
+          },
+          "function.method": {
+            "color": "#bcbcbc"
+          },
+          "hint": {
+            "color": "#008787",
+            "font_weight": 700
+          },
+          "keyword": {
+            "color": "#ffffff"
+          },
+          "label": {
+            "color": "#ffd700"
+          },
+          "link_text": {
+            "color": "#5fffff",
+            "font_style": "italic"
+          },
+          "link_uri": {
+            "color": "#5fffff"
+          },
+          "number": {
+            "color": "#5fffff"
+          },
+          "operator": {
+            "color": "#ffa500"
+          },
+          "predictive": {
+            "color": "#bcbcbc",
+            "font_style": "italic"
+          },
+          "preproc": {
+            "color": "#00ff00"
+          },
+          "primary": {
+            "color": "#ffd700"
+          },
+          "property": {
+            "color": "#bcbcbc"
+          },
+          "punctuation": {
+            "color": "#ffd700"
+          },
+          "punctuation.bracket": {
+            "color": "#ffd700"
+          },
+          "punctuation.delimiter": {
+            "color": "#d787d7"
+          },
+          "punctuation.list_marker": {
+            "color": "#ffd700"
+          },
+          "punctuation.special": {
+            "color": "#d787d7"
+          },
+          "string": {
+            "color": "#5fffff"
+          },
+          "string.escape": {
+            "color": "#d787d7"
+          },
+          "string.regex": {
+            "color": "#5fffff"
+          },
+          "string.special": {
+            "color": "#d787d7"
+          },
+          "string.special.symbol": {
+            "color": "#5fffff"
+          },
+          "tag": {
+            "color": "#d787d7"
+          },
+          "text.literal": {
+            "color": "#5fffff"
+          },
+          "title": {
+            "color": "#d787d7"
+          },
+          "type": {
+            "color": "#ffa500",
+            "font_weight": 700
+          },
+          "type.builtin": {
+            "color": "#ffa500",
+            "font_weight": 700
+          },
+          "variable": {
+            "color": "#bcbcbc"
+          },
+          "variable.builtin": {
+            "color": "#bcbcbc"
+          },
+          "variable.parameter": {
+            "color": "#bcbcbc"
+          },
+          "variable.special": {
+            "color": "#d787d7"
+          },
+          "variant": {
+            "color": "#ffa500"
+          }
+        },
+        
+        "terminal.background": "#000087",
+        "terminal.foreground": "#ffd700",
+        "terminal.bright_foreground": "#ffffff",
+        "terminal.dim_foreground": "#878787",
+        "terminal.ansi.black": "#000000",
+        "terminal.ansi.red": "#cd0000",
+        "terminal.ansi.green": "#00cd00",
+        "terminal.ansi.yellow": "#cdcd00",
+        "terminal.ansi.blue": "#0000ee",
+        "terminal.ansi.magenta": "#cd00cd",
+        "terminal.ansi.cyan": "#00cdcd",
+        "terminal.ansi.white": "#e5e5e5",
+        "terminal.ansi.bright_black": "#7f7f7f",
+        "terminal.ansi.bright_red": "#ff0000",
+        "terminal.ansi.bright_green": "#00ff00",
+        "terminal.ansi.bright_yellow": "#ffff00",
+        "terminal.ansi.bright_blue": "#5c5cff",
+        "terminal.ansi.bright_magenta": "#ff00ff",
+        "terminal.ansi.bright_cyan": "#00ffff",
+        "terminal.ansi.bright_white": "#ffffff"
+      }
+    }
+  ]
+}

--- a/themes/nord.json
+++ b/themes/nord.json
@@ -1,0 +1,586 @@
+{
+  "$schema": "https://zed.dev/schema/themes/v0.2.0.json",
+  "name": "Nord",
+  "author": "Sergei <Mikasius> Metlenkin",
+
+  "themes": [
+    {
+      "name": "Nord Dark",
+      "appearance": "dark",
+
+      "style": {
+        "border": "#3b4252",
+        "border.variant": "#4b5262",
+        "border.focused": "#6c99a6",
+        "border.selected": "#6c99a6",
+        "border.disabled": "#3b4252",
+        "border.transparent": "#3b4252",
+
+        "elevated_surface.background": "#3b4252",
+        "surface.background": "#2e3440",
+        "background": "#2e3440",
+
+        "element.background": "#3b4252",
+        "element.hover": "#6c99a666",
+        "element.active": "#6c99a666",
+        "element.selected": "#6c99a6",
+        "element.disabled": null,
+        "drop_target.background": "#6c99a699",
+        "ghost_element.background": null,
+        "ghost_element.hover": "#4c566a",
+        "ghost_element.active": null,
+        "ghost_element.selected": "#6c99a666",
+        "ghost_element.disabled": "#d8dee933",
+
+        "text": "#eceff4",
+        "text.muted": "#d8dee9",
+        "text.placeholder": "#d8dee966",
+        "text.disabled": "#d8dee966",
+        "text.accent": "#88C0D0",
+
+        "icon": null,
+        "icon.muted": null,
+        "icon.disabled": null,
+        "icon.placeholder": null,
+        "icon.accent": null,
+        "status_bar.background": "#3b4252",
+        "title_bar.background": "#2e3440",
+        "title_bar.inactive_background": "#3b4252",
+        "toolbar.background": "#2e3440",
+        "tab_bar.background": "#2e3440",
+        "tab.inactive_background": "#2e3440",
+        "tab.active_background": "#3b4252",
+        "search.match_background": "#88c0d033",
+        "panel.background": "#2e3440",
+        "panel.focused_border": null,
+        "pane.focused_border": null,
+        "scrollbar.thumb.background": "#434c5e99",
+        "scrollbar.thumb.hover_background": "#434c5eaa",
+        "scrollbar.thumb.border": "#434c5e99",
+        "scrollbar.track.background": "#2e3440",
+        "scrollbar.track.border": "#3b4252",
+
+        "editor.foreground": "#d8dee9",
+        "editor.background": "#2e3440",
+        "editor.gutter.background": "#2e3440",
+        "editor.subheader.background": "#3b4252",
+        "editor.active_line.background": "#3b4252",
+        "editor.highlighted_line.background": null,
+        "editor.line_number": "#4c566a",
+        "editor.active_line_number": "#d8dee9",
+        "editor.invisible": null,
+        "editor.wrap_guide": "#3b4252",
+        "editor.active_wrap_guide": "#3b4252",
+        "editor.document_highlight.read_background": "#5e81ac66",
+        "editor.document_highlight.write_background": "#5e81ac66",
+
+        "terminal.background": "#2e3440",
+        "terminal.foreground": null,
+        "terminal.bright_foreground": null,
+        "terminal.dim_foreground": null,
+        "terminal.ansi.black": "#3b4252",
+        "terminal.ansi.bright_black": "#4c566a",
+        "terminal.ansi.dim_black": null,
+        "terminal.ansi.red": "#bf616a",
+        "terminal.ansi.bright_red": "#bf616a",
+        "terminal.ansi.dim_red": null,
+        "terminal.ansi.green": "#a3be8c",
+        "terminal.ansi.bright_green": "#a3be8c",
+        "terminal.ansi.dim_green": null,
+        "terminal.ansi.yellow": "#ebcb8b",
+        "terminal.ansi.bright_yellow": "#ebcb8b",
+        "terminal.ansi.dim_yellow": null,
+        "terminal.ansi.blue": "#81a1c1",
+        "terminal.ansi.bright_blue": "#81a1c1",
+        "terminal.ansi.dim_blue": null,
+        "terminal.ansi.magenta": "#b48ead",
+        "terminal.ansi.bright_magenta": "#b48ead",
+        "terminal.ansi.dim_magenta": null,
+        "terminal.ansi.cyan": "#6c99a6",
+        "terminal.ansi.bright_cyan": "#8fbcbb",
+        "terminal.ansi.dim_cyan": null,
+        "terminal.ansi.white": "#e5e9f0",
+        "terminal.ansi.bright_white": "#eceff4",
+        "terminal.ansi.dim_white": null,
+
+        "link_text.hover": "#6c99a6",
+        "conflict": "#5e81ac",
+        "conflict.background": null,
+        "conflict.border": null,
+        "created": "#a3be8c",
+        "created.background": null,
+        "created.border": null,
+        "deleted": "#bf616a",
+        "deleted.background": null,
+        "deleted.border": null,
+        "error": "#bf616a",
+        "error.background": "#2e3440",
+        "error.border": "#bf616a",
+        "hidden": "#d8dee966",
+        "hidden.background": null,
+        "hidden.border": null,
+        "hint": "#5e81ac",
+        "hint.background": "#2e3440",
+        "hint.border": "#5e81ac",
+        "ignored": "#d8dee966",
+        "ignored.background": null,
+        "ignored.border": null,
+        "info": "#5e81ac",
+        "info.background": "#2e3440",
+        "info.border": "#5e81ac",
+        "modified": "#ebcb8b",
+        "modified.background": null,
+        "modified.border": null,
+        "predictive": null,
+        "predictive.background": null,
+        "predictive.border": null,
+        "renamed": null,
+        "renamed.background": null,
+        "renamed.border": null,
+        "success": null,
+        "success.background": null,
+        "success.border": null,
+        "unreachable": null,
+        "unreachable.background": null,
+        "unreachable.border": null,
+        "warning": "#ebcb8b",
+        "warning.background": "#2e3440",
+        "warning.border": "#ebcb8b",
+
+        "players": [
+          {
+            "cursor": "#eceff4",
+            "background": "#434c5e99",
+            "selection": "#434c5e99"
+          },
+          {
+            "cursor": "#eceff4",
+            "background": "#eceff4",
+            "selection": "#3b4252"
+          },
+          {
+            "cursor": "#d08770",
+            "background": "#d08770",
+            "selection": "#d087703d"
+          },
+          {
+            "cursor": "#a3be8c",
+            "background": "#a3be8c",
+            "selection": "#a3be8c3d"
+          },
+          {
+            "cursor": "#b48ead",
+            "background": "#b48ead",
+            "selection": "#b48ead3d"
+          },
+          {
+            "cursor": "#d08770",
+            "background": "#d08770",
+            "selection": "#d087703d"
+          }
+        ],
+
+        "syntax": {
+          "attribute": {
+            "color": "#8FBCBB",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#81A1C1",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#4C566A",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#4C566A",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#D8DEE9",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#81A1C1",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function": {
+            "color": "#88c0d0",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword": {
+            "color": "#81A1C1",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#B48EAD",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#81A1C1",
+            "font_style": null,
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#5E81AC",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#ECEFF4",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#ECEFF4",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#81A1C1",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#ECEFF4",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#ECEFF4",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#A3BE8C",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#EBCB8B",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#A3BE8C",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#A3BE8C",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#A3BE8C",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#81A1C1",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#A3BE8C",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type": {
+            "color": "#8FBCBB",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#D8DEE9",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#D8DEE9",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#88C0D0",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    },
+    {
+      "name": "Nord Light",
+      "appearance": "light",
+
+      "style": {
+        "border": "#e1e4e8",
+        "border.variant": "#e1e4e8",
+        "border.focused": "#2188ff",
+        "border.selected": "#e1e4e8",
+        "border.transparent": "#e1e4e8",
+        "border.disabled": "#e1e4e8",
+
+        "elevated_surface.background": "#fafbfc",
+        "surface.background": "#f6f8fa",
+        "background": "#eceff4",
+
+        "element.background": "#159739",
+        "element.hover": "#ebf0f4",
+        "element.active": "#ebf0f4",
+        "element.selected": "#e2e5e9",
+        "element.disabled": null,
+
+        "drop_target.background": null,
+        "ghost_element.background": null,
+        "ghost_element.hover": "#ebf0f4",
+        "ghost_element.active": "#ebf0f4",
+        "ghost_element.selected": "#e2e5e9",
+        "ghost_element.disabled": null,
+
+        "text": "#444d56",
+        "text.muted": "#6a737d",
+        "text.placeholder": null,
+        "text.disabled": null,
+        "text.accent": null,
+
+        "icon": null,
+        "icon.muted": null,
+        "icon.disabled": null,
+        "icon.placeholder": null,
+        "icon.accent": null,
+        "status_bar.background": "#e5e9f0",
+        "title_bar.background": "#e5e9f0",
+        "title_bar.inactive_background": "#eceff4",
+        "toolbar.background": "#eceff4",
+        "tab_bar.background": "#e5e9f0",
+        "tab.inactive_background": "#e5e9f0",
+        "tab.active_background": "#eceff4",
+        "search.match_background": null,
+        "panel.background": "#f6f8fa",
+        "panel.focused_border": null,
+        "pane.focused_border": null,
+        "scrollbar.thumb.background": "#959da533",
+        "scrollbar.thumb.hover_background": "#959da544",
+        "scrollbar.thumb.border": "#959da533",
+        "scrollbar.track.background": "#eceff4",
+        "scrollbar.track.border": "#ffffff",
+
+        "editor.foreground": "#24292e",
+        "editor.background": "#eceff4",
+        "editor.gutter.background": "#eceff4",
+        "editor.subheader.background": "#e5e9f0",
+        "editor.active_line.background": "#f6f8fa",
+        "editor.highlighted_line.background": null,
+        "editor.line_number": "#1b1f234d",
+        "editor.active_line_number": "#24292e",
+        "editor.invisible": null,
+        "editor.wrap_guide": "#e1e4e8",
+        "editor.active_wrap_guide": "#e1e4e8",
+        "editor.document_highlight.read_background": null,
+        "editor.document_highlight.write_background": null,
+
+        "terminal.background": null,
+        "terminal.foreground": null,
+        "terminal.bright_foreground": null,
+        "terminal.dim_foreground": null,
+        "terminal.ansi.black": null,
+        "terminal.ansi.bright_black": null,
+        "terminal.ansi.dim_black": null,
+        "terminal.ansi.red": null,
+        "terminal.ansi.bright_red": null,
+        "terminal.ansi.dim_red": null,
+        "terminal.ansi.green": null,
+        "terminal.ansi.bright_green": null,
+        "terminal.ansi.dim_green": null,
+        "terminal.ansi.yellow": null,
+        "terminal.ansi.bright_yellow": null,
+        "terminal.ansi.dim_yellow": null,
+        "terminal.ansi.blue": null,
+        "terminal.ansi.bright_blue": null,
+        "terminal.ansi.dim_blue": null,
+        "terminal.ansi.magenta": null,
+        "terminal.ansi.bright_magenta": null,
+        "terminal.ansi.dim_magenta": null,
+        "terminal.ansi.cyan": null,
+        "terminal.ansi.bright_cyan": null,
+        "terminal.ansi.dim_cyan": null,
+        "terminal.ansi.white": null,
+        "terminal.ansi.bright_white": null,
+        "terminal.ansi.dim_white": null,
+
+        "link_text.hover": "#032f62",
+        "conflict": "#e36209",
+        "conflict.background": null,
+        "conflict.border": null,
+        "created": "#28a745",
+        "created.background": null,
+        "created.border": null,
+        "deleted": "#d73a49",
+        "deleted.background": null,
+        "deleted.border": null,
+        "error": null,
+        "error.background": null,
+        "error.border": null,
+        "hidden": "#6a737d",
+        "hidden.background": null,
+        "hidden.border": null,
+        "hint": "#969696ff",
+        "hint.background": null,
+        "hint.border": null,
+        "ignored": "#959da5",
+        "ignored.background": null,
+        "ignored.border": null,
+        "info": null,
+        "info.background": null,
+        "info.border": null,
+        "modified": "#2188ff",
+        "modified.background": null,
+        "modified.border": null,
+        "predictive": null,
+        "predictive.background": null,
+        "predictive.border": null,
+        "renamed": null,
+        "renamed.background": null,
+        "renamed.border": null,
+        "success": null,
+        "success.background": null,
+        "success.border": null,
+        "unreachable": null,
+        "unreachable.background": null,
+        "unreachable.border": null,
+        "warning": null,
+        "warning.background": null,
+        "warning.border": null,
+        "players": [],
+        "syntax": {
+          "attribute": {
+            "color": "#D8DEE9",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#6A737D",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#6A737D",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#3B4252",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#0D7579",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": "#24292E",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": "#24292E",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "keyword": {
+            "color": "#D73A49",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#509546",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#CB5C69",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#CB5C69",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#3B4252",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#CB5C69",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#032F62",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#032F62",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#032F62",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#032F62",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#032F62",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#0D7579",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#032F62",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#509546",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#3B4252",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#0C60A5",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    }
+  ]
+}

--- a/themes/one.json
+++ b/themes/one.json
@@ -1,0 +1,813 @@
+{
+  "$schema": "https://zed.dev/schema/themes/v0.2.0.json",
+  "name": "One",
+  "author": "Zed Industries",
+  "themes": [
+    {
+      "name": "One Dark",
+      "appearance": "dark",
+      "style": {
+        "border": "#464b57ff",
+        "border.variant": "#363c46ff",
+        "border.focused": "#47679eff",
+        "border.selected": "#293b5bff",
+        "border.transparent": "#00000000",
+        "border.disabled": "#414754ff",
+        "elevated_surface.background": "#2f343eff",
+        "surface.background": "#2f343eff",
+        "background": "#3b414dff",
+        "element.background": "#2e343eff",
+        "element.hover": "#363c46ff",
+        "element.active": "#454a56ff",
+        "element.selected": "#454a56ff",
+        "element.disabled": "#2e343eff",
+        "drop_target.background": "#83899480",
+        "ghost_element.background": "#00000000",
+        "ghost_element.hover": "#363c46ff",
+        "ghost_element.active": "#454a56ff",
+        "ghost_element.selected": "#454a56ff",
+        "ghost_element.disabled": "#2e343eff",
+        "text": "#dce0e5ff",
+        "text.muted": "#a9afbcff",
+        "text.placeholder": "#878a98ff",
+        "text.disabled": "#878a98ff",
+        "text.accent": "#74ade8ff",
+        "icon": "#dce0e5ff",
+        "icon.muted": "#a9afbcff",
+        "icon.disabled": "#878a98ff",
+        "icon.placeholder": "#a9afbcff",
+        "icon.accent": "#74ade8ff",
+        "status_bar.background": "#3b414dff",
+        "title_bar.background": "#3b414dff",
+        "title_bar.inactive_background": "#2e343eff",
+        "toolbar.background": "#282c33ff",
+        "tab_bar.background": "#2f343eff",
+        "tab.inactive_background": "#2f343eff",
+        "tab.active_background": "#282c33ff",
+        "search.match_background": "#74ade866",
+        "search.active_match_background": "#e8af7466",
+        "panel.background": "#2f343eff",
+        "panel.focused_border": null,
+        "pane.focused_border": null,
+        "scrollbar.thumb.background": "#c8ccd44c",
+        "scrollbar.thumb.hover_background": "#363c46ff",
+        "scrollbar.thumb.border": "#363c46ff",
+        "scrollbar.track.background": "#00000000",
+        "scrollbar.track.border": "#2e333cff",
+        "editor.foreground": "#acb2beff",
+        "editor.background": "#282c33ff",
+        "editor.gutter.background": "#282c33ff",
+        "editor.subheader.background": "#2f343eff",
+        "editor.active_line.background": "#2f343ebf",
+        "editor.highlighted_line.background": "#2f343eff",
+        "editor.line_number": "#4e5a5f",
+        "editor.active_line_number": "#d0d4da",
+        "editor.hover_line_number": "#acb0b4",
+        "editor.invisible": "#878a98ff",
+        "editor.wrap_guide": "#c8ccd40d",
+        "editor.active_wrap_guide": "#c8ccd41a",
+        "editor.document_highlight.read_background": "#74ade81a",
+        "editor.document_highlight.write_background": "#555a6366",
+        "terminal.background": "#282c34ff",
+        "terminal.foreground": "#abb2bfff",
+        "terminal.bright_foreground": "#dce0e5ff",
+        "terminal.dim_foreground": "#636d83ff",
+        "terminal.ansi.black": "#282c34ff",
+        "terminal.ansi.bright_black": "#636d83ff",
+        "terminal.ansi.dim_black": "#3b3f4aff",
+        "terminal.ansi.red": "#e06c75ff",
+        "terminal.ansi.bright_red": "#EA858Bff",
+        "terminal.ansi.dim_red": "#a7545aff",
+        "terminal.ansi.green": "#98c379ff",
+        "terminal.ansi.bright_green": "#AAD581ff",
+        "terminal.ansi.dim_green": "#6d8f59ff",
+        "terminal.ansi.yellow": "#e5c07bff",
+        "terminal.ansi.bright_yellow": "#FFD885ff",
+        "terminal.ansi.dim_yellow": "#b8985bff",
+        "terminal.ansi.blue": "#61afefff",
+        "terminal.ansi.bright_blue": "#85C1FFff",
+        "terminal.ansi.dim_blue": "#457cadff",
+        "terminal.ansi.magenta": "#c678ddff",
+        "terminal.ansi.bright_magenta": "#D398EBff",
+        "terminal.ansi.dim_magenta": "#8d54a0ff",
+        "terminal.ansi.cyan": "#56b6c2ff",
+        "terminal.ansi.bright_cyan": "#6ED5DEff",
+        "terminal.ansi.dim_cyan": "#3c818aff",
+        "terminal.ansi.white": "#abb2bfff",
+        "terminal.ansi.bright_white": "#fafafaff",
+        "terminal.ansi.dim_white": "#8f969bff",
+        "link_text.hover": "#74ade8ff",
+        "version_control.added": "#27a657ff",
+        "version_control.modified": "#d3b020ff",
+        "version_control.word_added": "#2EA04859",
+        "version_control.word_deleted": "#78081BCC",
+        "version_control.deleted": "#e06c76ff",
+        "version_control.conflict_marker.ours": "#a1c1811a",
+        "version_control.conflict_marker.theirs": "#74ade81a",
+        "conflict": "#dec184ff",
+        "conflict.background": "#dec1841a",
+        "conflict.border": "#5d4c2fff",
+        "created": "#a1c181ff",
+        "created.background": "#a1c1811a",
+        "created.border": "#38482fff",
+        "deleted": "#d07277ff",
+        "deleted.background": "#d072771a",
+        "deleted.border": "#4c2b2cff",
+        "error": "#d07277ff",
+        "error.background": "#d072771a",
+        "error.border": "#4c2b2cff",
+        "hidden": "#878a98ff",
+        "hidden.background": "#696b771a",
+        "hidden.border": "#414754ff",
+        "hint": "#788ca6ff",
+        "hint.background": "#5a6f891a",
+        "hint.border": "#293b5bff",
+        "ignored": "#878a98ff",
+        "ignored.background": "#696b771a",
+        "ignored.border": "#464b57ff",
+        "info": "#74ade8ff",
+        "info.background": "#74ade81a",
+        "info.border": "#293b5bff",
+        "modified": "#dec184ff",
+        "modified.background": "#dec1841a",
+        "modified.border": "#5d4c2fff",
+        "predictive": "#5a6a87ff",
+        "predictive.background": "#5a6a871a",
+        "predictive.border": "#38482fff",
+        "renamed": "#74ade8ff",
+        "renamed.background": "#74ade81a",
+        "renamed.border": "#293b5bff",
+        "success": "#a1c181ff",
+        "success.background": "#a1c1811a",
+        "success.border": "#38482fff",
+        "unreachable": "#a9afbcff",
+        "unreachable.background": "#8389941a",
+        "unreachable.border": "#464b57ff",
+        "warning": "#dec184ff",
+        "warning.background": "#dec1841a",
+        "warning.border": "#5d4c2fff",
+        "players": [
+          {
+            "cursor": "#74ade8ff",
+            "background": "#74ade8ff",
+            "selection": "#74ade83d"
+          },
+          {
+            "cursor": "#be5046ff",
+            "background": "#be5046ff",
+            "selection": "#be50463d"
+          },
+          {
+            "cursor": "#bf956aff",
+            "background": "#bf956aff",
+            "selection": "#bf956a3d"
+          },
+          {
+            "cursor": "#b477cfff",
+            "background": "#b477cfff",
+            "selection": "#b477cf3d"
+          },
+          {
+            "cursor": "#6eb4bfff",
+            "background": "#6eb4bfff",
+            "selection": "#6eb4bf3d"
+          },
+          {
+            "cursor": "#d07277ff",
+            "background": "#d07277ff",
+            "selection": "#d072773d"
+          },
+          {
+            "cursor": "#dec184ff",
+            "background": "#dec184ff",
+            "selection": "#dec1843d"
+          },
+          {
+            "cursor": "#a1c181ff",
+            "background": "#a1c181ff",
+            "selection": "#a1c1813d"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": "#74ade8ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#bf956aff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#5d636fff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#878e98ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#dfc184ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#73ade9ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#dce0e5ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": "#74ade8ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": "#bf956aff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "enum": {
+            "color": "#d07277ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function": {
+            "color": "#73ade9ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "hint": {
+            "color": "#788ca6ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword": {
+            "color": "#b477cfff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#74ade8ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#73ade9ff",
+            "font_style": "normal",
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#6eb4bfff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#dce0e5ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#bf956aff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#6eb4bfff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predictive": {
+            "color": "#5a6a87ff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#dce0e5ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "#acb2beff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#d07277ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#acb2beff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#b2b9c6ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#b2b9c6ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#d07277ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.markup": {
+            "color": "#d07277ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#b1574bff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector": {
+            "color": "#dfc184ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector.pseudo": {
+            "color": "#74ade8ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#a1c181ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#878e98ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#bf956aff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#bf956aff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#bf956aff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#74ade8ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#a1c181ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#d07277ff",
+            "font_style": null,
+            "font_weight": 400
+          },
+          "type": {
+            "color": "#6eb4bfff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#acb2beff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#bf956aff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variant": {
+            "color": "#73ade9ff",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    },
+    {
+      "name": "One Light",
+      "appearance": "light",
+      "style": {
+        "border": "#c9c9caff",
+        "border.variant": "#dfdfe0ff",
+        "border.focused": "#7d82e8ff",
+        "border.selected": "#cbcdf6ff",
+        "border.transparent": "#00000000",
+        "border.disabled": "#d3d3d4ff",
+        "elevated_surface.background": "#ebebecff",
+        "surface.background": "#ebebecff",
+        "background": "#dcdcddff",
+        "element.background": "#ebebecff",
+        "element.hover": "#dfdfe0ff",
+        "element.active": "#cacacaff",
+        "element.selected": "#cacacaff",
+        "element.disabled": "#ebebecff",
+        "drop_target.background": "#7e808780",
+        "ghost_element.background": "#00000000",
+        "ghost_element.hover": "#dfdfe0ff",
+        "ghost_element.active": "#cacacaff",
+        "ghost_element.selected": "#cacacaff",
+        "ghost_element.disabled": "#ebebecff",
+        "text": "#242529ff",
+        "text.muted": "#58585aff",
+        "text.placeholder": "#7e8086ff",
+        "text.disabled": "#7e8086ff",
+        "text.accent": "#5c78e2ff",
+        "icon": "#242529ff",
+        "icon.muted": "#58585aff",
+        "icon.disabled": "#7e8086ff",
+        "icon.placeholder": "#58585aff",
+        "icon.accent": "#5c78e2ff",
+        "status_bar.background": "#dcdcddff",
+        "title_bar.background": "#dcdcddff",
+        "title_bar.inactive_background": "#ebebecff",
+        "toolbar.background": "#fafafaff",
+        "tab_bar.background": "#ebebecff",
+        "tab.inactive_background": "#ebebecff",
+        "tab.active_background": "#fafafaff",
+        "search.match_background": "#5c79e266",
+        "search.active_match_background": "#d0a92366",
+        "panel.background": "#ebebecff",
+        "panel.focused_border": null,
+        "pane.focused_border": null,
+        "scrollbar.thumb.background": "#383a414c",
+        "scrollbar.thumb.hover_background": "#dfdfe0ff",
+        "scrollbar.thumb.border": "#dfdfe0ff",
+        "scrollbar.track.background": "#00000000",
+        "scrollbar.track.border": "#eeeeeeff",
+        "editor.foreground": "#242529ff",
+        "editor.background": "#fafafaff",
+        "editor.gutter.background": "#fafafaff",
+        "editor.subheader.background": "#ebebecff",
+        "editor.active_line.background": "#ebebecbf",
+        "editor.highlighted_line.background": "#ebebecff",
+        "editor.line_number": "#b4b4bb",
+        "editor.active_line_number": "#44454b",
+        "editor.hover_line_number": "#61616b",
+        "editor.invisible": "#a3a3a4ff",
+        "editor.wrap_guide": "#383a410d",
+        "editor.active_wrap_guide": "#383a411a",
+        "editor.document_highlight.read_background": "#5c78e225",
+        "editor.document_highlight.write_background": "#a3a3a466",
+        "terminal.background": "#fafafaff",
+        "terminal.foreground": "#2a2c33ff",
+        "terminal.bright_foreground": "#2a2c33ff",
+        "terminal.dim_foreground": "#bbbbbbff",
+        "terminal.ansi.black": "#000000ff",
+        "terminal.ansi.bright_black": "#000000ff",
+        "terminal.ansi.dim_black": "#555555ff",
+        "terminal.ansi.red": "#de3e35ff",
+        "terminal.ansi.bright_red": "#de3e35ff",
+        "terminal.ansi.dim_red": "#9c2b26ff",
+        "terminal.ansi.green": "#3f953aff",
+        "terminal.ansi.bright_green": "#3f953aff",
+        "terminal.ansi.dim_green": "#2b6927ff",
+        "terminal.ansi.yellow": "#d2b67cff",
+        "terminal.ansi.bright_yellow": "#d2b67cff",
+        "terminal.ansi.dim_yellow": "#a48c5aff",
+        "terminal.ansi.blue": "#2f5af3ff",
+        "terminal.ansi.bright_blue": "#2f5af3ff",
+        "terminal.ansi.dim_blue": "#2140abff",
+        "terminal.ansi.magenta": "#950095ff",
+        "terminal.ansi.bright_magenta": "#a00095ff",
+        "terminal.ansi.dim_magenta": "#6a006aff",
+        "terminal.ansi.cyan": "#3f953aff",
+        "terminal.ansi.bright_cyan": "#3f953aff",
+        "terminal.ansi.dim_cyan": "#2b6927ff",
+        "terminal.ansi.white": "#bbbbbbff",
+        "terminal.ansi.bright_white": "#ffffffff",
+        "terminal.ansi.dim_white": "#888888ff",
+        "link_text.hover": "#5c78e2ff",
+        "version_control.added": "#27a657ff",
+        "version_control.modified": "#d3b020ff",
+        "version_control.word_added": "#2EA04859",
+        "version_control.word_deleted": "#F85149CC",
+        "version_control.deleted": "#e06c76ff",
+        "conflict": "#a48819ff",
+        "conflict.background": "#faf2e6ff",
+        "conflict.border": "#f4e7d1ff",
+        "created": "#669f59ff",
+        "created.background": "#dfeadbff",
+        "created.border": "#c8dcc1ff",
+        "deleted": "#d36151ff",
+        "deleted.background": "#fbdfd9ff",
+        "deleted.border": "#f6c6bdff",
+        "error": "#d36151ff",
+        "error.background": "#fbdfd9ff",
+        "error.border": "#f6c6bdff",
+        "hidden": "#7e8086ff",
+        "hidden.background": "#dcdcddff",
+        "hidden.border": "#d3d3d4ff",
+        "hint": "#7274a7ff",
+        "hint.background": "#e2e2faff",
+        "hint.border": "#cbcdf6ff",
+        "ignored": "#7e8086ff",
+        "ignored.background": "#dcdcddff",
+        "ignored.border": "#c9c9caff",
+        "info": "#5c78e2ff",
+        "info.background": "#e2e2faff",
+        "info.border": "#cbcdf6ff",
+        "modified": "#a48819ff",
+        "modified.background": "#faf2e6ff",
+        "modified.border": "#f4e7d1ff",
+        "predictive": "#9b9ec6ff",
+        "predictive.background": "#dfeadbff",
+        "predictive.border": "#c8dcc1ff",
+        "renamed": "#5c78e2ff",
+        "renamed.background": "#e2e2faff",
+        "renamed.border": "#cbcdf6ff",
+        "success": "#669f59ff",
+        "success.background": "#dfeadbff",
+        "success.border": "#c8dcc1ff",
+        "unreachable": "#58585aff",
+        "unreachable.background": "#dcdcddff",
+        "unreachable.border": "#c9c9caff",
+        "warning": "#a48819ff",
+        "warning.background": "#faf2e6ff",
+        "warning.border": "#f4e7d1ff",
+        "players": [
+          {
+            "cursor": "#5c78e2ff",
+            "background": "#5c78e2ff",
+            "selection": "#5c78e23d"
+          },
+          {
+            "cursor": "#984ea5ff",
+            "background": "#984ea5ff",
+            "selection": "#984ea53d"
+          },
+          {
+            "cursor": "#ad6e26ff",
+            "background": "#ad6e26ff",
+            "selection": "#ad6e263d"
+          },
+          {
+            "cursor": "#a349abff",
+            "background": "#a349abff",
+            "selection": "#a349ab3d"
+          },
+          {
+            "cursor": "#3a82b7ff",
+            "background": "#3a82b7ff",
+            "selection": "#3a82b73d"
+          },
+          {
+            "cursor": "#d36151ff",
+            "background": "#d36151ff",
+            "selection": "#d361513d"
+          },
+          {
+            "cursor": "#a48819ff",
+            "background": "#dec184ff",
+            "selection": "#dec1843d"
+          },
+          {
+            "cursor": "#669f59ff",
+            "background": "#669f59ff",
+            "selection": "#669f593d"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": "#5c78e2ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#ad6e25ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#a2a3a7ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#7c7e86ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#c18401ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#5c78e2ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#242529ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": "#5c78e2ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": "#ad6e25ff",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "enum": {
+            "color": "#d3604fff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function": {
+            "color": "#5b79e3ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "hint": {
+            "color": "#7274a7ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword": {
+            "color": "#a449abff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#5c78e2ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#5b79e3ff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#3882b7ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#242529ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#ad6e25ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#3882b7ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predictive": {
+            "color": "#9b9ec6ff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#242529ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "#242529ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#d3604fff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#242529ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#4d4f52ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#4d4f52ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#d3604fff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.markup": {
+            "color": "#d3604fff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#b92b46ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector": {
+            "color": "#669f59ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector.pseudo": {
+            "color": "#5c78e2ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#649f57ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#7c7e86ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#ad6e26ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#ad6e26ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#ad6e26ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#5c78e2ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#649f57ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#d3604fff",
+            "font_style": null,
+            "font_weight": 400
+          },
+          "type": {
+            "color": "#3882b7ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#242529ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#ad6e25ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variant": {
+            "color": "#5b79e3ff",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    }
+  ]
+}

--- a/themes/rose-pine.json
+++ b/themes/rose-pine.json
@@ -1,0 +1,293 @@
+{
+    "$schema": "https://zed.dev/schema/themes/v0.2.0.json",
+    "name": "Rosé Pine",
+    "author": "Kainoa Kanter <kainoa@t1c.dev>",
+    "themes": [
+        {
+            "appearance": "dark",
+            "name": "Rosé Pine",
+            "style": {
+                "editor.foreground": "#e0def4",
+                "editor.background": "#191724",
+                "editor.gutter.background": "#191724",
+                "editor.active_line.background": "#1f1d2e",
+                "editor.line_number": "#6e6a86",
+                "editor.active_line_number": "#e0def4",
+                "editor.indent_guide": "#6e6a8688",
+                "editor.indent_guide_active": "#908caaaa",
+                "editor.invisible": "#6e6a86",
+                "editor.wrap_guide": "#6e6a8644",
+                "editor.active_wrap_guide": "#6e6a8688",
+                "editor.document_highlight.read_background": "#9ccfd81a",
+                "editor.document_highlight.write_background": "#6e6a8666",
+                "editor.subheader.background": "#1f1d2e",
+                "editor.highlighted_line.background": "#1f1d2e",
+                "ghost_element.active": "#908caa",
+                "ghost_element.hover": "#403d52",
+                "ghost_element.selected": "#524f67",
+                "ghost_element.background": "#21202e",
+                "border": "#1f1d2e",
+                "border.variant": "#1f1d2e",
+                "border.focused": "#1f1d2e",
+                "border.selected": "#1f1d2e",
+                "border.transparent": "transparent",
+                "border.disabled": "#1f1d2e",
+                "text": "#e0def4",
+                "text.muted": "#6e6a86",
+                "text.placeholder": "#6e6a86",
+                "text.disabled": "#6e6a86",
+                "text.accent": "#9ccfd8",
+                "surface.background": "#1f1d2e",
+                "elevated_surface.background": "#1f1d2e",
+                "panel.background": "#191724",
+                "panel.focused_border": "#c4a7e744",
+                "background": "#191724",
+                "status_bar.background": "#191724",
+                "title_bar.background": "#191724",
+                "title_bar.inactive_background": "#191724",
+                "toolbar.background": "#191724",
+                "tab_bar.background": "#1f1d2e",
+                "tab.inactive_background": "#1f1d2e",
+                "tab.active_background": "#191724",
+                "element.background": "#1f1d2e",
+                "element.hover": "#26233a",
+                "element.active": "#26233a",
+                "element.selected": "#524f67",
+                "element.disabled": "#26233a",
+                "drop_target.background": "#e0def480",
+                "predictive": "#6e6a86",
+                "modified": "#ebbcba",
+                "ignored": "#6e6a86",
+                "deleted": "#eb6f92",
+                "created": "#9ccfd8",
+                "warning": "#f6c177",
+                "warning.background": "#21202e",
+                "warning.border": "#f6c177",
+                "hint": "#908caa",
+                "hint.background": "#21202e",
+                "error": "#eb6f92",
+                "error.background": "#21202e",
+                "error.border": "#eb6f92",
+                "info": "#31748f",
+                "scrollbar.thumb.background": "#403d524d",
+                "scrollbar.thumb.hover_background": "#1f1d2e4d",
+                "scrollbar.thumb.border": "#21202e4d",
+                "scrollbar.track.background": "#00000000",
+                "scrollbar.track.border": "#21202e4d",
+                "terminal.background": "#191724",
+                "terminal.foreground": "#e0def4",
+                "terminal.bright_foreground": "#e0def4",
+                "terminal.dim_foreground": "#191724",
+                "terminal.ansi.black": "#21202e",
+                "terminal.ansi.bright_black": "#908caa",
+                "terminal.ansi.dim_black": "#e0def4",
+                "terminal.ansi.red": "#eb6f92",
+                "terminal.ansi.bright_red": "#eb6f92",
+                "terminal.ansi.dim_red": "#eb6f92",
+                "terminal.ansi.green": "#31748f",
+                "terminal.ansi.bright_green": "#31748f",
+                "terminal.ansi.dim_green": "#31748f",
+                "terminal.ansi.yellow": "#f6c177",
+                "terminal.ansi.bright_yellow": "#f6c177",
+                "terminal.ansi.dim_yellow": "#f6c177",
+                "terminal.ansi.blue": "#9ccfd8",
+                "terminal.ansi.bright_blue": "#9ccfd8",
+                "terminal.ansi.dim_blue": "#9ccfd8",
+                "terminal.ansi.magenta": "#c4a7e7",
+                "terminal.ansi.bright_magenta": "#c4a7e7",
+                "terminal.ansi.dim_magenta": "#c4a7e7",
+                "terminal.ansi.cyan": "#ebbcba",
+                "terminal.ansi.bright_cyan": "#ebbcba",
+                "terminal.ansi.dim_cyan": "#ebbcba",
+                "terminal.ansi.white": "#e0def4",
+                "terminal.ansi.bright_white": "#e0def4",
+                "terminal.ansi.dim_white": "#e0def4",
+                "link_text.hover": "#9ccfd8",
+                "conflict": "#f6c177",
+                "conflict.background": "#21202e",
+                "conflict.border": "#f6c177",
+                "created.background": "#21202e",
+                "created.border": "#9ccfd8",
+                "deleted.background": "#21202e",
+                "deleted.border": "#eb6f92",
+                "hidden.background": "#191724",
+                "hidden.border": "#1f1d2e",
+                "ignored.background": "#191724",
+                "ignored.border": "#1f1d2e",
+                "info.background": "#21202e",
+                "info.border": "#31748f",
+                "modified.background": "#21202e",
+                "modified.border": "#ebbcba",
+                "predictive.background": "#21202e",
+                "predictive.border": "#31748f",
+                "renamed.background": "#21202e",
+                "renamed.border": "#31748f",
+                "success": "#31748f",
+                "success.background": "#21202e",
+                "success.border": "#31748f",
+                "unreachable": "#908caa",
+                "unreachable.background": "#191724",
+                "unreachable.border": "#1f1d2e",
+                "version_control.added": "#9ccfd8",
+                "version_control.deleted": "#eb6f92",
+                "version_control.modified": "#f6c177",
+                "version_control.conflict": "#ebbcba",
+                "version_control.renamed": "#c4a7e7",
+                "version_control.ignored": "#6e6a86",
+                "version_control.conflict_marker.ours": "#f6c17733",
+                "version_control.conflict_marker.theirs": "#9ccfd833",
+                "players": [
+                    {
+                        "cursor": "#e0def4",
+                        "background": "#e0def4",
+                        "selection": "#e0def422"
+                    },
+                    {
+                        "cursor": "#9ccfd8",
+                        "background": "#9ccfd8",
+                        "selection": "#9ccfd844"
+                    },
+                    {
+                        "cursor": "#c4a7e7",
+                        "background": "#c4a7e7",
+                        "selection": "#c4a7e744"
+                    },
+                    {
+                        "cursor": "#31748f",
+                        "background": "#31748f",
+                        "selection": "#31748f44"
+                    },
+                    {
+                        "cursor": "#eb6f92",
+                        "background": "#eb6f92",
+                        "selection": "#eb6f9244"
+                    }
+                ],
+                "syntax": {
+                    "attribute": {
+                        "color": "#908caa"
+                    },
+                    "boolean": {
+                        "color": "#ebbcba"
+                    },
+                    "comment": {
+                        "color": "#6e6a86",
+                        "font_style": "italic"
+                    },
+                    "comment.doc": {
+                        "color": "#908caa"
+                    },
+                    "constant": {
+                        "color": "#e0def4"
+                    },
+                    "constructor": {
+                        "color": "#eb6f92"
+                    },
+                    "embedded": {
+                        "color": "#e0def4"
+                    },
+                    "emphasis": {
+                        "color": "#c4a7e7",
+                        "font_style": "italic"
+                    },
+                    "emphasis.strong": {
+                        "color": "#9ccfd8",
+                        "font_weight": 700
+                    },
+                    "enum": {
+                        "color": "#31748f"
+                    },
+                    "function": {
+                        "color": "#ebbcba"
+                    },
+                    "hint": {
+                        "color": "#c4a7e7"
+                    },
+                    "keyword": {
+                        "color": "#31748f"
+                    },
+                    "label": {
+                        "color": "#ebbcba"
+                    },
+                    "link_text": {
+                        "color": "#c4a7e7"
+                    },
+                    "link_uri": {
+                        "color": "#31748f"
+                    },
+                    "number": {
+                        "color": "#9ccfd8"
+                    },
+                    "operator": {
+                        "color": "#908caa"
+                    },
+                    "predictive": {
+                        "color": "#908caa"
+                    },
+                    "preproc": {
+                        "color": "#f6c177"
+                    },
+                    "primary": {
+                        "color": "#c4a7e7"
+                    },
+                    "property": {
+                        "color": "#e0def4"
+                    },
+                    "punctuation": {
+                        "color": "#908caa"
+                    },
+                    "punctuation.bracket": {
+                        "color": "#908caa"
+                    },
+                    "punctuation.delimiter": {
+                        "color": "#908caa"
+                    },
+                    "punctuation.list_marker": {
+                        "color": "#908caa",
+                        "font_weight": 700
+                    },
+                    "ion.special": {
+                        "color": "#31748f"
+                    },
+                    "string": {
+                        "color": "#f6c177"
+                    },
+                    "string.escape": {
+                        "color": "#f6c177"
+                    },
+                    "string.regex": {
+                        "color": "#f6c177"
+                    },
+                    "string.special": {
+                        "color": "#31748f"
+                    },
+                    "string.special.symbol": {
+                        "color": "#31748f"
+                    },
+                    "tag": {
+                        "color": "#c4a7e7"
+                    },
+                    "text.literal": {
+                        "color": "#f6c177"
+                    },
+                    "title": {
+                        "color": "#eb6f92",
+                        "font_weight": 700
+                    },
+                    "type": {
+                        "color": "#9ccfd8"
+                    },
+                    "variable": {
+                        "color": "#e0def4"
+                    },
+                    "variable.special": {
+                        "color": "#9ccfd8"
+                    },
+                    "variant": {
+                        "color": "#ebbcba"
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/themes/solarized.json
+++ b/themes/solarized.json
@@ -1,0 +1,633 @@
+{
+  "$schema": "https://zed.dev/schema/themes/v0.2.0.json",
+  "author": "harmtemolder",
+  "name": "Solarized",
+  "themes": [
+    {
+      "appearance": "dark",
+      "name": "Solarized Dark",
+      "style": {
+        "accents": [
+          "#268bd2"
+        ],
+        "background": "#002b36",
+        "background.appearance": "transparent",
+        "border": "#586e75",
+        "border.disabled": null,
+        "border.focused": "#839496",
+        "border.selected": "#268bd2",
+        "border.transparent": null,
+        "border.variant": null,
+        "conflict": "#dc322f",
+        "conflict.background": "#002b36",
+        "conflict.border": "#dc322f",
+        "created": "#859900",
+        "created.background": "#002b36",
+        "created.border": "#859900",
+        "deleted": "#cb4b16",
+        "deleted.background": "#002b36",
+        "deleted.border": "#cb4b16",
+        "drop_target.background": "#073642",
+        "editor.active_line.background": "#073642",
+        "editor.active_line_number": "#839496",
+        "editor.active_wrap_guide": "#586e75",
+        "editor.background": "#002b36",
+        "editor.document_highlight.bracket_background": "#268bd266",
+        "editor.document_highlight.read_background": "#268bd233",
+        "editor.document_highlight.write_background": "#268bd233",
+        "editor.foreground": "#839496",
+        "editor.gutter.background": "#002b36",
+        "editor.highlighted_line.background": "#002b36",
+        "editor.indent_guide": "#073642",
+        "editor.indent_guide_active": "#cb4b16",
+        "editor.invisible": "#073642",
+        "editor.line_number": "#586e75",
+        "editor.subheader.background": "#002b36",
+        "editor.wrap_guide": "#073642",
+        "element.active": "#073642",
+        "element.background": "#073642",
+        "element.disabled": "#073642",
+        "element.hover": "#073642",
+        "element.selected": "#268bd266",
+        "elevated_surface.background": "#002b36",
+        "error": "#dc322f",
+        "error.background": "#002b36",
+        "error.border": "#dc322f",
+        "ghost_element.active": "#839496",
+        "ghost_element.background": "#073642",
+        "ghost_element.disabled": "#586e75",
+        "ghost_element.hover": "#268bd266",
+        "ghost_element.selected": "#268bd266",
+        "hidden": "#586e75",
+        "hidden.background": "#002b36",
+        "hidden.border": "#002b36",
+        "hint": "#586e75AA",
+        "hint.background": "#002b3600",
+        "hint.border": "#586e75",
+        "icon": "#839496",
+        "icon.accent": "#268bd2",
+        "icon.disabled": "#586e75",
+        "icon.muted": "#586e75",
+        "icon.placeholder": "#586e75",
+        "ignored": "#586e75",
+        "ignored.background": "#002b36",
+        "ignored.border": "#586e75",
+        "info": "#268bd2",
+        "info.background": "#002b36",
+        "info.border": "#268bd2",
+        "link_text.hover": "#268bd2",
+        "modified": "#b58900",
+        "modified.background": "#002b36",
+        "modified.border": "#b58900",
+        "pane.focused_border": "#268bd2",
+        "pane_group.border": "#839496",
+        "panel.background": "#073642",
+        "panel.focused_border": "#268bd2",
+        "panel.indent_guide": "#586e75",
+        "panel.indent_guide_active": "#cb4b16",
+        "panel.indent_guide_hover": "#839496",
+        "players": [
+          {
+            "background": "#268bd2",
+            "cursor": "#268bd2",
+            "selection": "#268bd266"
+          },
+          {
+            "background": "#2aa198",
+            "cursor": "#2aa198",
+            "selection": "#2aa19866"
+          },
+          {
+            "background": "#859900",
+            "cursor": "#859900",
+            "selection": "#85990066"
+          },
+          {
+            "background": "#d33682",
+            "cursor": "#d33682",
+            "selection": "#d3368266"
+          },
+          {
+            "background": "#cb4b16",
+            "cursor": "#cb4b16",
+            "selection": "#cb4b1666"
+          },
+          {
+            "background": "#dc322f",
+            "cursor": "#dc322f",
+            "selection": "#dc322f66"
+          },
+          {
+            "background": "#6c71c4",
+            "cursor": "#6c71c4",
+            "selection": "#6c71c466"
+          },
+          {
+            "background": "#b58900",
+            "cursor": "#b58900",
+            "selection": "#b5890066"
+          }
+        ],
+        "predictive": "#d33682",
+        "predictive.background": "#002b3600",
+        "predictive.border": "#d33682",
+        "renamed": "#d33682",
+        "renamed.background": "#002b3600",
+        "renamed.border": "#d33682",
+        "scrollbar.thumb.background": "#073642BB",
+        "scrollbar.thumb.border": null,
+        "scrollbar.thumb.hover_background": "#073642",
+        "scrollbar.track.background": null,
+        "scrollbar.track.border": "#073642",
+        "search.match_background": "#b5890099",
+        "status_bar.background": "#073642",
+        "success": "#859900",
+        "success.background": "#002b3600",
+        "success.border": "#859900",
+        "surface.background": "#002b36",
+        "syntax": {
+          "attribute": {
+            "color": "#268bd2"
+          },
+          "boolean": {
+            "color": "#b58900"
+          },
+          "comment": {
+            "color": "#586e75",
+            "font_style": "italic"
+          },
+          "comment.doc": {
+            "color": "#586e75",
+            "font_style": "italic"
+          },
+          "constant": {
+            "color": "#2aa198"
+          },
+          "constructor": {
+            "color": "#268bd2"
+          },
+          "embedded": {
+            "color": "#839496"
+          },
+          "emphasis": {
+            "color": "#268bd2"
+          },
+          "emphasis.strong": {
+            "color": "#268bd2",
+            "font_weight": 700
+          },
+          "enum": {
+            "color": "#cb4b16"
+          },
+          "function": {
+            "color": "#268bd2"
+          },
+          "hint": {
+            "color": "#4f8297ff",
+            "font_weight": 700
+          },
+          "keyword": {
+            "color": "#859900"
+          },
+          "label": {
+            "color": "#268bd2"
+          },
+          "link_text": {
+            "color": "#268bd2",
+            "font_style": "italic"
+          },
+          "link_uri": {
+            "color": "#6c71c4"
+          },
+          "number": {
+            "color": "#d33682"
+          },
+          "operator": {
+            "color": "#859900"
+          },
+          "predictive": {
+            "background_color": "#002b36",
+            "color": "#d33682"
+          },
+          "preproc": {
+            "color": "#cb4b16"
+          },
+          "primary": {
+            "color": "#839496"
+          },
+          "property": {
+            "color": "#268bd2"
+          },
+          "punctuation": {
+            "color": "#586e75"
+          },
+          "punctuation.bracket": {
+            "color": "#586e75"
+          },
+          "punctuation.delimiter": {
+            "color": "#586e75"
+          },
+          "punctuation.list_marker": {
+            "color": "#586e75"
+          },
+          "punctuation.special": {
+            "color": "#586e75"
+          },
+          "string": {
+            "color": "#2aa198"
+          },
+          "string.escape": {
+            "color": "#586e75"
+          },
+          "string.regex": {
+            "color": "#cb4b16"
+          },
+          "string.special": {
+            "color": "#cb4b16"
+          },
+          "string.special.symbol": {
+            "color": "#cb4b16"
+          },
+          "tag": {
+            "color": "#dc322f"
+          },
+          "text.literal": {
+            "color": "#2aa198"
+          },
+          "title": {
+            "color": "#cb4b16",
+            "font_weight": 700
+          },
+          "type": {
+            "color": "#b58900"
+          },
+          "variable": {
+            "color": "#839496"
+          },
+          "variant": {
+            "color": "#268bd2"
+          }
+        },
+        "tab.active_background": "#002b36",
+        "tab.inactive_background": "#073642",
+        "tab_bar.background": "#073642",
+        "terminal.ansi.background": "#002b36",
+        "terminal.ansi.black": "#073642",
+        "terminal.ansi.blue": "#268bd2",
+        "terminal.ansi.bright_black": "#002b36",
+        "terminal.ansi.bright_blue": "#839496",
+        "terminal.ansi.bright_cyan": "#93a1a1",
+        "terminal.ansi.bright_green": "#586e75",
+        "terminal.ansi.bright_magenta": "#6c71c4",
+        "terminal.ansi.bright_red": "#cb4b16",
+        "terminal.ansi.bright_white": "#fdf6e3",
+        "terminal.ansi.bright_yellow": "#657b83",
+        "terminal.ansi.cyan": "#2aa198",
+        "terminal.ansi.dim_black": "#073642",
+        "terminal.ansi.dim_blue": "#268bd2",
+        "terminal.ansi.dim_cyan": "#2aa198",
+        "terminal.ansi.dim_green": "#859900",
+        "terminal.ansi.dim_magenta": "#d33682",
+        "terminal.ansi.dim_red": "#dc322f",
+        "terminal.ansi.dim_white": "#eee8d5",
+        "terminal.ansi.dim_yellow": "#b58900",
+        "terminal.ansi.green": "#859900",
+        "terminal.ansi.magenta": "#d33682",
+        "terminal.ansi.red": "#dc322f",
+        "terminal.ansi.white": "#eee8d5",
+        "terminal.ansi.yellow": "#b58900",
+        "terminal.background": "#002b36",
+        "terminal.bright_foreground": "#93a1a1",
+        "terminal.dim_foreground": "#586e75",
+        "terminal.foreground": "#839496",
+        "text": "#839496",
+        "text.accent": "#93a1a1",
+        "text.disabled": "#586e75",
+        "text.muted": "#586e75",
+        "text.placeholder": "#586e75",
+        "title_bar.background": "#073642",
+        "title_bar.inactive_background": "#073642",
+        "toolbar.background": "#002b36",
+        "unreachable": "#6c71c4",
+        "unreachable.background": "#002b36",
+        "unreachable.border": "#6c71c4",
+        "warning": "#cb4b16",
+        "warning.background": "#002b36",
+        "warning.border": "#cb4b16"
+      }
+    },
+    {
+      "appearance": "light",
+      "name": "Solarized Light",
+      "style": {
+        "accents": [
+          "#268bd2"
+        ],
+        "background": "#fdf6e3",
+        "background.appearance": "transparent",
+        "border": "#93a1a1",
+        "border.disabled": null,
+        "border.focused": "#657b83",
+        "border.selected": "#268bd2",
+        "border.transparent": null,
+        "border.variant": null,
+        "conflict": "#dc322f",
+        "conflict.background": "#fdf6e3",
+        "conflict.border": "#dc322f",
+        "created": "#859900",
+        "created.background": "#fdf6e3",
+        "created.border": "#859900",
+        "deleted": "#cb4b16",
+        "deleted.background": "#fdf6e3",
+        "deleted.border": "#cb4b16",
+        "drop_target.background": "#eee8d5",
+        "editor.active_line.background": "#eee8d5",
+        "editor.active_line_number": "#657b83",
+        "editor.active_wrap_guide": "#93a1a1",
+        "editor.background": "#fdf6e3",
+        "editor.document_highlight.bracket_background": "#268bd266",
+        "editor.document_highlight.read_background": "#268bd233",
+        "editor.document_highlight.write_background": "#268bd233",
+        "editor.foreground": "#657b83",
+        "editor.gutter.background": "#fdf6e3",
+        "editor.highlighted_line.background": "#fdf6e3",
+        "editor.indent_guide": "#eee8d5",
+        "editor.indent_guide_active": "#cb4b16",
+        "editor.invisible": "#eee8d5",
+        "editor.line_number": "#93a1a1",
+        "editor.subheader.background": "#fdf6e3",
+        "editor.wrap_guide": "#eee8d5",
+        "element.active": "#eee8d5",
+        "element.background": "#eee8d5",
+        "element.disabled": "#eee8d5",
+        "element.hover": "#eee8d5",
+        "element.selected": "#268bd266",
+        "elevated_surface.background": "#fdf6e3",
+        "error": "#dc322f",
+        "error.background": "#fdf6e3",
+        "error.border": "#dc322f",
+        "ghost_element.active": "#657b83",
+        "ghost_element.background": "#eee8d5",
+        "ghost_element.disabled": "#93a1a1",
+        "ghost_element.hover": "#268bd266",
+        "ghost_element.selected": "#268bd266",
+        "hidden": "#93a1a1",
+        "hidden.background": "#fdf6e3",
+        "hidden.border": "#fdf6e3",
+        "hint": "#93a1a1AA",
+        "hint.background": "#fdf6e300",
+        "hint.border": "#93a1a1",
+        "icon": "#657b83",
+        "icon.accent": "#268bd2",
+        "icon.disabled": "#93a1a1",
+        "icon.muted": "#93a1a1",
+        "icon.placeholder": "#93a1a1",
+        "ignored": "#93a1a1",
+        "ignored.background": "#fdf6e3",
+        "ignored.border": "#93a1a1",
+        "info": "#268bd2",
+        "info.background": "#fdf6e3",
+        "info.border": "#268bd2",
+        "link_text.hover": "#268bd2",
+        "modified": "#b58900",
+        "modified.background": "#fdf6e3",
+        "modified.border": "#b58900",
+        "pane.focused_border": "#268bd2",
+        "pane_group.border": "#657b83",
+        "panel.background": "#eee8d5",
+        "panel.focused_border": "#268bd2",
+        "panel.indent_guide": "#93a1a1",
+        "panel.indent_guide_active": "#cb4b16",
+        "panel.indent_guide_hover": "#657b83",
+        "players": [
+          {
+            "background": "#268bd2",
+            "cursor": "#268bd2",
+            "selection": "#268bd266"
+          },
+          {
+            "background": "#2aa198",
+            "cursor": "#2aa198",
+            "selection": "#2aa19866"
+          },
+          {
+            "background": "#859900",
+            "cursor": "#859900",
+            "selection": "#85990066"
+          },
+          {
+            "background": "#d33682",
+            "cursor": "#d33682",
+            "selection": "#d3368266"
+          },
+          {
+            "background": "#cb4b16",
+            "cursor": "#cb4b16",
+            "selection": "#cb4b1666"
+          },
+          {
+            "background": "#dc322f",
+            "cursor": "#dc322f",
+            "selection": "#dc322f66"
+          },
+          {
+            "background": "#6c71c4",
+            "cursor": "#6c71c4",
+            "selection": "#6c71c466"
+          },
+          {
+            "background": "#b58900",
+            "cursor": "#b58900",
+            "selection": "#b5890066"
+          }
+        ],
+        "predictive": "#d33682",
+        "predictive.background": "#fdf6e300",
+        "predictive.border": "#d33682",
+        "renamed": "#d33682",
+        "renamed.background": "#fdf6e300",
+        "renamed.border": "#d33682",
+        "scrollbar.thumb.background": "#eee8d5BB",
+        "scrollbar.thumb.border": null,
+        "scrollbar.thumb.hover_background": "#eee8d5",
+        "scrollbar.track.background": null,
+        "scrollbar.track.border": "#eee8d5",
+        "search.match_background": "#b5890099",
+        "status_bar.background": "#eee8d5",
+        "success": "#859900",
+        "success.background": "#fdf6e300",
+        "success.border": "#859900",
+        "surface.background": "#fdf6e3",
+        "syntax": {
+          "attribute": {
+            "color": "#268bd2"
+          },
+          "boolean": {
+            "color": "#b58900"
+          },
+          "comment": {
+            "color": "#93a1a1",
+            "font_style": "italic"
+          },
+          "comment.doc": {
+            "color": "#93a1a1",
+            "font_style": "italic"
+          },
+          "constant": {
+            "color": "#2aa198"
+          },
+          "constructor": {
+            "color": "#268bd2"
+          },
+          "embedded": {
+            "color": "#657b83"
+          },
+          "emphasis": {
+            "color": "#268bd2"
+          },
+          "emphasis.strong": {
+            "color": "#268bd2",
+            "font_weight": 700
+          },
+          "enum": {
+            "color": "#cb4b16"
+          },
+          "function": {
+            "color": "#268bd2"
+          },
+          "hint": {
+            "color": "#4f8297ff",
+            "font_weight": 700
+          },
+          "keyword": {
+            "color": "#859900"
+          },
+          "label": {
+            "color": "#268bd2"
+          },
+          "link_text": {
+            "color": "#268bd2",
+            "font_style": "italic"
+          },
+          "link_uri": {
+            "color": "#6c71c4"
+          },
+          "number": {
+            "color": "#d33682"
+          },
+          "operator": {
+            "color": "#859900"
+          },
+          "predictive": {
+            "background_color": "#fdf6e3",
+            "color": "#d33682"
+          },
+          "preproc": {
+            "color": "#cb4b16"
+          },
+          "primary": {
+            "color": "#657b83"
+          },
+          "property": {
+            "color": "#268bd2"
+          },
+          "punctuation": {
+            "color": "#93a1a1"
+          },
+          "punctuation.bracket": {
+            "color": "#93a1a1"
+          },
+          "punctuation.delimiter": {
+            "color": "#93a1a1"
+          },
+          "punctuation.list_marker": {
+            "color": "#93a1a1"
+          },
+          "punctuation.special": {
+            "color": "#93a1a1"
+          },
+          "string": {
+            "color": "#2aa198"
+          },
+          "string.escape": {
+            "color": "#93a1a1"
+          },
+          "string.regex": {
+            "color": "#cb4b16"
+          },
+          "string.special": {
+            "color": "#cb4b16"
+          },
+          "string.special.symbol": {
+            "color": "#cb4b16"
+          },
+          "tag": {
+            "color": "#dc322f"
+          },
+          "text.literal": {
+            "color": "#2aa198"
+          },
+          "title": {
+            "color": "#cb4b16",
+            "font_weight": 700
+          },
+          "type": {
+            "color": "#b58900"
+          },
+          "variable": {
+            "color": "#657b83"
+          },
+          "variant": {
+            "color": "#268bd2"
+          }
+        },
+        "tab.active_background": "#fdf6e3",
+        "tab.inactive_background": "#eee8d5",
+        "tab_bar.background": "#eee8d5",
+        "terminal.ansi.background": "#fdf6e3",
+        "terminal.ansi.black": "#073642",
+        "terminal.ansi.blue": "#268bd2",
+        "terminal.ansi.bright_black": "#002b36",
+        "terminal.ansi.bright_blue": "#839496",
+        "terminal.ansi.bright_cyan": "#93a1a1",
+        "terminal.ansi.bright_green": "#586e75",
+        "terminal.ansi.bright_magenta": "#6c71c4",
+        "terminal.ansi.bright_red": "#cb4b16",
+        "terminal.ansi.bright_white": "#fdf6e3",
+        "terminal.ansi.bright_yellow": "#657b83",
+        "terminal.ansi.cyan": "#2aa198",
+        "terminal.ansi.dim_black": "#073642",
+        "terminal.ansi.dim_blue": "#268bd2",
+        "terminal.ansi.dim_cyan": "#2aa198",
+        "terminal.ansi.dim_green": "#859900",
+        "terminal.ansi.dim_magenta": "#d33682",
+        "terminal.ansi.dim_red": "#dc322f",
+        "terminal.ansi.dim_white": "#eee8d5",
+        "terminal.ansi.dim_yellow": "#b58900",
+        "terminal.ansi.green": "#859900",
+        "terminal.ansi.magenta": "#d33682",
+        "terminal.ansi.red": "#dc322f",
+        "terminal.ansi.white": "#eee8d5",
+        "terminal.ansi.yellow": "#b58900",
+        "terminal.background": "#fdf6e3",
+        "terminal.bright_foreground": "#586e75",
+        "terminal.dim_foreground": "#93a1a1",
+        "terminal.foreground": "#657b83",
+        "text": "#657b83",
+        "text.accent": "#586e75",
+        "text.disabled": "#93a1a1",
+        "text.muted": "#93a1a1",
+        "text.placeholder": "#93a1a1",
+        "title_bar.background": "#eee8d5",
+        "title_bar.inactive_background": "#eee8d5",
+        "toolbar.background": "#fdf6e3",
+        "unreachable": "#6c71c4",
+        "unreachable.background": "#fdf6e3",
+        "unreachable.border": "#6c71c4",
+        "warning": "#cb4b16",
+        "warning.background": "#fdf6e3",
+        "warning.border": "#cb4b16"
+      }
+    }
+  ]
+}

--- a/themes/tokyo-night.json
+++ b/themes/tokyo-night.json
@@ -1,0 +1,2566 @@
+{
+  "$schema": "https://zed.dev/schema/themes/v0.2.0.json",
+  "name": "Tokyo Night",
+  "author": "Tokyo Night: Zed Theme Importer",
+  "themes": [
+    {
+      "name": "Tokyo Night",
+      "appearance": "dark",
+      "style": {
+        "accents": [
+          "#bb9af766",
+          "#7aa2f766", 
+          "#9ece6a66",
+          "#73daca66",
+          "#e0af6866",
+          "#ff9e6466",
+          "#f7768e66"
+        ],
+        "background.appearance": "opaque",
+        "border": "#101014",
+        "border.variant": "#101014",
+        "border.focused": "#545c7e33",
+        "border.selected": "#101014",
+        "border.transparent": "#101014",
+        "border.disabled": "#101014",
+        "elevated_surface.background": "#14141b",
+        "surface.background": "#16161e",
+        "background": "#1a1b26",
+        "element.background": "#1a1b26",
+        "element.hover": "#565f89",
+        "element.active": "#9aa5ce",
+        "element.selected": "#565f89",
+        "element.disabled": "#414868",
+        "drop_target.background": "#1e202e",
+        "ghost_element.background": "#1a1b26",
+        "ghost_element.hover": "#565f89",
+        "ghost_element.active": "#9aa5ce",
+        "ghost_element.selected": "#565f89",
+        "ghost_element.disabled": "#414868",
+        "text": "#a9b1d6",
+        "text.muted": "#787c99",
+        "text.placeholder": "#787c99",
+        "text.disabled": "#414868",
+        "text.accent": "#7dcfff",
+        "icon": "#787c99",
+        "icon.muted": "#787c99",
+        "icon.disabled": "#414868",
+        "icon.placeholder": "#565f89",
+        "icon.accent": "#7dcfff",
+        "status_bar.background": "#16161e",
+        "title_bar.background": "#16161e",
+        "title_bar.inactive_background": "#16161e",
+        "toolbar.background": "#16161e",
+        "tab_bar.background": "#16161e",
+        "tab.inactive_background": "#16161e",
+        "tab.active_background": "#414868",
+        "search.match_background": "#414868",
+        "panel.background": "#16161e",
+        "panel.focused_border": null,
+        "panel.indent_guide": "#363b54",
+        "panel.indent_guide_active": "#565f89",
+        "panel.indent_guide_hover": "#565f89",
+        "panel.overlay_background": "#14141b",
+        "pane.focused_border": null,
+        "pane_group.border": "#101014",
+        "scrollbar.thumb.background": "#41486880",
+        "scrollbar.thumb.hover_background": "#414868",
+        "scrollbar.thumb.border": "#414868",
+        "scrollbar.track.background": "#1a1b2680",
+        "scrollbar.track.border": "#101014",
+        "editor.foreground": "#a9b1d6",
+        "editor.background": "#1a1b26",
+        "editor.gutter.background": "#1a1b26",
+        "editor.subheader.background": "#1a1b26",
+        "editor.active_line.background": "#1e202e",
+        "editor.highlighted_line.background": "#1e202e",
+        "editor.line_number": "#363b54",
+        "editor.active_line_number": "#a9b1d6",
+        "editor.invisible": null,
+        "editor.wrap_guide": "#101014",
+        "editor.active_wrap_guide": "#101014",
+        "editor.document_highlight.read_background": "#363b54",
+        "editor.document_highlight.write_background": "#363b54",
+        "editor.document_highlight.bracket_background": "#414868",
+        "editor.indent_guide": "#363b54",
+        "editor.indent_guide_active": "#565f89",
+        "terminal.background": "#16161e",
+        "terminal.foreground": null,
+        "terminal.ansi.background": "#16161e",
+        "terminal.bright_foreground": null,
+        "terminal.dim_foreground": null,
+        "terminal.ansi.black": "#363b54",
+        "terminal.ansi.bright_black": "#363b54",
+        "terminal.ansi.dim_black": null,
+        "terminal.ansi.red": "#f7768e",
+        "terminal.ansi.bright_red": "#f7768e",
+        "terminal.ansi.dim_red": null,
+        "terminal.ansi.green": "#73daca",
+        "terminal.ansi.bright_green": "#41a6b5",
+        "terminal.ansi.dim_green": null,
+        "terminal.ansi.yellow": "#e0af68",
+        "terminal.ansi.bright_yellow": "#e0af68",
+        "terminal.ansi.dim_yellow": null,
+        "terminal.ansi.blue": "#7aa2f7",
+        "terminal.ansi.bright_blue": "#7aa2f7",
+        "terminal.ansi.dim_blue": null,
+        "terminal.ansi.magenta": "#bb9af7",
+        "terminal.ansi.bright_magenta": "#bb9af7",
+        "terminal.ansi.dim_magenta": null,
+        "terminal.ansi.cyan": "#7dcfff",
+        "terminal.ansi.bright_cyan": "#7dcfff",
+        "terminal.ansi.dim_cyan": null,
+        "terminal.ansi.white": "#787c99",
+        "terminal.ansi.bright_white": "#acb0d0",
+        "terminal.ansi.dim_white": null,
+        "link_text.hover": "#7dcfff",
+        "conflict": "#bb9af7",
+        "conflict.background": "#1a1b26",
+        "conflict.border": "#414868",
+        "created": "#9ece6a",
+        "created.background": "#1a1b26",
+        "created.border": "#414868",
+        "deleted": "#f7768e",
+        "deleted.background": "#1a1b26",
+        "deleted.border": "#414868",
+        "error": "#f7768e",
+        "error.background": "#1a1b26",
+        "error.border": "#414868",
+        "hidden": "#787c99",
+        "hidden.background": "#1a1b26",
+        "hidden.border": "#414868",
+        "hint": "#51597d",
+        "hint.background": "#1a1b26",
+        "hint.border": "#414868",
+        "ignored": "#515670",
+        "ignored.background": "#1a1b26",
+        "ignored.border": "#414868",
+        "info": "#0da0ba",
+        "info.background": "#1a1b26",
+        "info.border": "#414868",
+        "modified": "#e0af68",
+        "modified.background": "#1a1b26",
+        "modified.border": "#414868",
+        "predictive": "#51597d",
+        "predictive.background": "#1a1b26",
+        "predictive.border": "#414868",
+        "renamed": "#9ece6a",
+        "renamed.background": "#1a1b26",
+        "renamed.border": "#414868",
+        "success": "#9ece6a",
+        "success.background": "#1a1b26",
+        "success.border": "#414868",
+        "unreachable": "#f7768e",
+        "unreachable.background": "#1a1b26",
+        "unreachable.border": "#414868",
+        "warning": "#e0af68",
+        "warning.background": "#1a1b26",
+        "warning.border": "#414868",
+        "version_control.added": "#9ece6a",
+        "version_control.added_background": "#1a1b26",
+        "version_control.conflict": "#bb9af7",
+        "version_control.conflict_background": "#1a1b26",
+        "version_control.deleted": "#f7768e",
+        "version_control.deleted_background": "#1a1b26",
+        "version_control.ignored": "#787c99",
+        "version_control.modified": "#e0af68",
+        "version_control.modified_background": "#1a1b26",
+        "version_control.renamed": "#7dcfff",
+        "players": [
+          {
+            "cursor": "#7c7f93",
+            "background": "#7c7f93",
+            "selection": "#267ead3d"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#ff9e64",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#51597d",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#51597d",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#ff9e64",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#f7768e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": "#f7768e",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": "#f7768e",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "function": {
+            "color": "#7aa2f7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#c0caf5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#73daca",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#73daca",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#ff9e64",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#89ddff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#73daca",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#89ddff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#89ddff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#89ddff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#89ddff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#89ddff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#9ece6a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#9ece6a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#9ece6a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#9ece6a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#f7768e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#9ece6a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#ff9e64",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type": {
+            "color": "#0db9d7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#c0caf5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#f7768e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "character": {
+            "color": "#9ece6a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "character.special": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.documentation": {
+            "color": "#51597d",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.error": {
+            "color": "#f7768e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.hint": {
+            "color": "#0da0ba",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.note": {
+            "color": "#7dcfff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.todo": {
+            "color": "#e0af68",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.warning": {
+            "color": "#e0af68",
+            "font_style": null,
+            "font_weight": null
+          },
+          "concept": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant.builtin": {
+            "color": "#ff9e64",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant.macro": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "diff.minus": {
+            "color": "#f7768e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "diff.plus": {
+            "color": "#9ece6a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#c0caf5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "enum": {
+            "color": "#0db9d7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "field": {
+            "color": "#c0caf5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "float": {
+            "color": "#ff9e64",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.builtin": {
+            "color": "#7aa2f7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.call": {
+            "color": "#7aa2f7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.decorator": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.macro": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.method": {
+            "color": "#7aa2f7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.method.call": {
+            "color": "#7aa2f7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.conditional": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.conditional.ternary": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.coroutine": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.debug": {
+            "color": "#f7768e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.directive": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.directive.define": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.exception": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.export": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.function": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.import": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.modifier": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.operator": {
+            "color": "#89ddff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.repeat": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.return": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.type": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "module": {
+            "color": "#c0caf5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#c0caf5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number.float": {
+            "color": "#ff9e64",
+            "font_style": null,
+            "font_weight": null
+          },
+          "parameter": {
+            "color": "#c0caf5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "parent": {
+            "color": "#c0caf5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predoc": {
+            "color": "#51597d",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "#c0caf5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#c0caf5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.doc": {
+            "color": "#9ece6a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.documentation": {
+            "color": "#9ece6a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regexp": {
+            "color": "#9ece6a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.path": {
+            "color": "#9ece6a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.url": {
+            "color": "#7dcfff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "symbol": {
+            "color": "#c0caf5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag.attribute": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag.delimiter": {
+            "color": "#89ddff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag.doctype": {
+            "color": "#51597d",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.builtin": {
+            "color": "#0db9d7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.class.definition": {
+            "color": "#0db9d7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.definition": {
+            "color": "#0db9d7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.interface": {
+            "color": "#0db9d7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.super": {
+            "color": "#0db9d7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.builtin": {
+            "color": "#f7768e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.member": {
+            "color": "#c0caf5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.parameter": {
+            "color": "#c0caf5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variant": {
+            "color": "#c0caf5",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    },
+    {
+      "name": "Tokyo Night Light",
+      "appearance": "light",
+      "style": {
+        "accents": [
+          "#5a4a7866",
+          "#34548a66",
+          "#485e3066",
+          "#33635c66",
+          "#8f5e1566",
+          "#96502766",
+          "#8c435166"
+        ],
+        "background.appearance": "opaque",
+        "border": "#c1c2c7",
+        "border.variant": "#c1c2c7",
+        "border.focused": "#82859433",
+        "border.selected": "#c1c2c7",
+        "border.transparent": "#c1c2c7",
+        "border.disabled": "#c1c2c7",
+        "elevated_surface.background": "#d5d6db",
+        "surface.background": "#cbccd1",
+        "background": "#d5d6db",
+        "element.background": "#d5d6db",
+        "element.hover": "#9699a3",
+        "element.active": "#565a6e",
+        "element.selected": "#9699a3",
+        "element.disabled": "#0f0f14",
+        "drop_target.background": "#c1c2c7",
+        "ghost_element.background": "#d5d6db",
+        "ghost_element.hover": "#9699a3",
+        "ghost_element.active": "#565a6e",
+        "ghost_element.selected": "#9699a3",
+        "ghost_element.disabled": "#0f0f14",
+        "text": "#343b58",
+        "text.muted": "#4c505e",
+        "text.placeholder": "#4c505e",
+        "text.disabled": "#0f0f14",
+        "text.accent": "0f4b6e",
+        "icon": "#4c505e",
+        "icon.muted": "#4c505e",
+        "icon.disabled": "#0f0f14",
+        "icon.placeholder": "#9699a3",
+        "icon.accent": "#0f4b6e",
+        "status_bar.background": "#cbccd1",
+        "title_bar.background": "#cbccd1",
+        "title_bar.inactive_background": "#cbccd1",
+        "toolbar.background": "#cbccd1",
+        "tab_bar.background": "#cbccd1",
+        "tab.inactive_background": "#cbccd1",
+        "tab.active_background": "#9699a3",
+        "search.match_background": "#9699a3",
+        "panel.background": "#cbccd1",
+        "panel.focused_border": null,
+        "pane.focused_border": null,
+        "scrollbar.thumb.background": "#9699a380",
+        "scrollbar.thumb.hover_background": "#9699a3",
+        "scrollbar.thumb.border": "#9699a3",
+        "scrollbar.track.background": "#d5d6db80",
+        "scrollbar.track.border": "#c1c2c7",
+        "editor.foreground": "#343b59",
+        "editor.background": "#d5d6db",
+        "editor.gutter.background": "#d5d6db",
+        "editor.subheader.background": "#d5d6db",
+        "editor.active_line.background": "#dcdee3",
+        "editor.highlighted_line.background": "#dcdee3",
+        "editor.line_number": "#9da0ab",
+        "editor.active_line_number": "#343b59",
+        "editor.invisible": null,
+        "editor.wrap_guide": "#c1c2c7",
+        "editor.active_wrap_guide": "#c1c2c7",
+        "editor.document_highlight.read_background": "#9da0ab",
+        "editor.document_highlight.write_background": "#9da0ab",
+        "terminal.background": "#cbccd1",
+        "terminal.foreground": null,
+        "terminal.bright_foreground": null,
+        "terminal.dim_foreground": null,
+        "terminal.ansi.black": "#0f0f14",
+        "terminal.ansi.bright_black": "#0f0f14",
+        "terminal.ansi.dim_black": null,
+        "terminal.ansi.red": "#8c4351",
+        "terminal.ansi.bright_red": "#8c4351",
+        "terminal.ansi.dim_red": null,
+        "terminal.ansi.green": "#33635c",
+        "terminal.ansi.bright_green": "#33635c",
+        "terminal.ansi.dim_green": null,
+        "terminal.ansi.yellow": "#8f5e15",
+        "terminal.ansi.bright_yellow": "#8f5e15",
+        "terminal.ansi.dim_yellow": null,
+        "terminal.ansi.blue": "#34548a",
+        "terminal.ansi.bright_blue": "#34548a",
+        "terminal.ansi.dim_blue": null,
+        "terminal.ansi.magenta": "#5a4a78",
+        "terminal.ansi.bright_magenta": "#5a4a78",
+        "terminal.ansi.dim_magenta": null,
+        "terminal.ansi.cyan": "#0f4b6e",
+        "terminal.ansi.bright_cyan": "#0f4b6e",
+        "terminal.ansi.dim_cyan": null,
+        "terminal.ansi.white": "#828594",
+        "terminal.ansi.bright_white": "#828594",
+        "terminal.ansi.dim_white": null,
+        "link_text.hover": "#4c505e",
+        "conflict": "#5a4a78",
+        "conflict.background": "#d5d6db",
+        "conflict.border": "#343b58",
+        "created": "#485e30",
+        "created.background": "#d5d6db",
+        "created.border": "#343b58",
+        "deleted": "#8c4351",
+        "deleted.background": "#d5d6db",
+        "deleted.border": "#343b58",
+        "error": "#8c4351",
+        "error.background": "#d5d6db",
+        "error.border": "#343b58",
+        "hidden": "#4c505e",
+        "hidden.background": "#d5d6db",
+        "hidden.border": "#343b58",
+        "hint": "#634f30",
+        "hint.background": "#d5d6db",
+        "hint.border": "#343b58",
+        "ignored": "#828594",
+        "ignored.background": "#d5d6db",
+        "ignored.border": "#343b58",
+        "info": "#0da0ba",
+        "info.background": "#d5d6db",
+        "info.border": "#343b58",
+        "modified": "#8f5e15",
+        "modified.background": "#d5d6db",
+        "modified.border": "#343b58",
+        "predictive": "#634f30",
+        "predictive.background": "#d5d6db",
+        "predictive.border": "#343b58",
+        "renamed": "#485e30",
+        "renamed.background": "#d5d6db",
+        "renamed.border": "#343b58",
+        "success": "#485e30",
+        "success.background": "#d5d6db",
+        "success.border": "#343b58",
+        "unreachable": "#8c4351",
+        "unreachable.background": "#d5d6db",
+        "unreachable.border": "#343b58",
+        "warning": "#8f5e15",
+        "warning.background": "#d5d6db",
+        "warning.border": "#343b58",
+        "players": [
+          {
+            "cursor": "#7c7f93",
+            "background": "#7c7f93",
+            "selection": "#267ead3d"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": "#5a4a78",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#965027",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#9699a3",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#9699a3",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#965027",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#8c4351",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": "#8c4351",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": "#8c4351",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "function": {
+            "color": "#34548a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword": {
+            "color": "#5a4a78",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#343b58",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#33635c",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#33635c",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#965027",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#4c505e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#33635c",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#4c505e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#4c505e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#4c505e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#4c505e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#4c505e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#485e30",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#5a4a78",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#485e30",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#485e30",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#485e30",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#8c4351",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#485e30",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#965027",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type": {
+            "color": "#166775",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#343b58",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#8c4351",
+            "font_style": null,
+            "font_weight": null
+          },
+          "character": {
+            "color": "#485e30",
+            "font_style": null,
+            "font_weight": null
+          },
+          "character.special": {
+            "color": "#5a4a78",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.documentation": {
+            "color": "#9699a3",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.error": {
+            "color": "#8c4351",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.hint": {
+            "color": "#9699a3",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.note": {
+            "color": "#9699a3",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.todo": {
+            "color": "#9699a3",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.warning": {
+            "color": "#9699a3",
+            "font_style": null,
+            "font_weight": null
+          },
+          "concept": {
+            "color": "#5a4a78",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant.builtin": {
+            "color": "#965027",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant.macro": {
+            "color": "#5a4a78",
+            "font_style": null,
+            "font_weight": null
+          },
+          "diff.minus": {
+            "color": "#8c4351",
+            "font_style": null,
+            "font_weight": null
+          },
+          "diff.plus": {
+            "color": "#485e30",
+            "font_style": null,
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#343b58",
+            "font_style": null,
+            "font_weight": null
+          },
+          "enum": {
+            "color": "#0f4b6e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "field": {
+            "color": "#343b58",
+            "font_style": null,
+            "font_weight": null
+          },
+          "float": {
+            "color": "#965027",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.builtin": {
+            "color": "#34548a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.call": {
+            "color": "#34548a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.decorator": {
+            "color": "#5a4a78",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.macro": {
+            "color": "#5a4a78",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.method": {
+            "color": "#34548a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.method.call": {
+            "color": "#34548a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.conditional": {
+            "color": "#5a4a78",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.conditional.ternary": {
+            "color": "#5a4a78",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.coroutine": {
+            "color": "#5a4a78",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.debug": {
+            "color": "#8c4351",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.directive": {
+            "color": "#5a4a78",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.directive.define": {
+            "color": "#5a4a78",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.exception": {
+            "color": "#5a4a78",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.export": {
+            "color": "#5a4a78",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.function": {
+            "color": "#5a4a78",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.import": {
+            "color": "#5a4a78",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.modifier": {
+            "color": "#5a4a78",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.operator": {
+            "color": "#4c505e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.repeat": {
+            "color": "#5a4a78",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.return": {
+            "color": "#5a4a78",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.type": {
+            "color": "#5a4a78",
+            "font_style": null,
+            "font_weight": null
+          },
+          "module": {
+            "color": "#343b58",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#343b58",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number.float": {
+            "color": "#965027",
+            "font_style": null,
+            "font_weight": null
+          },
+          "parameter": {
+            "color": "#343b58",
+            "font_style": null,
+            "font_weight": null
+          },
+          "parent": {
+            "color": "#343b58",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predoc": {
+            "color": "#9699a3",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "#343b58",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#343b58",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.doc": {
+            "color": "#485e30",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.documentation": {
+            "color": "#485e30",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regexp": {
+            "color": "#485e30",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.path": {
+            "color": "#485e30",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.url": {
+            "color": "#0f4b6e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "symbol": {
+            "color": "#343b58",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag.attribute": {
+            "color": "#5a4a78",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag.delimiter": {
+            "color": "#4c505e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag.doctype": {
+            "color": "#9699a3",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.builtin": {
+            "color": "#0f4b6e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.class.definition": {
+            "color": "#0f4b6e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.definition": {
+            "color": "#0f4b6e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.interface": {
+            "color": "#0f4b6e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.super": {
+            "color": "#0f4b6e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.builtin": {
+            "color": "#8c4351",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.member": {
+            "color": "#343b58",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.parameter": {
+            "color": "#343b58",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variant": {
+            "color": "#343b58",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    },
+    {
+      "name": "Tokyo Night Storm",
+      "appearance": "dark",
+      "style": {
+        "accents": [
+          "#bb9af766",
+          "#7aa2f766",
+          "#9ece6a66", 
+          "#73daca66",
+          "#e0af6866",
+          "#ff9e6466",
+          "#f7768e66"
+        ],
+        "background.appearance": "opaque",
+        "border": "#1b1e2e",
+        "border.variant": "#1b1e2e",
+        "border.focused": "#545c7e33",
+        "border.selected": "#1b1e2e",
+        "border.transparent": "#1b1e2e",
+        "border.disabled": "#1b1e2e",
+        "elevated_surface.background": "#1b1e2e",
+        "surface.background": "#1f2335",
+        "background": "#24283b",
+        "element.background": "#24283b",
+        "element.hover": "#565f89",
+        "element.active": "#9aa5ce",
+        "element.selected": "#565f89",
+        "element.disabled": "#414868",
+        "drop_target.background": "#1e202e",
+        "ghost_element.background": "#1a1b26",
+        "ghost_element.hover": "#565f89",
+        "ghost_element.active": "#9aa5ce",
+        "ghost_element.selected": "#565f89",
+        "ghost_element.disabled": "#414868",
+        "text": "#a9b1d6",
+        "text.muted": "#7982a9",
+        "text.placeholder": "#787c99",
+        "text.disabled": "#414868",
+        "text.accent": "#7dcfff",
+        "icon": "#787c99",
+        "icon.muted": "#787c99",
+        "icon.disabled": "#414868",
+        "icon.placeholder": "#565f89",
+        "icon.accent": "#7dcfff",
+        "status_bar.background": "#1f2335",
+        "title_bar.background": "#1f2335",
+        "title_bar.inactive_background": "#1f2335",
+        "toolbar.background": "#1f2335",
+        "tab_bar.background": "#1f2335",
+        "tab.inactive_background": "#1f2335",
+        "tab.active_background": "#414868",
+        "search.match_background": "#414868",
+        "panel.background": "#1f2335",
+        "panel.focused_border": null,
+        "pane.focused_border": null,
+        "scrollbar.thumb.background": "#41486880",
+        "scrollbar.thumb.hover_background": "#414868",
+        "scrollbar.thumb.border": "#414868",
+        "scrollbar.track.background": "#24283b80",
+        "scrollbar.track.border": "#1b1e2e",
+        "editor.foreground": "#a9b1d6",
+        "editor.background": "#24283b",
+        "editor.gutter.background": "#24283b",
+        "editor.subheader.background": "#24283b",
+        "editor.active_line.background": "#292e42",
+        "editor.highlighted_line.background": "#1e202e",
+        "editor.line_number": "#3b4261",
+        "editor.active_line_number": "#a9b1d6",
+        "editor.invisible": null,
+        "editor.wrap_guide": "#1b1e2e",
+        "editor.active_wrap_guide": "#1b1e2e",
+        "editor.document_highlight.read_background": "#363b54",
+        "editor.document_highlight.write_background": "#363b54",
+        "terminal.background": "#1f2335",
+        "terminal.foreground": null,
+        "terminal.bright_foreground": null,
+        "terminal.dim_foreground": null,
+        "terminal.ansi.black": "#414868",
+        "terminal.ansi.bright_black": "#414868",
+        "terminal.ansi.dim_black": null,
+        "terminal.ansi.red": "#f7768e",
+        "terminal.ansi.bright_red": "#f7768e",
+        "terminal.ansi.dim_red": null,
+        "terminal.ansi.green": "#73daca",
+        "terminal.ansi.bright_green": "#73daca",
+        "terminal.ansi.dim_green": null,
+        "terminal.ansi.yellow": "#e0af68",
+        "terminal.ansi.bright_yellow": "#e0af68",
+        "terminal.ansi.dim_yellow": null,
+        "terminal.ansi.blue": "#7aa2f7",
+        "terminal.ansi.bright_blue": "#7aa2f7",
+        "terminal.ansi.dim_blue": null,
+        "terminal.ansi.magenta": "#bb9af7",
+        "terminal.ansi.bright_magenta": "#bb9af7",
+        "terminal.ansi.dim_magenta": null,
+        "terminal.ansi.cyan": "#7dcfff",
+        "terminal.ansi.bright_cyan": "#7dcfff",
+        "terminal.ansi.dim_cyan": null,
+        "terminal.ansi.white": "#7982a9",
+        "terminal.ansi.bright_white": "#a9b1d6",
+        "terminal.ansi.dim_white": null,
+        "link_text.hover": "#7dcfff",
+        "conflict": "#bb9af7",
+        "conflict.background": "#24283b",
+        "conflict.border": "#414868",
+        "created": "#9ece6a",
+        "created.background": "#24283b",
+        "created.border": "#414868",
+        "deleted": "#f7768e",
+        "deleted.background": "#24283b",
+        "deleted.border": "#414868",
+        "error": "#f7768e",
+        "error.background": "#24283b",
+        "error.border": "#414868",
+        "hidden": "#787c99",
+        "hidden.background": "#24283b",
+        "hidden.border": "#414868",
+        "hint": "#5f6996",
+        "hint.background": "#24283b",
+        "hint.border": "#414868",
+        "ignored": "#515670",
+        "ignored.background": "#24283b",
+        "ignored.border": "#414868",
+        "info": "#0da0ba",
+        "info.background": "#24283b",
+        "info.border": "#414868",
+        "modified": "#e0af68",
+        "modified.background": "#24283b",
+        "modified.border": "#414868",
+        "predictive": "#5f6996",
+        "predictive.background": "#24283b",
+        "predictive.border": "#414868",
+        "renamed": "#9ece6a",
+        "renamed.background": "#24283b",
+        "renamed.border": "#414868",
+        "success": "#9ece6a",
+        "success.background": "#24283b",
+        "success.border": "#414868",
+        "unreachable": "#f7768e",
+        "unreachable.background": "#24283b",
+        "unreachable.border": "#414868",
+        "warning": "#e0af68",
+        "warning.background": "#24283b",
+        "warning.border": "#414868",
+        "players": [
+          {
+            "cursor": "#7c7f93",
+            "background": "#7c7f93",
+            "selection": "#267ead3d"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#ff9e64",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#5f6996",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#5f6996",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#ff9e64",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#f7768e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": "#f7768e",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": "#f7768e",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "function": {
+            "color": "#7aa2f7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#c0caf5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#73daca",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#73daca",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#ff9e64",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#89ddff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#73daca",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#89ddff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#89ddff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#89ddff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#89ddff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#89ddff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#9ece6a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#9ece6a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#9ece6a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#9ece6a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#f7768e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#9ece6a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#ff9e64",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type": {
+            "color": "#2ac3de",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#c0caf5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#f7768e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "character": {
+            "color": "#9ece6a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "character.special": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.documentation": {
+            "color": "#5f6996",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.error": {
+            "color": "#f7768e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.hint": {
+            "color": "#0da0ba",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.note": {
+            "color": "#7dcfff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.todo": {
+            "color": "#e0af68",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.warning": {
+            "color": "#e0af68",
+            "font_style": null,
+            "font_weight": null
+          },
+          "concept": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant.builtin": {
+            "color": "#ff9e64",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant.macro": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "diff.minus": {
+            "color": "#f7768e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "diff.plus": {
+            "color": "#9ece6a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#c0caf5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "enum": {
+            "color": "#2ac3de",
+            "font_style": null,
+            "font_weight": null
+          },
+          "field": {
+            "color": "#c0caf5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "float": {
+            "color": "#ff9e64",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.builtin": {
+            "color": "#7aa2f7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.call": {
+            "color": "#7aa2f7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.decorator": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.macro": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.method": {
+            "color": "#7aa2f7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.method.call": {
+            "color": "#7aa2f7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.conditional": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.conditional.ternary": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.coroutine": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.debug": {
+            "color": "#f7768e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.directive": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.directive.define": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.exception": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.export": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.function": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.import": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.modifier": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.operator": {
+            "color": "#89ddff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.repeat": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.return": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.type": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "module": {
+            "color": "#c0caf5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#c0caf5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number.float": {
+            "color": "#ff9e64",
+            "font_style": null,
+            "font_weight": null
+          },
+          "parameter": {
+            "color": "#c0caf5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "parent": {
+            "color": "#c0caf5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predoc": {
+            "color": "#5f6996",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "#c0caf5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#c0caf5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.doc": {
+            "color": "#9ece6a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.documentation": {
+            "color": "#9ece6a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regexp": {
+            "color": "#9ece6a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.path": {
+            "color": "#9ece6a",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.url": {
+            "color": "#7dcfff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "symbol": {
+            "color": "#c0caf5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag.attribute": {
+            "color": "#bb9af7",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag.delimiter": {
+            "color": "#89ddff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag.doctype": {
+            "color": "#5f6996",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.builtin": {
+            "color": "#2ac3de",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.class.definition": {
+            "color": "#2ac3de",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.definition": {
+            "color": "#2ac3de",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.interface": {
+            "color": "#2ac3de",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.super": {
+            "color": "#2ac3de",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.builtin": {
+            "color": "#f7768e",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.member": {
+            "color": "#c0caf5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.parameter": {
+            "color": "#c0caf5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variant": {
+            "color": "#c0caf5",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    },
+    {
+      "name": "Tokyo Night Moon",
+      "appearance": "dark",
+      "style": {
+        "accents": [
+          "#c099ff66",
+          "#82aaff66",
+          "#c3e88d66",
+          "#4fd6be66",
+          "#ffc77766",
+          "#ff966c66",
+          "#ff757f66"
+        ],
+        "background.appearance": "opaque",
+        "border": "#1b1e2e",
+        "border.variant": "#1b1e2e",
+        "border.focused": "#86e1fc33",
+        "border.selected": "#1b1e2e",
+        "border.transparent": "#1b1e2e",
+        "border.disabled": "#1b1e2e",
+        "elevated_surface.background": "#1b1e2e",
+        "surface.background": "#1e2030",
+        "background": "#222436",
+        "element.background": "#222436",
+        "element.hover": "#636da6",
+        "element.active": "#9aa5ce",
+        "element.selected": "#636da6",
+        "element.disabled": "#444a73",
+        "drop_target.background": "#1e202e",
+        "ghost_element.background": "#222436",
+        "ghost_element.hover": "#636da6",
+        "ghost_element.active": "#9aa5ce",
+        "ghost_element.selected": "#636da6",
+        "ghost_element.disabled": "#444a73",
+        "text": "#828bb8",
+        "text.muted": "#7982a9",
+        "text.placeholder": "#787c99",
+        "text.disabled": "#444a73",
+        "text.accent": "#86e1fc",
+        "icon": "#787c99",
+        "icon.muted": "#787c99",
+        "icon.disabled": "#444a73",
+        "icon.placeholder": "#636da6",
+        "icon.accent": "#86e1fc",
+        "status_bar.background": "#1e2030",
+        "title_bar.background": "#1e2030",
+        "title_bar.inactive_background": "#1e2030",
+        "toolbar.background": "#1e2030",
+        "tab_bar.background": "#1e2030",
+        "tab.inactive_background": "#1e2030",
+        "tab.active_background": "#444a73",
+        "search.match_background": "#444a73",
+        "panel.background": "#1e2030",
+        "panel.focused_border": null,
+        "pane.focused_border": null,
+        "scrollbar.thumb.background": "#444a7380",
+        "scrollbar.thumb.hover_background": "#444a73",
+        "scrollbar.thumb.border": "#444a73",
+        "scrollbar.track.background": "#22243680",
+        "scrollbar.track.border": "#1b1e2e",
+        "editor.foreground": "#828bb8",
+        "editor.background": "#222436",
+        "editor.gutter.background": "#222436",
+        "editor.subheader.background": "#222436",
+        "editor.active_line.background": "#2f334d",
+        "editor.highlighted_line.background": "#1e202e",
+        "editor.line_number": "#3b4261",
+        "editor.active_line_number": "#828bb8",
+        "editor.invisible": null,
+        "editor.wrap_guide": "#1b1e2e",
+        "editor.active_wrap_guide": "#1b1e2e",
+        "editor.document_highlight.read_background": "#363b54",
+        "editor.document_highlight.write_background": "#363b54",
+        "terminal.background": "#1e2030",
+        "terminal.foreground": null,
+        "terminal.bright_foreground": null,
+        "terminal.dim_foreground": null,
+        "terminal.ansi.black": "#444a73",
+        "terminal.ansi.bright_black": "#444a73",
+        "terminal.ansi.dim_black": null,
+        "terminal.ansi.red": "#ff757f",
+        "terminal.ansi.bright_red": "#ff757f",
+        "terminal.ansi.dim_red": null,
+        "terminal.ansi.green": "#4fd6be",
+        "terminal.ansi.bright_green": "#4fd6be",
+        "terminal.ansi.dim_green": null,
+        "terminal.ansi.yellow": "#ffc777",
+        "terminal.ansi.bright_yellow": "#ffc777",
+        "terminal.ansi.dim_yellow": null,
+        "terminal.ansi.blue": "#82aaff",
+        "terminal.ansi.bright_blue": "#82aaff",
+        "terminal.ansi.dim_blue": null,
+        "terminal.ansi.magenta": "#c099ff",
+        "terminal.ansi.bright_magenta": "#c099ff",
+        "terminal.ansi.dim_magenta": null,
+        "terminal.ansi.cyan": "#86e1fc",
+        "terminal.ansi.bright_cyan": "#86e1fc",
+        "terminal.ansi.dim_cyan": null,
+        "terminal.ansi.white": "#7982a9",
+        "terminal.ansi.bright_white": "#828bb8",
+        "terminal.ansi.dim_white": null,
+        "link_text.hover": "#86e1fc",
+        "conflict": "#c099ff",
+        "conflict.background": "#222436",
+        "conflict.border": "#444a73",
+        "created": "#c3e88d",
+        "created.background": "#222436",
+        "created.border": "#444a73",
+        "deleted": "#ff757f",
+        "deleted.background": "#222436",
+        "deleted.border": "#444a73",
+        "error": "#ff757f",
+        "error.background": "#222436",
+        "error.border": "#444a73",
+        "hidden": "#787c99",
+        "hidden.background": "#222436",
+        "hidden.border": "#444a73",
+        "hint": "#636da6",
+        "hint.background": "#222436",
+        "hint.border": "#444a73",
+        "ignored": "#515670",
+        "ignored.background": "#222436",
+        "ignored.border": "#444a73",
+        "info": "#0da0ba",
+        "info.background": "#222436",
+        "info.border": "#444a73",
+        "modified": "#ffc777",
+        "modified.background": "#222436",
+        "modified.border": "#444a73",
+        "predictive": "#636da6",
+        "predictive.background": "#222436",
+        "predictive.border": "#444a73",
+        "renamed": "#c3e88d",
+        "renamed.background": "#222436",
+        "renamed.border": "#444a73",
+        "success": "#c3e88d",
+        "success.background": "#222436",
+        "success.border": "#444a73",
+        "unreachable": "#ff757f",
+        "unreachable.background": "#222436",
+        "unreachable.border": "#444a73",
+        "warning": "#ffc777",
+        "warning.background": "#222436",
+        "warning.border": "#444a73",
+        "players": [
+          {
+            "cursor": "#7c7f93",
+            "background": "#7c7f93",
+            "selection": "#267ead3d"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": "#c099ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#ff966c",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#636da6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#636da6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant": {
+            "color": "#ff966c",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#ff757f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": "#ff757f",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": "#ff757f",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "function": {
+            "color": "#82aaff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword": {
+            "color": "#c099ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "#c8d3f5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "#4fd6be",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "#4fd6be",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#ff966c",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#89ddff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "#4fd6be",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#89ddff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "#89ddff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "#89ddff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "#89ddff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "#89ddff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#c3e88d",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#c099ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "#c3e88d",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "#c3e88d",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "#c3e88d",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#ff757f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#c3e88d",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "#ff966c",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type": {
+            "color": "#65bcff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#c8d3f5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#ff757f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "character": {
+            "color": "#c3e88d",
+            "font_style": null,
+            "font_weight": null
+          },
+          "character.special": {
+            "color": "#c099ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.documentation": {
+            "color": "#636da6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.error": {
+            "color": "#ff757f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.hint": {
+            "color": "#0da0ba",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.note": {
+            "color": "#86e1fc",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.todo": {
+            "color": "#ffc777",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment.warning": {
+            "color": "#ffc777",
+            "font_style": null,
+            "font_weight": null
+          },
+          "concept": {
+            "color": "#c099ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant.builtin": {
+            "color": "#ff966c",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constant.macro": {
+            "color": "#c099ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "diff.minus": {
+            "color": "#ff757f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "diff.plus": {
+            "color": "#c3e88d",
+            "font_style": null,
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "#c8d3f5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "enum": {
+            "color": "#65bcff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "field": {
+            "color": "#c8d3f5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "float": {
+            "color": "#ff966c",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.builtin": {
+            "color": "#82aaff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.call": {
+            "color": "#82aaff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.decorator": {
+            "color": "#c099ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.macro": {
+            "color": "#c099ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.method": {
+            "color": "#82aaff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function.method.call": {
+            "color": "#82aaff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.conditional": {
+            "color": "#c099ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.conditional.ternary": {
+            "color": "#c099ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.coroutine": {
+            "color": "#c099ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.debug": {
+            "color": "#ff757f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.directive": {
+            "color": "#c099ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.directive.define": {
+            "color": "#c099ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.exception": {
+            "color": "#c099ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.export": {
+            "color": "#c099ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.function": {
+            "color": "#c099ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.import": {
+            "color": "#c099ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.modifier": {
+            "color": "#c099ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.operator": {
+            "color": "#89ddff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.repeat": {
+            "color": "#c099ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.return": {
+            "color": "#c099ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword.type": {
+            "color": "#c099ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "module": {
+            "color": "#c8d3f5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#c8d3f5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number.float": {
+            "color": "#ff966c",
+            "font_style": null,
+            "font_weight": null
+          },
+          "parameter": {
+            "color": "#c8d3f5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "parent": {
+            "color": "#c8d3f5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predoc": {
+            "color": "#636da6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "#c8d3f5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#c8d3f5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.doc": {
+            "color": "#c3e88d",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.documentation": {
+            "color": "#c3e88d",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regexp": {
+            "color": "#c3e88d",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.path": {
+            "color": "#c3e88d",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.url": {
+            "color": "#86e1fc",
+            "font_style": null,
+            "font_weight": null
+          },
+          "symbol": {
+            "color": "#c8d3f5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag.attribute": {
+            "color": "#c099ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag.delimiter": {
+            "color": "#89ddff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag.doctype": {
+            "color": "#636da6",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.builtin": {
+            "color": "#65bcff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.class.definition": {
+            "color": "#65bcff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.definition": {
+            "color": "#65bcff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.interface": {
+            "color": "#65bcff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type.super": {
+            "color": "#65bcff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.builtin": {
+            "color": "#ff757f",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.member": {
+            "color": "#c8d3f5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.parameter": {
+            "color": "#c8d3f5",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variant": {
+            "color": "#c8d3f5",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    }
+  ]
+}

--- a/zed_theme/Cargo.toml
+++ b/zed_theme/Cargo.toml
@@ -6,4 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+miniz_oxide = "0.8.9"
 serde.workspace = true
+serde_json_lenient = "0.2.4"
+
+[build-dependencies]
+miniz_oxide = "0.8.9"

--- a/zed_theme/build.rs
+++ b/zed_theme/build.rs
@@ -1,0 +1,25 @@
+fn main() {
+    let compiled_theme_path = std::path::PathBuf::from(
+        std::env::var_os("OUT_DIR").expect("Cargo didn't give us an OUT_DIR?"),
+    )
+    .join("compiled_themes.bin");
+
+    let data = format!(
+        "[{}]",
+        std::fs::read_dir("../themes")
+            .expect("Failed to read themes dir")
+            .map(|entry| {
+                let entry = entry.expect("Failed to get particular file entry in themes dir");
+                std::fs::read_to_string(entry.path())
+                    .unwrap_or_else(|_| panic!("Failed to read {}", entry.path().to_string_lossy()))
+            })
+            .collect::<Vec<_>>()
+            .join(",")
+    );
+
+    // 6 is the default compression level and a good compromise.
+    let compressed_data = miniz_oxide::deflate::compress_to_vec(data.as_bytes(), 6);
+
+    std::fs::write(compiled_theme_path, compressed_data)
+        .expect("Failed to write compiled theme contents");
+}

--- a/zed_theme/src/lib.rs
+++ b/zed_theme/src/lib.rs
@@ -1,3 +1,36 @@
-pub mod zed_theme_schema;
+mod zed_theme_schema;
 
 pub use zed_theme_schema::*;
+
+use std::collections::HashMap;
+
+const COMPILED_THEME_BYTES: &[u8] =
+    include_bytes!(concat!(env!("OUT_DIR"), "/compiled_themes.bin"));
+
+pub fn get_zed_themes() -> HashMap<String, ThemeContent> {
+    let decompressed_themes = miniz_oxide::inflate::decompress_to_vec(COMPILED_THEME_BYTES)
+        .expect("Compiled themes can't be decompressed?");
+    let theme_families: Vec<ThemeFamilyContent> =
+        serde_json_lenient::from_slice(&decompressed_themes)
+            .expect("Compiled themes aren't valid lenient JSON?");
+
+    theme_families
+        .into_iter()
+        .flat_map(|theme_family| {
+            theme_family
+                .themes
+                .into_iter()
+                .map(|theme| (theme.name.clone(), theme))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_zed_themes_can_be_loaded() {
+        assert!(get_zed_themes().len() > 0);
+    }
+}


### PR DESCRIPTION
Instead of downloading zed themes and caching them, we can directly embed them into the binary. This change also refactors ThemeDescriptors a bit, which is a bit more ergonomic and helps prepare better for custom theme support.

Why not convert to a Ki theme, then embed? Because this requires some sort of build script or pre-build step that converts, and doing that right now is arduous at best. Besides, we need a zed theme converter in the binary anyway, since we've more or less decided that custom theme schema will simply be the Zed theme schema.

Why compress the Zed themes? Because they are 10x the size (around 700K) otherwise, whereas presently they are ~60K.

Why miniz_oxide? It's a tiny library and an extremely popular crate: at present the rust standard library even depends on it.

Last but not least, this change alters the zed theme parsing from serde_json5 to serde_json_lenient. This is because zed actually uses the latter.