### PR TITLE
fix(file-picker): unable to use `/` to search for files in some cases

### DIFF
--- a/src/components/dropdown.rs
+++ b/src/components/dropdown.rs
@@ -99,7 +99,7 @@ impl DropdownItem {
                 .map(|path| path.display().to_string())
                 .unwrap_or_else(|_| path.display().to_string());
             let icon = shared::canonicalized_path::get_path_icon(&path);
-            format!("{name} {icon}")
+            format!("{icon} {name}")
         })
         .set_dispatches(Dispatches::one(crate::app::Dispatch::OpenFileFromPathBuf {
             path,


### PR DESCRIPTION
This is fixed by showing the full relative path instead of showing only the files' name and their parent directory.