### PR TITLE
fix(ci): delete nightly release before uploading

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     uses: ./.github/workflows/release-common.yml
-  
+
   publish:
     needs: [build]
     runs-on: ubuntu-latest
@@ -20,4 +20,6 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/download-artifact@v7
       - name: Publish release
-        run: gh release create nightly --prerelease --title 'Nightly Release' ki-linux-arm64/ki-linux-arm64 ki-linux-x64/ki-linux-x64 ki-windows-x64/ki-windows-x64.exe ki-macos-arm64/ki-macos-arm64
+        run: |
+          gh release delete nightly --yes | true # Don't fail if the release doesn't exist
+          gh release create nightly --prerelease --title 'Nightly Release' ki-linux-arm64/ki-linux-arm64 ki-linux-x64/ki-linux-x64 ki-windows-x64/ki-windows-x64.exe ki-macos-arm64/ki-macos-arm64


### PR DESCRIPTION
The nightly job fails when the release already exists.

This is the failing job: https://github.com/ki-editor/ki-editor/actions/runs/20686935504/job/59389177798