### PR TITLE
fix(ci): nightly build crashes on start

### DIFF
--- a/.ki/config.json
+++ b/.ki/config.json
@@ -24,5 +24,24 @@
                 "arguments": ["format", "--stdin-file-path=_.json"]
             }
         }
-    }
+    },
+    "leader_keymap": [
+        [
+            {
+                "name": "Example",
+                "script": "example.py"
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ],
+        [null, null, null, null, null, null, null, null, null, null],
+        [null, null, null, null, null, null, null, null, null, null]
+    ]
 }

--- a/src/config_default.json
+++ b/src/config_default.json
@@ -27,21 +27,7 @@
         }
     ],
     "leader_keymap": [
-        [
-            {
-                "name": "Example",
-                "script": "example.py"
-            },
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null
-        ],
+        [null, null, null, null, null, null, null, null, null, null],
         [null, null, null, null, null, null, null, null, null, null],
         [null, null, null, null, null, null, null, null, null, null]
     ],


### PR DESCRIPTION
This is because the embdedded default config requires a custom script `example.py` to exist in either `~/.config/ki/scripts` or `./ki/scripts/`.

This is fixed by moving it from the default config, to the workspace config of this repository.