### PR TITLE
feat(build): split release to release-lto

### DIFF
--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -44,10 +44,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Build
-        run: cargo build --release --locked
+        run: cargo build --profile release-lto --locked
 
       - name: Rename
-        run: ${{ matrix.mv }} target/release/ki${{ matrix.extension }} ki-${{ matrix.code }}${{ matrix.extension }}
+        run: ${{ matrix.mv }} target/release-lto/ki${{ matrix.extension }} ki-${{ matrix.code }}${{ matrix.extension }}
 
       - name: Upload
         uses: actions/upload-artifact@v6
@@ -81,10 +81,10 @@ jobs:
           rustup target add ${{ matrix.rustup_target }}
         
       - name: Build
-        run: cargo build --release --locked --target ${{ matrix.rustup_target }}
+        run: cargo build --profile release-lto --locked --target ${{ matrix.rustup_target }}
 
       - name: Rename
-        run: mv target/${{ matrix.rustup_target }}/release/ki ki-${{ matrix.code }}
+        run: mv target/${{ matrix.rustup_target }}/release-lto/ki ki-${{ matrix.code }}
 
       - name: Upload
         uses: actions/upload-artifact@v6

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,5 +132,8 @@ tempfile.workspace = true
 
 
 [profile.release]
-lto = true
 debug = false # Set this to true when using `sudo cargo flamegraph`
+
+[profile.release-lto]
+inherits = 'release'
+lto = true


### PR DESCRIPTION
LTO is awesome for our heavily optimized release builds, but slow for "regular" release builds, including CI. Making a separate profile is called out as a pattern in the cargo documentation.