### PR TITLE
refactor(visibility): pub(crate) => pub

### DIFF
--- a/src/alternator.rs
+++ b/src/alternator.rs
@@ -1,32 +1,32 @@
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct Alternator<T: Clone + std::fmt::Debug + PartialEq + Eq> {
+pub struct Alternator<T: Clone + std::fmt::Debug + PartialEq + Eq> {
     primary: T,
     secondary: Option<T>,
 }
 
 impl<T: Clone + std::fmt::Debug + PartialEq + Eq> Alternator<T> {
-    pub(crate) fn new(primary: T) -> Self {
+    pub fn new(primary: T) -> Self {
         Self {
             primary,
             secondary: None,
         }
     }
 
-    pub(crate) fn cycle(&mut self) {
+    pub fn cycle(&mut self) {
         if let Some(secondary) = self.secondary.take() {
             self.secondary = Some(std::mem::replace(&mut self.primary, secondary));
         }
     }
 
-    pub(crate) fn copy_primary_to_secondary(&mut self) {
+    pub fn copy_primary_to_secondary(&mut self) {
         self.secondary = Some(self.primary.clone())
     }
 
-    pub(crate) fn primary(&self) -> &T {
+    pub fn primary(&self) -> &T {
         &self.primary
     }
 
-    pub(crate) fn replace_primary(self, mode: T) -> Alternator<T> {
+    pub fn replace_primary(self, mode: T) -> Alternator<T> {
         Alternator {
             primary: mode,
             secondary: self.secondary,

--- a/src/app.rs
+++ b/src/app.rs
@@ -82,7 +82,7 @@ use crate::{layout::BufferContentsMap, test_app::RunTestOptions};
 // The scroll offset of each componentn should only be recalculated when:
 // 1. The number of components is changed (this means we need to store the components)
 // 2. The terminal dimension is changed
-pub(crate) struct App<T: Frontend> {
+pub struct App<T: Frontend> {
     context: Context,
 
     sender: Sender<AppMessage>,
@@ -123,17 +123,17 @@ pub(crate) struct App<T: Frontend> {
 }
 
 #[derive(Clone, Serialize, Deserialize, JsonSchema)]
-pub(crate) struct StatusLine {
+pub struct StatusLine {
     components: Vec<StatusLineComponent>,
 }
 impl StatusLine {
     #[cfg(test)]
-    pub(crate) fn new(components: Vec<StatusLineComponent>) -> Self {
+    pub fn new(components: Vec<StatusLineComponent>) -> Self {
         Self { components }
     }
 }
 #[derive(Clone, Serialize, Deserialize, JsonSchema)]
-pub(crate) enum StatusLineComponent {
+pub enum StatusLineComponent {
     KiCharacter,
     CurrentWorkingDirectory,
     GitBranch,
@@ -156,7 +156,7 @@ pub(crate) enum StatusLineComponent {
 
 impl<T: Frontend> App<T> {
     #[cfg(test)]
-    pub(crate) fn new(
+    pub fn new(
         frontend: Rc<Mutex<T>>,
         working_directory: CanonicalizedPath,
         status_lines: Vec<StatusLine>,
@@ -186,7 +186,7 @@ impl<T: Frontend> App<T> {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn from_channel(
+    pub fn from_channel(
         frontend: Rc<Mutex<T>>,
         working_directory: CanonicalizedPath,
         sender: Sender<AppMessage>,
@@ -278,10 +278,7 @@ impl<T: Frontend> App<T> {
     }
 
     /// This is the main event loop.
-    pub(crate) fn run(
-        mut self,
-        entry_path: Option<CanonicalizedPath>,
-    ) -> Result<(), anyhow::Error> {
+    pub fn run(mut self, entry_path: Option<CanonicalizedPath>) -> Result<(), anyhow::Error> {
         self.set_terminal_options()?;
 
         if let Some(entry_path) = entry_path {
@@ -310,7 +307,7 @@ impl<T: Frontend> App<T> {
         self.quit()
     }
 
-    pub(crate) fn process_message(&mut self, message: AppMessage) -> anyhow::Result<bool> {
+    pub fn process_message(&mut self, message: AppMessage) -> anyhow::Result<bool> {
         match message {
             AppMessage::Event(event) => self.handle_event(event),
             AppMessage::LspNotification(notification) => {
@@ -356,7 +353,7 @@ impl<T: Frontend> App<T> {
         Ok(())
     }
 
-    pub(crate) fn quit(&mut self) -> anyhow::Result<()> {
+    pub fn quit(&mut self) -> anyhow::Result<()> {
         self.prepare_to_suspend_or_quit()?;
 
         self.lsp_manager.shutdown();
@@ -393,12 +390,12 @@ impl<T: Frontend> App<T> {
         Ok(())
     }
 
-    pub(crate) fn components(&self) -> Vec<KindedComponent> {
+    pub fn components(&self) -> Vec<KindedComponent> {
         self.layout.components()
     }
 
     /// Returns true if the app should quit.
-    pub(crate) fn handle_event(&mut self, event: Event) -> anyhow::Result<bool> {
+    pub fn handle_event(&mut self, event: Event) -> anyhow::Result<bool> {
         // Pass event to focused window
         let component = self.current_component();
         match event {
@@ -425,7 +422,7 @@ impl<T: Frontend> App<T> {
         self.layout.components().is_empty()
     }
 
-    pub(crate) fn render(&mut self) -> Result<(), anyhow::Error> {
+    pub fn render(&mut self) -> Result<(), anyhow::Error> {
         let screen = self.get_screen()?;
         self.render_screen(screen)?;
         Ok(())
@@ -435,7 +432,7 @@ impl<T: Frontend> App<T> {
         self.context.keyboard_layout_kind()
     }
 
-    pub(crate) fn get_screen(&mut self) -> Result<Screen, anyhow::Error> {
+    pub fn get_screen(&mut self) -> Result<Screen, anyhow::Error> {
         // Recalculate layout before each render
         self.layout.recalculate_layout(&self.context);
 
@@ -666,10 +663,7 @@ impl<T: Frontend> App<T> {
         self.handle_dispatches(dispatches?)
     }
 
-    pub(crate) fn handle_dispatches(
-        &mut self,
-        dispatches: Dispatches,
-    ) -> Result<(), anyhow::Error> {
+    pub fn handle_dispatches(&mut self, dispatches: Dispatches) -> Result<(), anyhow::Error> {
         for dispatch in dispatches.into_vec() {
             self.handle_dispatch(dispatch)?;
         }
@@ -691,7 +685,7 @@ impl<T: Frontend> App<T> {
         self.integration_event_sender.emit_event(event)
     }
 
-    pub(crate) fn handle_dispatch(&mut self, dispatch: Dispatch) -> Result<(), anyhow::Error> {
+    pub fn handle_dispatch(&mut self, dispatch: Dispatch) -> Result<(), anyhow::Error> {
         log::info!("App::handle_dispatch = {}", dispatch.variant_name());
         match dispatch {
             Dispatch::Suspend => {
@@ -1125,14 +1119,14 @@ impl<T: Frontend> App<T> {
         Ok(())
     }
 
-    pub(crate) fn get_editor_by_file_path(
+    pub fn get_editor_by_file_path(
         &self,
         path: &CanonicalizedPath,
     ) -> Option<Rc<RefCell<SuggestiveEditor>>> {
         self.layout.get_existing_editor(path)
     }
 
-    pub(crate) fn current_component(&self) -> Rc<RefCell<dyn Component>> {
+    pub fn current_component(&self) -> Rc<RefCell<dyn Component>> {
         self.layout.get_current_component()
     }
 
@@ -1488,10 +1482,7 @@ impl<T: Frontend> App<T> {
         Ok(component)
     }
 
-    pub(crate) fn handle_lsp_notification(
-        &mut self,
-        notification: LspNotification,
-    ) -> anyhow::Result<()> {
+    pub fn handle_lsp_notification(&mut self, notification: LspNotification) -> anyhow::Result<()> {
         match notification {
             LspNotification::Hover(hover) => self.show_editor_info(Info::new(
                 "Hover Info".to_string(),
@@ -1611,7 +1602,7 @@ impl<T: Frontend> App<T> {
         }
     }
 
-    pub(crate) fn update_diagnostics(
+    pub fn update_diagnostics(
         &mut self,
         path: CanonicalizedPath,
         diagnostics: Vec<lsp_types::Diagnostic>,
@@ -1626,7 +1617,7 @@ impl<T: Frontend> App<T> {
         Ok(())
     }
 
-    pub(crate) fn get_quickfix_list(&self) -> Option<QuickfixList> {
+    pub fn get_quickfix_list(&self) -> Option<QuickfixList> {
         self.context.quickfix_list_state().as_ref().map(|state| {
             let items = self
                 .layout
@@ -1869,11 +1860,11 @@ impl<T: Frontend> App<T> {
         Ok(())
     }
 
-    pub(crate) fn quit_all(&self) -> Result<(), anyhow::Error> {
+    pub fn quit_all(&self) -> Result<(), anyhow::Error> {
         Ok(self.sender.send(AppMessage::QuitAll)?)
     }
 
-    pub(crate) fn sender(&self) -> Sender<AppMessage> {
+    pub fn sender(&self) -> Sender<AppMessage> {
         self.sender.clone()
     }
 
@@ -2015,7 +2006,7 @@ impl<T: Frontend> App<T> {
     }
 
     #[cfg(test)]
-    pub(crate) fn get_current_selected_texts(&self) -> Vec<String> {
+    pub fn get_current_selected_texts(&self) -> Vec<String> {
         self.current_component()
             .borrow()
             .editor()
@@ -2023,7 +2014,7 @@ impl<T: Frontend> App<T> {
     }
 
     #[cfg(test)]
-    pub(crate) fn get_current_editor(&self) -> Rc<RefCell<dyn Component>> {
+    pub fn get_current_editor(&self) -> Rc<RefCell<dyn Component>> {
         let component = self
             .layout
             .get_component_by_kind(ComponentKind::SuggestiveEditor)
@@ -2032,7 +2023,7 @@ impl<T: Frontend> App<T> {
     }
 
     #[cfg(test)]
-    pub(crate) fn get_file_content(&self, path: &CanonicalizedPath) -> String {
+    pub fn get_file_content(&self, path: &CanonicalizedPath) -> String {
         self.layout
             .get_existing_editor(path)
             .unwrap()
@@ -2040,7 +2031,7 @@ impl<T: Frontend> App<T> {
             .content()
     }
 
-    pub(crate) fn handle_dispatch_editor(
+    pub fn handle_dispatch_editor(
         &mut self,
         dispatch_editor: DispatchEditor,
     ) -> anyhow::Result<()> {
@@ -2124,7 +2115,7 @@ impl<T: Frontend> App<T> {
         self.global_title = Some(title)
     }
 
-    pub(crate) fn get_current_file_path(&self) -> Option<CanonicalizedPath> {
+    pub fn get_current_file_path(&self) -> Option<CanonicalizedPath> {
         self.current_component().borrow().path()
     }
 
@@ -2137,7 +2128,7 @@ impl<T: Frontend> App<T> {
     }
 
     #[cfg(test)]
-    pub(crate) fn context(&self) -> &Context {
+    pub fn context(&self) -> &Context {
         &self.context
     }
 
@@ -2239,12 +2230,12 @@ impl<T: Frontend> App<T> {
     }
 
     #[cfg(test)]
-    pub(crate) fn get_current_component_content(&self) -> String {
+    pub fn get_current_component_content(&self) -> String {
         self.current_component().borrow().editor().content()
     }
 
     #[cfg(test)]
-    pub(crate) fn get_buffer_contents_map(&self) -> BufferContentsMap {
+    pub fn get_buffer_contents_map(&self) -> BufferContentsMap {
         self.layout.get_buffer_contents_map()
     }
 
@@ -2256,7 +2247,7 @@ impl<T: Frontend> App<T> {
         Ok(())
     }
 
-    pub(crate) fn handle_dispatch_suggestive_editor(
+    pub fn handle_dispatch_suggestive_editor(
         &mut self,
         dispatch: DispatchSuggestiveEditor,
     ) -> anyhow::Result<()> {
@@ -2292,16 +2283,16 @@ impl<T: Frontend> App<T> {
     }
 
     #[cfg(test)]
-    pub(crate) fn completion_dropdown_is_open(&self) -> bool {
+    pub fn completion_dropdown_is_open(&self) -> bool {
         self.layout.completion_dropdown_is_open()
     }
 
-    pub(crate) fn current_completion_dropdown(&self) -> Option<Rc<RefCell<dyn Component>>> {
+    pub fn current_completion_dropdown(&self) -> Option<Rc<RefCell<dyn Component>>> {
         self.layout.current_completion_dropdown()
     }
 
     #[cfg(test)]
-    pub(crate) fn current_completion_dropdown_info(&self) -> Option<Rc<RefCell<dyn Component>>> {
+    pub fn current_completion_dropdown_info(&self) -> Option<Rc<RefCell<dyn Component>>> {
         self.layout
             .get_component_by_kind(ComponentKind::DropdownInfo)
     }
@@ -2405,14 +2396,11 @@ impl<T: Frontend> App<T> {
     }
 
     #[cfg(test)]
-    pub(crate) fn get_dropdown_infos_count(&self) -> usize {
+    pub fn get_dropdown_infos_count(&self) -> usize {
         self.layout.get_dropdown_infos_count()
     }
 
-    pub(crate) fn render_quickfix_list(
-        &mut self,
-        quickfix_list: QuickfixList,
-    ) -> anyhow::Result<()> {
+    pub fn render_quickfix_list(&mut self, quickfix_list: QuickfixList) -> anyhow::Result<()> {
         let (editor, dispatches) = self
             .layout
             .show_quickfix_list(quickfix_list, &self.context)?;
@@ -2442,12 +2430,12 @@ impl<T: Frontend> App<T> {
     }
 
     #[cfg(test)]
-    pub(crate) fn editor_info_contents(&self) -> Vec<String> {
+    pub fn editor_info_contents(&self) -> Vec<String> {
         self.layout.editor_info_contents()
     }
 
     #[cfg(test)]
-    pub(crate) fn global_info_contents(&self) -> Vec<String> {
+    pub fn global_info_contents(&self) -> Vec<String> {
         self.layout.global_info_contents()
     }
 
@@ -2467,7 +2455,7 @@ impl<T: Frontend> App<T> {
     }
 
     #[cfg(test)]
-    pub(crate) fn file_explorer_content(&self) -> String {
+    pub fn file_explorer_content(&self) -> String {
         self.layout.file_explorer_content()
     }
 
@@ -2495,20 +2483,17 @@ impl<T: Frontend> App<T> {
             .emit_event(IntegrationEvent::ShowInfo { info: None });
     }
 
-    pub(crate) fn opened_files_count(&self) -> usize {
+    pub fn opened_files_count(&self) -> usize {
         self.layout.get_opened_files().len()
     }
 
     #[cfg(test)]
-    pub(crate) fn global_info(&self) -> Option<String> {
+    pub fn global_info(&self) -> Option<String> {
         self.layout.global_info()
     }
 
     #[cfg(test)]
-    pub(crate) fn get_component_by_kind(
-        &self,
-        kind: ComponentKind,
-    ) -> Option<Rc<RefCell<dyn Component>>> {
+    pub fn get_component_by_kind(&self, kind: ComponentKind) -> Option<Rc<RefCell<dyn Component>>> {
         self.layout.get_component_by_kind(kind)
     }
 
@@ -2517,7 +2502,7 @@ impl<T: Frontend> App<T> {
     }
 
     #[cfg(test)]
-    pub(crate) fn components_order(&self) -> Vec<ComponentKind> {
+    pub fn components_order(&self) -> Vec<ComponentKind> {
         self.layout
             .components()
             .into_iter()
@@ -2616,7 +2601,7 @@ impl<T: Frontend> App<T> {
     }
 
     #[cfg(test)]
-    pub(crate) fn lsp_request_sent(&self, from_editor: &FromEditor) -> bool {
+    pub fn lsp_request_sent(&self, from_editor: &FromEditor) -> bool {
         self.lsp_manager.lsp_request_sent(from_editor)
     }
 
@@ -2813,7 +2798,7 @@ impl<T: Frontend> App<T> {
         self.context.is_running_as_embedded()
     }
 
-    pub(crate) fn take_queued_events(&mut self) -> Vec<Event> {
+    pub fn take_queued_events(&mut self) -> Vec<Event> {
         std::mem::take(&mut self.queued_events)
     }
 
@@ -2910,9 +2895,7 @@ impl<T: Frontend> App<T> {
     }
 
     #[cfg(test)]
-    pub(crate) fn lsp_server_initialized_args(
-        &self,
-    ) -> Option<(LanguageId, Vec<CanonicalizedPath>)> {
+    pub fn lsp_server_initialized_args(&self) -> Option<(LanguageId, Vec<CanonicalizedPath>)> {
         self.lsp_manager.lsp_server_initialized_args()
     }
 
@@ -2985,7 +2968,7 @@ impl<T: Frontend> App<T> {
     }
 
     #[cfg(test)]
-    pub(crate) fn wait_for_app_message(
+    pub fn wait_for_app_message(
         &mut self,
         app_message_matcher: &lazy_regex::Lazy<regex::Regex>,
         timeout: Option<Duration>,
@@ -3011,7 +2994,7 @@ impl<T: Frontend> App<T> {
     }
 
     #[cfg(test)]
-    pub(crate) fn expect_app_message_not_received(
+    pub fn expect_app_message_not_received(
         &mut self,
         regex: &&'static lazy_regex::Lazy<regex::Regex>,
         timeout: &Duration,
@@ -3310,19 +3293,19 @@ Conflict markers will be injected in areas that cannot be merged gracefully."
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub(crate) struct Dimension {
-    pub(crate) height: usize,
-    pub(crate) width: usize,
+pub struct Dimension {
+    pub height: usize,
+    pub width: usize,
 }
 
 impl Dimension {
     #[cfg(test)]
-    pub(crate) fn area(&self) -> usize {
+    pub fn area(&self) -> usize {
         self.height * self.width
     }
 
     #[cfg(test)]
-    pub(crate) fn positions(&self) -> std::collections::HashSet<Position> {
+    pub fn positions(&self) -> std::collections::HashSet<Position> {
         (0..self.height)
             .flat_map(|line| (0..self.width).map(move |column| Position { column, line }))
             .collect()
@@ -3338,30 +3321,30 @@ impl Dimension {
 
 #[must_use]
 #[derive(Clone, Debug, PartialEq, Default)]
-pub(crate) struct Dispatches(Vec<Dispatch>);
+pub struct Dispatches(Vec<Dispatch>);
 impl From<Vec<Dispatch>> for Dispatches {
     fn from(value: Vec<Dispatch>) -> Self {
         Self(value)
     }
 }
 impl Dispatches {
-    pub(crate) fn into_vec(self) -> Vec<Dispatch> {
+    pub fn into_vec(self) -> Vec<Dispatch> {
         self.0
     }
 
-    pub(crate) fn new(dispatches: Vec<Dispatch>) -> Dispatches {
+    pub fn new(dispatches: Vec<Dispatch>) -> Dispatches {
         Dispatches(dispatches)
     }
 
-    pub(crate) fn chain(self, other: Dispatches) -> Dispatches {
+    pub fn chain(self, other: Dispatches) -> Dispatches {
         self.0.into_iter().chain(other.0).collect_vec().into()
     }
 
-    pub(crate) fn append(self, other: Dispatch) -> Dispatches {
+    pub fn append(self, other: Dispatch) -> Dispatches {
         self.0.into_iter().chain(Some(other)).collect_vec().into()
     }
 
-    pub(crate) fn append_some(self, dispatch: Option<Dispatch>) -> Dispatches {
+    pub fn append_some(self, dispatch: Option<Dispatch>) -> Dispatches {
         if let Some(dispatch) = dispatch {
             self.append(dispatch)
         } else {
@@ -3369,11 +3352,11 @@ impl Dispatches {
         }
     }
 
-    pub(crate) fn one(edit: Dispatch) -> Dispatches {
+    pub fn one(edit: Dispatch) -> Dispatches {
         Dispatches(vec![edit])
     }
 
-    pub(crate) fn empty() -> Dispatches {
+    pub fn empty() -> Dispatches {
         Dispatches(Default::default())
     }
 }
@@ -3381,7 +3364,7 @@ impl Dispatches {
 #[must_use]
 #[derive(Clone, Debug, PartialEq, NamedVariant)]
 /// Dispatch are for child component to request action from the root node
-pub(crate) enum Dispatch {
+pub enum Dispatch {
     SetTheme(crate::themes::Theme),
     SetThemeFromDescriptor(crate::themes::theme_descriptor::ThemeDescriptor),
     CloseCurrentWindow,
@@ -3590,7 +3573,7 @@ pub(crate) enum Dispatch {
 
 /// Used to send notify host app about changes
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) enum ToHostApp {
+pub enum ToHostApp {
     BufferEditTransaction {
         path: CanonicalizedPath,
         edits: Vec<ki_protocol_types::DiffEdit>,
@@ -3610,7 +3593,7 @@ pub(crate) enum ToHostApp {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) enum FromHostApp {
+pub enum FromHostApp {
     TargetedEvent {
         event: Event,
         path: Option<CanonicalizedPath>,
@@ -3619,12 +3602,12 @@ pub(crate) enum FromHostApp {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) enum GlobalSearchConfigUpdate {
+pub enum GlobalSearchConfigUpdate {
     Config(GlobalSearchConfig),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) enum LocalSearchConfigUpdate {
+pub enum LocalSearchConfigUpdate {
     #[cfg(test)]
     Mode(LocalSearchConfigMode),
     #[cfg(test)]
@@ -3635,19 +3618,19 @@ pub(crate) enum LocalSearchConfigUpdate {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub(crate) struct YesNoPrompt {
-    pub(crate) title: String,
-    pub(crate) yes: Box<Dispatch>,
+pub struct YesNoPrompt {
+    pub title: String,
+    pub yes: Box<Dispatch>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) enum FilePickerKind {
+pub enum FilePickerKind {
     NonGitIgnored,
     GitStatus(git::DiffMode),
     Opened,
 }
 impl FilePickerKind {
-    pub(crate) fn display(&self) -> String {
+    pub fn display(&self) -> String {
         match self {
             FilePickerKind::NonGitIgnored => "Not Git Ignored".to_string(),
             FilePickerKind::GitStatus(diff_mode) => format!("Git Status ({})", diff_mode.display()),
@@ -3657,13 +3640,13 @@ impl FilePickerKind {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct RequestParams {
-    pub(crate) path: CanonicalizedPath,
-    pub(crate) position: Position,
-    pub(crate) context: ResponseContext,
+pub struct RequestParams {
+    pub path: CanonicalizedPath,
+    pub position: Position,
+    pub context: ResponseContext,
 }
 impl RequestParams {
-    pub(crate) fn set_kind(self, scope: Option<Scope>) -> Self {
+    pub fn set_kind(self, scope: Option<Scope>) -> Self {
         Self {
             context: ResponseContext {
                 scope,
@@ -3673,7 +3656,7 @@ impl RequestParams {
         }
     }
 
-    pub(crate) fn set_description(self, description: &str) -> Self {
+    pub fn set_description(self, description: &str) -> Self {
         Self {
             context: ResponseContext {
                 description: Some(description.to_string()),
@@ -3685,13 +3668,13 @@ impl RequestParams {
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq, Copy)]
-pub(crate) enum Scope {
+pub enum Scope {
     Local,
     Global,
 }
 
 #[derive(Debug)]
-pub(crate) enum AppMessage {
+pub enum AppMessage {
     LspNotification(Box<LspNotification>),
     Event(Event),
     QuitAll,
@@ -3708,7 +3691,7 @@ pub(crate) enum AppMessage {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) enum DispatchParser {
+pub enum DispatchParser {
     MoveSelectionByIndex,
     RenameSymbol,
     UpdateLocalSearchConfigSearch {
@@ -3737,7 +3720,7 @@ pub(crate) enum DispatchParser {
 }
 
 impl DispatchParser {
-    pub(crate) fn parse(&self, text: &str) -> anyhow::Result<Dispatches> {
+    pub fn parse(&self, text: &str) -> anyhow::Result<Dispatches> {
         match self.clone() {
             DispatchParser::MoveSelectionByIndex => {
                 let index = text.parse::<usize>()?.saturating_sub(1);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -154,7 +154,7 @@ fn process_edit_args(args: EditArgs) -> anyhow::Result<RunConfig> {
     }
 }
 
-pub(crate) fn cli() -> anyhow::Result<()> {
+pub fn cli() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
@@ -200,7 +200,7 @@ pub(crate) fn cli() -> anyhow::Result<()> {
     }
 }
 
-pub(crate) fn get_version() -> String {
+pub fn get_version() -> String {
     let git_hash = env!("GIT_HASH");
     let build_time = env!("BUILD_TIME");
     format!("{git_hash} (Built on {build_time})")
@@ -208,7 +208,7 @@ pub(crate) fn get_version() -> String {
 
 use grammar::grammar::GrammarConfiguration;
 
-pub(crate) fn grammar_configs() -> Vec<GrammarConfiguration> {
+pub fn grammar_configs() -> Vec<GrammarConfiguration> {
     crate::config::AppConfig::singleton()
         .languages()
         .iter()

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -6,7 +6,7 @@ use scraper::{Html, Selector};
 use crate::osc52;
 
 #[derive(Clone)]
-pub(crate) struct Clipboard {
+pub struct Clipboard {
     history: RingHistory<CopiedTexts>,
 }
 
@@ -15,11 +15,11 @@ pub(crate) struct Clipboard {
 /// Because it needs to support multiple cursors.
 /// The first entry represent the copied text of the first cursor,
 /// and so forth.
-pub(crate) struct CopiedTexts {
+pub struct CopiedTexts {
     texts: NonEmpty<String>,
 }
 impl CopiedTexts {
-    pub(crate) fn new(texts: NonEmpty<String>) -> Self {
+    pub fn new(texts: NonEmpty<String>) -> Self {
         Self { texts }
     }
 
@@ -28,7 +28,7 @@ impl CopiedTexts {
     }
 
     /// Returns the first element if no element is found at the given `index`
-    pub(crate) fn get(&self, index: usize) -> String {
+    pub fn get(&self, index: usize) -> String {
         self.texts
             .get(index)
             .unwrap_or_else(|| self.texts.first())
@@ -36,7 +36,7 @@ impl CopiedTexts {
     }
 
     #[cfg(test)]
-    pub(crate) fn one(string: String) -> CopiedTexts {
+    pub fn one(string: String) -> CopiedTexts {
         CopiedTexts::new(NonEmpty::singleton(string))
     }
 
@@ -142,17 +142,17 @@ impl CopiedTexts {
 }
 
 impl Clipboard {
-    pub(crate) fn new() -> Clipboard {
+    pub fn new() -> Clipboard {
         Clipboard {
             history: RingHistory::new(),
         }
     }
 
-    pub(crate) fn get(&self, history_offset: isize) -> Option<CopiedTexts> {
+    pub fn get(&self, history_offset: isize) -> Option<CopiedTexts> {
         self.history.get(history_offset)
     }
 
-    pub(crate) fn get_from_system_clipboard(&self) -> anyhow::Result<CopiedTexts> {
+    pub fn get_from_system_clipboard(&self) -> anyhow::Result<CopiedTexts> {
         // Try to parse the HTML as a Ki-injected HTML
         let mut clipboard = arboard::Clipboard::new()?;
         clipboard
@@ -167,7 +167,7 @@ impl Clipboard {
             })
     }
 
-    pub(crate) fn set(&mut self, copied_texts: CopiedTexts) -> anyhow::Result<()> {
+    pub fn set(&mut self, copied_texts: CopiedTexts) -> anyhow::Result<()> {
         self.history.add(copied_texts.clone());
         arboard::Clipboard::new()
             .and_then(|mut clipboard| {
@@ -177,20 +177,20 @@ impl Clipboard {
         Ok(())
     }
 
-    pub(crate) fn add_clipboard_history(&mut self, copied_texts: CopiedTexts) {
+    pub fn add_clipboard_history(&mut self, copied_texts: CopiedTexts) {
         self.history.add(copied_texts.clone());
     }
 }
 
 #[derive(PartialEq, Clone, Debug, Eq, Hash, Default)]
-pub(crate) struct RingHistory<T: Clone> {
+pub struct RingHistory<T: Clone> {
     items: Vec<T>,
 }
 impl<T: Clone> RingHistory<T> {
     /// 0 means latest.  
     /// -1 means previous.  
     /// +1 means next.  
-    pub(crate) fn get(&self, history_offset: isize) -> Option<T> {
+    pub fn get(&self, history_offset: isize) -> Option<T> {
         let len = self.items.len();
         if len == 0 {
             return None;
@@ -211,7 +211,7 @@ impl<T: Clone> RingHistory<T> {
         }
     }
 
-    pub(crate) fn add(&mut self, item: T) {
+    pub fn add(&mut self, item: T) {
         self.items.push(item)
     }
 

--- a/src/components/component.rs
+++ b/src/components/component.rs
@@ -8,9 +8,9 @@ use crate::{context::Context, grid::Grid, position::Position, rectangle::Rectang
 
 use super::editor::{DispatchEditor, Editor};
 
-pub(crate) struct GetGridResult {
-    pub(crate) grid: Grid,
-    pub(crate) cursor: Option<Cursor>,
+pub struct GetGridResult {
+    pub grid: Grid,
+    pub cursor: Option<Cursor>,
 }
 
 #[cfg(test)]
@@ -31,7 +31,7 @@ impl std::fmt::Display for GetGridResult {
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct Cursor {
+pub struct Cursor {
     position: Position,
     style: SetCursorStyle,
 }
@@ -65,19 +65,19 @@ impl From<&SetCursorStyle> for crossterm::cursor::SetCursorStyle {
 }
 
 impl Cursor {
-    pub(crate) fn style(&self) -> &SetCursorStyle {
+    pub fn style(&self) -> &SetCursorStyle {
         &self.style
     }
 
-    pub(crate) fn position(&self) -> &Position {
+    pub fn position(&self) -> &Position {
         &self.position
     }
 
-    pub(crate) fn new(position: Position, style: SetCursorStyle) -> Cursor {
+    pub fn new(position: Position, style: SetCursorStyle) -> Cursor {
         Cursor { position, style }
     }
 
-    pub(crate) fn set_position(self, position: Position) -> Cursor {
+    pub fn set_position(self, position: Position) -> Cursor {
         Cursor { position, ..self }
     }
 }
@@ -209,9 +209,9 @@ fn increment_counter() -> usize {
 }
 
 #[derive(Ord, PartialOrd, Eq, PartialEq, Debug, Clone, Copy, Hash, Default)]
-pub(crate) struct ComponentId(usize);
+pub struct ComponentId(usize);
 impl ComponentId {
-    pub(crate) fn new() -> ComponentId {
+    pub fn new() -> ComponentId {
         ComponentId(increment_counter())
     }
 }

--- a/src/components/dropdown.rs
+++ b/src/components/dropdown.rs
@@ -14,8 +14,8 @@ use super::suggestive_editor::{Decoration, Info};
 
 #[derive(Clone, Debug, PartialEq)]
 /// Note: filtering will be done on the combination of `display` and `group` (if applicable)
-pub(crate) struct DropdownItem {
-    pub(crate) dispatches: Dispatches,
+pub struct DropdownItem {
+    pub dispatches: Dispatches,
     display: String,
     group: Option<String>,
     info: Option<Info>,
@@ -30,11 +30,11 @@ pub(crate) struct DropdownItem {
 }
 
 impl DropdownItem {
-    pub(crate) fn display(&self) -> String {
+    pub fn display(&self) -> String {
         self.display.clone()
     }
 
-    pub(crate) fn new(display: String) -> Self {
+    pub fn new(display: String) -> Self {
         Self {
             dispatches: Default::default(),
             display,
@@ -47,49 +47,46 @@ impl DropdownItem {
         }
     }
 
-    pub(crate) fn set_highlight_column_range(
-        self,
-        highlight_column_range: Option<Range<usize>>,
-    ) -> Self {
+    pub fn set_highlight_column_range(self, highlight_column_range: Option<Range<usize>>) -> Self {
         Self {
             highlight_column_range,
             ..self
         }
     }
 
-    pub(crate) fn set_info(self, info: Option<Info>) -> Self {
+    pub fn set_info(self, info: Option<Info>) -> Self {
         Self { info, ..self }
     }
 
-    pub(crate) fn info(&self) -> Option<&Info> {
+    pub fn info(&self) -> Option<&Info> {
         self.info.as_ref()
     }
 
-    pub(crate) fn set_dispatches(self, dispatches: Dispatches) -> DropdownItem {
+    pub fn set_dispatches(self, dispatches: Dispatches) -> DropdownItem {
         Self { dispatches, ..self }
     }
 
-    pub(crate) fn set_group(self, group: Option<String>) -> Self {
+    pub fn set_group(self, group: Option<String>) -> Self {
         Self { group, ..self }
     }
 
-    pub(crate) fn set_rank(self, rank: Option<Box<[usize]>>) -> DropdownItem {
+    pub fn set_rank(self, rank: Option<Box<[usize]>>) -> DropdownItem {
         Self { rank, ..self }
     }
 
-    pub(crate) fn set_on_focused(self, on_focused: Dispatches) -> DropdownItem {
+    pub fn set_on_focused(self, on_focused: Dispatches) -> DropdownItem {
         Self { on_focused, ..self }
     }
 
-    pub(crate) fn on_focused(&self) -> Dispatches {
+    pub fn on_focused(&self) -> Dispatches {
         self.on_focused.clone()
     }
 
-    pub(crate) fn resolved(&self) -> bool {
+    pub fn resolved(&self) -> bool {
         self.resolved
     }
 
-    pub(crate) fn from_path_buf(
+    pub fn from_path_buf(
         working_directory: &CanonicalizedPath,
         path: std::path::PathBuf,
     ) -> DropdownItem {
@@ -108,7 +105,7 @@ impl DropdownItem {
         }))
     }
 
-    pub(crate) fn group(&self) -> &Option<String> {
+    pub fn group(&self) -> &Option<String> {
         &self.group
     }
 }
@@ -146,7 +143,7 @@ impl From<String> for DropdownItem {
     }
 }
 
-pub(crate) struct Dropdown {
+pub struct Dropdown {
     title: String,
     filter: String,
     items: Vec<DropdownItem>,
@@ -154,12 +151,12 @@ pub(crate) struct Dropdown {
     current_item_index: usize,
 }
 
-pub(crate) struct DropdownConfig {
-    pub(crate) title: String,
+pub struct DropdownConfig {
+    pub title: String,
 }
 
 impl Dropdown {
-    pub(crate) fn new(config: DropdownConfig) -> Self {
+    pub fn new(config: DropdownConfig) -> Self {
         Self {
             filter: String::new(),
             items: vec![],
@@ -169,7 +166,7 @@ impl Dropdown {
         }
     }
 
-    pub(crate) fn change_index(&mut self, index: usize) {
+    pub fn change_index(&mut self, index: usize) {
         if !self.filtered_item_groups.iter().any(|group| {
             group
                 .items
@@ -199,11 +196,11 @@ impl Dropdown {
         item_index + group_index * group_title_size + group_gap + group_title_size
     }
 
-    pub(crate) fn next_item(&mut self) {
+    pub fn next_item(&mut self) {
         self.change_index(self.current_item_index + 1)
     }
 
-    pub(crate) fn previous_item(&mut self) {
+    pub fn previous_item(&mut self) {
         self.change_index(self.current_item_index.saturating_sub(1))
     }
 
@@ -278,7 +275,7 @@ impl Dropdown {
         self.change_group_index(false).unwrap_or_default()
     }
 
-    pub(crate) fn current_item(&self) -> Option<DropdownItem> {
+    pub fn current_item(&self) -> Option<DropdownItem> {
         self.get_item_by_index(self.current_item_index)
     }
 
@@ -290,7 +287,7 @@ impl Dropdown {
             .map(|item| item.item.clone())
     }
 
-    pub(crate) fn set_items(&mut self, items: Vec<DropdownItem>) {
+    pub fn set_items(&mut self, items: Vec<DropdownItem>) {
         if items == self.items {
             return;
         }
@@ -449,7 +446,7 @@ impl Dropdown {
             .collect_vec();
     }
 
-    pub(crate) fn set_filter(&mut self, filter: &str) {
+    pub fn set_filter(&mut self, filter: &str) {
         if filter == self.filter {
             return;
         }
@@ -458,7 +455,7 @@ impl Dropdown {
         self.compute_filtered_items();
     }
 
-    pub(crate) fn render(&self) -> DropdownRender {
+    pub fn render(&self) -> DropdownRender {
         let (content, decorations) = self.content();
         DropdownRender {
             title: self.title.clone(),
@@ -558,7 +555,7 @@ impl Dropdown {
         (joined, decorations)
     }
 
-    pub(crate) fn apply_movement(&mut self, movement: Movement) {
+    pub fn apply_movement(&mut self, movement: Movement) {
         match movement {
             Movement::Right | Movement::Down => self.next_item(),
             Movement::Current(_) => {}
@@ -579,15 +576,15 @@ impl Dropdown {
         assert_eq!(highlighed_content, label);
     }
 
-    pub(crate) fn items(&self) -> Vec<DropdownItem> {
+    pub fn items(&self) -> Vec<DropdownItem> {
         self.items.clone()
     }
 
-    pub(crate) fn set_current_item_index(&mut self, current_item_index: usize) {
+    pub fn set_current_item_index(&mut self, current_item_index: usize) {
         self.current_item_index = current_item_index
     }
 
-    pub(crate) fn current_item_index(&self) -> usize {
+    pub fn current_item_index(&self) -> usize {
         self.current_item_index
     }
 
@@ -650,11 +647,11 @@ impl Dropdown {
             .collect_vec()
     }
 
-    pub(crate) fn no_matching_candidates(&self) -> bool {
+    pub fn no_matching_candidates(&self) -> bool {
         self.filtered_item_groups.is_empty()
     }
 
-    pub(crate) fn update_current_item(&mut self, item: DropdownItem) {
+    pub fn update_current_item(&mut self, item: DropdownItem) {
         if let Some(matching) = self.items.iter_mut().find(|i| i.display == item.display) {
             debug_assert!(!matching.resolved());
             *matching = DropdownItem {
@@ -1104,12 +1101,12 @@ mod test_dropdown {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct DropdownRender {
-    pub(crate) content: String,
-    pub(crate) decorations: Vec<Decoration>,
-    pub(crate) title: String,
-    pub(crate) highlight_line_index: usize,
-    pub(crate) info: Option<Info>,
+pub struct DropdownRender {
+    pub content: String,
+    pub decorations: Vec<Decoration>,
+    pub title: String,
+    pub highlight_line_index: usize,
+    pub info: Option<Info>,
 }
 #[derive(Debug, Clone, PartialEq)]
 struct FilteredDropdownItem {

--- a/src/components/editor.rs
+++ b/src/components/editor.rs
@@ -51,7 +51,7 @@ use std::{
 use DispatchEditor::*;
 
 #[derive(PartialEq, Clone, Debug, Eq)]
-pub(crate) enum Mode {
+pub enum Mode {
     Normal,
     Insert,
     MultiCursor,
@@ -62,15 +62,15 @@ pub(crate) enum Mode {
 }
 
 #[derive(Clone, Copy, PartialEq, Debug, Eq)]
-pub(crate) enum PriorChange {
+pub enum PriorChange {
     EnterMultiCursorMode,
     EnableSelectionExtension,
 }
 
 #[derive(PartialEq, Clone, Debug)]
-pub(crate) struct Jump {
-    pub(crate) character: char,
-    pub(crate) selection: Selection,
+pub struct Jump {
+    pub character: char,
+    pub selection: Selection,
 }
 
 impl Component for Editor {
@@ -412,7 +412,7 @@ impl Component for Editor {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) enum Reveal {
+pub enum Reveal {
     CurrentSelectionMode,
     Cursor,
     Mark,
@@ -441,14 +441,14 @@ impl Clone for Editor {
     }
 }
 
-pub(crate) struct Editor {
-    pub(crate) mode: Mode,
-    pub(crate) regex_highlight_rules: Vec<RegexHighlightRule>,
+pub struct Editor {
+    pub mode: Mode,
+    pub regex_highlight_rules: Vec<RegexHighlightRule>,
 
-    pub(crate) selection_set: SelectionSet,
+    pub selection_set: SelectionSet,
 
-    pub(crate) jumps: Option<Vec<Jump>>,
-    pub(crate) cursor_direction: Direction,
+    pub jumps: Option<Vec<Jump>>,
+    pub cursor_direction: Direction,
 
     /// This means the number of lines to be skipped from the top during rendering.
     /// 2 means the first line to be rendered on the screen if the 3rd line of the text.
@@ -457,16 +457,16 @@ pub(crate) struct Editor {
     buffer: Rc<RefCell<Buffer>>,
     title: Option<String>,
     id: ComponentId,
-    pub(crate) current_view_alignment: Option<ViewAlignment>,
+    pub current_view_alignment: Option<ViewAlignment>,
     copied_text_history_offset: Counter,
-    pub(crate) normal_mode_override: Option<NormalModeOverride>,
-    pub(crate) reveal: Option<Reveal>,
+    pub normal_mode_override: Option<NormalModeOverride>,
+    pub reveal: Option<Reveal>,
 
     /// This is only used when Ki is running as an embedded component,
     /// for example, inside VS Code.
     visible_line_ranges: Option<Vec<Range<usize>>>,
 
-    pub(crate) incremental_search_matches: Option<Vec<Range<usize>>>,
+    pub incremental_search_matches: Option<Vec<Range<usize>>>,
 }
 
 #[derive(Default)]
@@ -495,20 +495,20 @@ impl Counter {
     }
 }
 
-pub(crate) struct RegexHighlightRule {
-    pub(crate) regex: regex::Regex,
-    pub(crate) capture_styles: Vec<RegexHighlightRuleCaptureStyle>,
+pub struct RegexHighlightRule {
+    pub regex: regex::Regex,
+    pub capture_styles: Vec<RegexHighlightRuleCaptureStyle>,
 }
 
-pub(crate) struct RegexHighlightRuleCaptureStyle {
+pub struct RegexHighlightRuleCaptureStyle {
     /// 0 means the entire match.
     /// Refer https://docs.rs/regex/latest/regex/struct.Regex.html#method.captures
-    pub(crate) capture_name: &'static str,
-    pub(crate) source: Source,
+    pub capture_name: &'static str,
+    pub source: Source,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) enum Direction {
+pub enum Direction {
     /// Also means Backward or Previous
     Start,
     /// Also means Forward or Next
@@ -516,7 +516,7 @@ pub(crate) enum Direction {
 }
 
 impl Direction {
-    pub(crate) fn reverse(&self) -> Self {
+    pub fn reverse(&self) -> Self {
         match self {
             Direction::Start => Direction::End,
             Direction::End => Direction::Start,
@@ -524,18 +524,18 @@ impl Direction {
     }
 
     #[cfg(test)]
-    pub(crate) fn default() -> Direction {
+    pub fn default() -> Direction {
         Direction::Start
     }
 
-    pub(crate) fn format_action(&self, action: &str) -> String {
+    pub fn format_action(&self, action: &str) -> String {
         match self {
             Direction::Start => format!("← {action}"),
             Direction::End => format!("{action} →"),
         }
     }
 
-    pub(crate) fn to_if_current_not_found(&self) -> IfCurrentNotFound {
+    pub fn to_if_current_not_found(&self) -> IfCurrentNotFound {
         match self {
             Direction::Start => IfCurrentNotFound::LookBackward,
             Direction::End => IfCurrentNotFound::LookForward,
@@ -544,12 +544,12 @@ impl Direction {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Copy)]
-pub(crate) enum IfCurrentNotFound {
+pub enum IfCurrentNotFound {
     LookForward,
     LookBackward,
 }
 impl IfCurrentNotFound {
-    pub(crate) fn inverse(&self) -> IfCurrentNotFound {
+    pub fn inverse(&self) -> IfCurrentNotFound {
         use IfCurrentNotFound::*;
         match self {
             LookForward => LookBackward,
@@ -560,7 +560,7 @@ impl IfCurrentNotFound {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 /// This enum is to be used for binding keys
-pub(crate) enum Movement {
+pub enum Movement {
     Right,
     Left,
     Last,
@@ -576,7 +576,7 @@ pub(crate) enum Movement {
     Next,
 }
 impl Movement {
-    pub(crate) fn into_movement_applicandum(
+    pub fn into_movement_applicandum(
         self,
         sticky_column_index: &Option<usize>,
     ) -> MovementApplicandum {
@@ -637,7 +637,7 @@ impl Movement {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 /// This enum is to be used internally, not exposed to keybindings
 /// Applicandum = To Be Applied
-pub(crate) enum MovementApplicandum {
+pub enum MovementApplicandum {
     Right,
     Left,
     Last,
@@ -659,14 +659,14 @@ pub(crate) enum MovementApplicandum {
 
 impl Editor {
     /// Returns (hidden_parent_lines, visible_parent_lines)
-    pub(crate) fn get_parent_lines(&self) -> anyhow::Result<(Vec<Line>, Vec<Line>)> {
+    pub fn get_parent_lines(&self) -> anyhow::Result<(Vec<Line>, Vec<Line>)> {
         let position = self.get_cursor_position()?;
 
         self.get_parent_lines_given_line_index_and_scroll_offset(position.line, self.scroll_offset)
     }
 
     // BOTTLENECK 5: This causes hiccup when navigating 10,000 lines CSV
-    pub(crate) fn get_parent_lines_given_line_index_and_scroll_offset(
+    pub fn get_parent_lines_given_line_index_and_scroll_offset(
         &self,
         line_index: usize,
         scroll_offset: usize,
@@ -677,13 +677,13 @@ impl Editor {
             .partition(|line| line.line < scroll_offset))
     }
 
-    pub(crate) fn show_info(&mut self, info: Info, context: &Context) -> Result<(), anyhow::Error> {
+    pub fn show_info(&mut self, info: Info, context: &Context) -> Result<(), anyhow::Error> {
         self.set_title(info.title());
         self.set_decorations(info.decorations());
         self.set_content(info.content(), context)
     }
 
-    pub(crate) fn render_dropdown(
+    pub fn render_dropdown(
         &mut self,
         context: &mut Context,
         render: &DropdownRender,
@@ -699,7 +699,7 @@ impl Editor {
         )
     }
 
-    pub(crate) fn from_text(language: Option<tree_sitter::Language>, text: &str) -> Self {
+    pub fn from_text(language: Option<tree_sitter::Language>, text: &str) -> Self {
         Self {
             selection_set: SelectionSet::default(),
             jumps: None,
@@ -721,7 +721,7 @@ impl Editor {
         }
     }
 
-    pub(crate) fn from_buffer(buffer: Rc<RefCell<Buffer>>) -> Self {
+    pub fn from_buffer(buffer: Rc<RefCell<Buffer>>) -> Self {
         // Select the first line of the file
 
         let first_line_range = selection_mode::LineTrimmed
@@ -768,7 +768,7 @@ impl Editor {
     }
 
     /// The returned value includes leading whitespaces but elides trailing newline character
-    pub(crate) fn current_line(&self) -> anyhow::Result<String> {
+    pub fn current_line(&self) -> anyhow::Result<String> {
         let cursor = self.get_cursor_char_index();
         Ok(self
             .buffer
@@ -779,12 +779,12 @@ impl Editor {
             .to_string())
     }
 
-    pub(crate) fn get_current_word(&self) -> anyhow::Result<String> {
+    pub fn get_current_word(&self) -> anyhow::Result<String> {
         let cursor = self.get_cursor_char_index();
         self.buffer.borrow().get_word_before_char_index(cursor)
     }
 
-    pub(crate) fn select_line(
+    pub fn select_line(
         &mut self,
         movement: Movement,
         context: &Context,
@@ -792,11 +792,7 @@ impl Editor {
         self.select(SelectionMode::Line, movement, context)
     }
 
-    pub(crate) fn select_line_at(
-        &mut self,
-        line: usize,
-        context: &Context,
-    ) -> anyhow::Result<Dispatches> {
+    pub fn select_line_at(&mut self, line: usize, context: &Context) -> anyhow::Result<Dispatches> {
         let start = self.buffer.borrow().line_to_char(line)?;
         let selection_set = SelectionSet::new(NonEmpty::singleton(Selection::new(
             (start
@@ -813,11 +809,11 @@ impl Editor {
     }
 
     #[cfg(test)]
-    pub(crate) fn reset(&mut self) {
+    pub fn reset(&mut self) {
         self.selection_set.escape_highlight_mode();
     }
 
-    pub(crate) fn update_selection_set(
+    pub fn update_selection_set(
         &mut self,
         selection_set: SelectionSet,
         store_history: bool,
@@ -838,7 +834,7 @@ impl Editor {
         Dispatches::default().append_some(show_info)
     }
 
-    pub(crate) fn char_index_range_to_selection_set(
+    pub fn char_index_range_to_selection_set(
         &self,
         range: CharIndexRange,
     ) -> anyhow::Result<SelectionSet> {
@@ -929,7 +925,7 @@ impl Editor {
         }
     }
 
-    pub(crate) fn align_selection_to_bottom(&mut self, context: &Context) {
+    pub fn align_selection_to_bottom(&mut self, context: &Context) {
         self.align_selection(
             context,
             // We need to subtract line_range.end by one because it is exclusive
@@ -950,7 +946,7 @@ impl Editor {
 
     /// If the primary selection has multiple lines
     /// then the first line will be used for top alignment
-    pub(crate) fn align_selection_to_top(&mut self) {
+    pub fn align_selection_to_top(&mut self) {
         let selection_first_line = self
             .buffer()
             .char_to_line({
@@ -970,7 +966,7 @@ impl Editor {
             .unwrap_or_default()
     }
 
-    pub(crate) fn select(
+    pub fn select(
         &mut self,
         selection_mode: SelectionMode,
         movement: Movement,
@@ -996,7 +992,7 @@ impl Editor {
         chars.clone().chain(chars.map(shifted_char)).collect()
     }
 
-    pub(crate) fn get_selection_mode_trait_object(
+    pub fn get_selection_mode_trait_object(
         &self,
         selection: &Selection,
         use_current_selection_mode: bool,
@@ -1057,7 +1053,7 @@ impl Editor {
         Ok(())
     }
 
-    pub(crate) fn show_jumps(
+    pub fn show_jumps(
         &mut self,
         use_current_selection_mode: bool,
         context: &Context,
@@ -1088,7 +1084,7 @@ impl Editor {
                     // Let the current_range be at least one character long
                     // so even if the current_range is empty, the user can
                     // still delete the character which is apparently under the cursor.
-                    let current_range = if current_range.len() == 0 {
+                    let current_range = if current_range.is_empty() {
                         (current_range.start
                             ..(current_range.start + 1).min(CharIndex(self.buffer().len_chars())))
                             .into()
@@ -1248,7 +1244,7 @@ impl Editor {
         self.apply_edit_transaction(edit_transaction, context)
     }
 
-    pub(crate) fn copy(&mut self) -> Dispatches {
+    pub fn copy(&mut self) -> Dispatches {
         Dispatches::one(Dispatch::SetClipboardContent {
             copied_texts: CopiedTexts::new(self.selection_set.map(|selection| {
                 self.buffer()
@@ -1408,7 +1404,7 @@ impl Editor {
         self.apply_edit_transaction(edit_transaction, context)
     }
 
-    pub(crate) fn paste_with_movement(
+    pub fn paste_with_movement(
         &mut self,
         context: &mut Context,
         movement: Movement,
@@ -1445,7 +1441,7 @@ impl Editor {
     /// If `history_offset` is 0, it means select the latest copied text;
     ///   +n means select the nth next copied text (cycle to the first copied text if current copied text is the latest)
     ///   -n means select the nth previous copied text (cycle to the last copied text if current copied text is the first)
-    pub(crate) fn replace_with_copied_text(
+    pub fn replace_with_copied_text(
         &mut self,
         context: &Context,
         cut: bool,
@@ -1465,7 +1461,7 @@ impl Editor {
             .chain(dispatches))
     }
 
-    pub(crate) fn apply_edit_transaction(
+    pub fn apply_edit_transaction(
         &mut self,
         edit_transaction: EditTransaction,
         context: &Context,
@@ -1518,7 +1514,7 @@ impl Editor {
         Ok(dispatches)
     }
 
-    pub(crate) fn get_document_did_change_dispatch(&mut self) -> Dispatches {
+    pub fn get_document_did_change_dispatch(&mut self) -> Dispatches {
         [Dispatch::DocumentDidChange {
             component_id: self.id(),
             batch_id: self.buffer().batch_id().clone(),
@@ -1531,15 +1527,15 @@ impl Editor {
         .into()
     }
 
-    pub(crate) fn undo(&mut self, context: &Context) -> anyhow::Result<Dispatches> {
+    pub fn undo(&mut self, context: &Context) -> anyhow::Result<Dispatches> {
         self.undo_or_redo(true, context)
     }
 
-    pub(crate) fn redo(&mut self, context: &Context) -> anyhow::Result<Dispatches> {
+    pub fn redo(&mut self, context: &Context) -> anyhow::Result<Dispatches> {
         self.undo_or_redo(false, context)
     }
 
-    pub(crate) fn swap_cursor(&mut self, context: &Context) {
+    pub fn swap_cursor(&mut self, context: &Context) {
         self.cursor_direction = match self.cursor_direction {
             Direction::Start => Direction::End,
             Direction::End => Direction::Start,
@@ -1547,7 +1543,7 @@ impl Editor {
         self.recalculate_scroll_offset(context)
     }
 
-    pub(crate) fn get_selection_set(
+    pub fn get_selection_set(
         &self,
         mode: &SelectionMode,
         movement: Movement,
@@ -1562,21 +1558,21 @@ impl Editor {
         )
     }
 
-    pub(crate) fn get_cursor_char_index(&self) -> CharIndex {
+    pub fn get_cursor_char_index(&self) -> CharIndex {
         self.selection_set
             .primary_selection()
             .to_char_index(&self.cursor_direction)
     }
 
-    pub(crate) fn enable_selection_extension(&mut self) {
+    pub fn enable_selection_extension(&mut self) {
         self.selection_set.enable_selection_extension();
     }
 
-    pub(crate) fn disable_selection_extension(&mut self) {
+    pub fn disable_selection_extension(&mut self) {
         self.selection_set.unset_initial_range();
     }
 
-    pub(crate) fn handle_key_event(
+    pub fn handle_key_event(
         &mut self,
         context: &Context,
         key_event: KeyEvent,
@@ -1660,11 +1656,7 @@ impl Editor {
     }
 
     // This is similar to Ki's Change, except it enters normal mode
-    pub(crate) fn delete_one(
-        &mut self,
-        context: &Context,
-        cut: bool,
-    ) -> anyhow::Result<Dispatches> {
+    pub fn delete_one(&mut self, context: &Context, cut: bool) -> anyhow::Result<Dispatches> {
         let copy_dispatches: Dispatches = if cut { self.copy() } else { Default::default() };
         let edit_transaction = EditTransaction::from_action_groups(
             self.selection_set
@@ -1673,7 +1665,7 @@ impl Editor {
 
                     // Ensure the delete range is at least one character long
 
-                    let delete_range = if delete_range.len() == 0
+                    let delete_range = if selection.extended_range().is_empty()
                         && delete_range.start < CharIndex(self.buffer().len_chars())
                     {
                         (delete_range.start..delete_range.start + 1).into()
@@ -1709,7 +1701,7 @@ impl Editor {
     }
 
     /// Similar to Change in Vim, but does not copy the current selection
-    pub(crate) fn change(&mut self, context: &Context) -> anyhow::Result<Dispatches> {
+    pub fn change(&mut self, context: &Context) -> anyhow::Result<Dispatches> {
         let edit_transaction = EditTransaction::from_action_groups(
             self.selection_set
                 .map(|selection| -> anyhow::Result<_> {
@@ -1737,11 +1729,11 @@ impl Editor {
             .chain(self.enter_insert_mode(Direction::Start, context)?))
     }
 
-    pub(crate) fn change_cut(&mut self, context: &Context) -> anyhow::Result<Dispatches> {
+    pub fn change_cut(&mut self, context: &Context) -> anyhow::Result<Dispatches> {
         Ok(self.copy().chain(self.change(context)?))
     }
 
-    pub(crate) fn insert(&mut self, s: &str, context: &Context) -> anyhow::Result<Dispatches> {
+    pub fn insert(&mut self, s: &str, context: &Context) -> anyhow::Result<Dispatches> {
         let edit_transaction = EditTransaction::from_action_groups(
             self.selection_set
                 .map(|selection| {
@@ -1772,7 +1764,7 @@ impl Editor {
         self.apply_edit_transaction(edit_transaction, context)
     }
 
-    pub(crate) fn get_request_params(&self) -> Option<RequestParams> {
+    pub fn get_request_params(&self) -> Option<RequestParams> {
         let position = self.get_cursor_position().ok()?;
         self.path().map(|path| RequestParams {
             path,
@@ -1784,7 +1776,7 @@ impl Editor {
         })
     }
 
-    pub(crate) fn set_selection_mode(
+    pub fn set_selection_mode(
         &mut self,
         if_current_not_found: IfCurrentNotFound,
         selection_mode: SelectionMode,
@@ -1877,7 +1869,7 @@ impl Editor {
         }
     }
 
-    pub(crate) fn handle_movement(
+    pub fn handle_movement(
         &mut self,
         context: &Context,
         movement: Movement,
@@ -1902,7 +1894,7 @@ impl Editor {
         }
     }
 
-    pub(crate) fn toggle_marks(&mut self) -> Dispatches {
+    pub fn toggle_marks(&mut self) -> Dispatches {
         let selections = self
             .selection_set
             .map(|selection| selection.extended_range());
@@ -1917,11 +1909,11 @@ impl Editor {
             .unwrap_or_default()
     }
 
-    pub(crate) fn path(&self) -> Option<CanonicalizedPath> {
+    pub fn path(&self) -> Option<CanonicalizedPath> {
         self.editor().buffer().path()
     }
 
-    pub(crate) fn enter_insert_mode(
+    pub fn enter_insert_mode(
         &mut self,
         direction: Direction,
         context: &Context,
@@ -1946,7 +1938,7 @@ impl Editor {
         Ok(Dispatches::one(Dispatch::RequestSignatureHelp))
     }
 
-    pub(crate) fn enter_normal_mode(&mut self, context: &Context) -> anyhow::Result<()> {
+    pub fn enter_normal_mode(&mut self, context: &Context) -> anyhow::Result<()> {
         if self.mode == Mode::Insert {
             // This is necessary for cursor to not overflow after exiting insert mode
             self.set_selection_set(
@@ -1980,14 +1972,14 @@ impl Editor {
     }
 
     #[cfg(test)]
-    pub(crate) fn jump_chars(&self) -> Vec<char> {
+    pub fn jump_chars(&self) -> Vec<char> {
         self.jumps()
             .into_iter()
             .map(|jump| jump.character)
             .collect_vec()
     }
 
-    pub(crate) fn jumps(&self) -> Vec<&Jump> {
+    pub fn jumps(&self) -> Vec<&Jump> {
         self.jumps
             .as_ref()
             .map(|jumps| jumps.iter().collect())
@@ -1996,7 +1988,7 @@ impl Editor {
 
     // TODO: handle mouse click
     #[allow(dead_code)]
-    pub(crate) fn set_cursor_position(
+    pub fn set_cursor_position(
         &mut self,
         row: usize,
         column: usize,
@@ -2220,11 +2212,7 @@ impl Editor {
         self.apply_edit_transaction(EditTransaction::merge(edit_transactions), context)
     }
 
-    pub(crate) fn swap(
-        &mut self,
-        movement: Movement,
-        context: &Context,
-    ) -> anyhow::Result<Dispatches> {
+    pub fn swap(&mut self, movement: Movement, context: &Context) -> anyhow::Result<Dispatches> {
         match movement {
             Movement::Last => self.swap_till_last(context),
             Movement::First => self.swap_till_first(context),
@@ -2338,7 +2326,7 @@ impl Editor {
         self.apply_edit_transaction(edit_transaction, context)
     }
 
-    pub(crate) fn add_cursor(
+    pub fn add_cursor(
         &mut self,
         movement: &MovementApplicandum,
         context: &Context,
@@ -2367,7 +2355,7 @@ impl Editor {
     }
 
     #[cfg(test)]
-    pub(crate) fn get_selected_texts(&self) -> Vec<String> {
+    pub fn get_selected_texts(&self) -> Vec<String> {
         let buffer = self.buffer.borrow();
         let mut selections = self
             .selection_set
@@ -2388,12 +2376,12 @@ impl Editor {
     }
 
     #[cfg(test)]
-    pub(crate) fn text(&self) -> String {
+    pub fn text(&self) -> String {
         let buffer = self.buffer.borrow().clone();
         buffer.rope().slice(0..buffer.len_chars()).to_string()
     }
 
-    pub(crate) fn dimension(&self) -> Dimension {
+    pub fn dimension(&self) -> Dimension {
         self.rectangle.dimension()
     }
 
@@ -2404,7 +2392,7 @@ impl Editor {
         };
     }
 
-    pub(crate) fn backspace(&mut self, context: &Context) -> anyhow::Result<Dispatches> {
+    pub fn backspace(&mut self, context: &Context) -> anyhow::Result<Dispatches> {
         let edit_transaction = EditTransaction::from_action_groups(
             self.selection_set
                 .map(|selection| {
@@ -2427,7 +2415,7 @@ impl Editor {
         self.apply_edit_transaction(edit_transaction, context)
     }
 
-    pub(crate) fn delete_word_backward(
+    pub fn delete_word_backward(
         &mut self,
         short: bool,
         context: &Context,
@@ -2497,7 +2485,7 @@ impl Editor {
     }
 
     /// Replace the parent node of the current node with the current node
-    pub(crate) fn replace_with_movement(
+    pub fn replace_with_movement(
         &mut self,
         movement: &Movement,
         context: &Context,
@@ -2552,15 +2540,15 @@ impl Editor {
         self.apply_edit_transaction(edit_transaction, context)
     }
 
-    pub(crate) fn buffer(&self) -> Ref<'_, Buffer> {
+    pub fn buffer(&self) -> Ref<'_, Buffer> {
         self.buffer.borrow()
     }
 
-    pub(crate) fn buffer_rc(&self) -> Rc<RefCell<Buffer>> {
+    pub fn buffer_rc(&self) -> Rc<RefCell<Buffer>> {
         self.buffer.clone()
     }
 
-    pub(crate) fn buffer_mut(&mut self) -> RefMut<'_, Buffer> {
+    pub fn buffer_mut(&mut self) -> RefMut<'_, Buffer> {
         self.buffer.borrow_mut()
     }
 
@@ -2692,7 +2680,7 @@ impl Editor {
             .append(Dispatch::ToEditor(EnterInsertMode(direction))))
     }
 
-    pub(crate) fn apply_positional_edits(
+    pub fn apply_positional_edits(
         &mut self,
         edits: Vec<PositionalEdit>,
         context: &Context,
@@ -2722,7 +2710,7 @@ impl Editor {
         self.apply_edit_transaction(edit_transaction, context)
     }
 
-    pub(crate) fn save(&mut self, context: &Context) -> anyhow::Result<Dispatches> {
+    pub fn save(&mut self, context: &Context) -> anyhow::Result<Dispatches> {
         self.do_save(false, context)
     }
 
@@ -2769,7 +2757,7 @@ impl Editor {
         Ok(())
     }
 
-    pub(crate) fn surround(
+    pub fn surround(
         &mut self,
         open: String,
         close: String,
@@ -2845,7 +2833,7 @@ impl Editor {
         self.apply_edit_transaction(edit_transaction, context)
     }
 
-    pub(crate) fn display_mode(&self) -> String {
+    pub fn display_mode(&self) -> String {
         if self.jumps.is_some() {
             "JUMP".to_string()
         } else {
@@ -2868,20 +2856,20 @@ impl Editor {
         }
     }
 
-    pub(crate) fn display_selection_mode(&self) -> String {
+    pub fn display_selection_mode(&self) -> String {
         let selection_mode = self.selection_set.mode().display();
         let cursor_count = self.selection_set.len();
         format!("{selection_mode: <5}x{cursor_count}")
     }
 
-    pub(crate) fn visible_line_range(&self) -> Range<usize> {
+    pub fn visible_line_range(&self) -> Range<usize> {
         self.visible_line_range_given_scroll_offset_and_height(
             self.scroll_offset,
             self.rectangle.height,
         )
     }
 
-    pub(crate) fn visible_line_range_given_scroll_offset_and_height(
+    pub fn visible_line_range_given_scroll_offset_and_height(
         &self,
         scroll_offset: usize,
         height: usize,
@@ -2892,10 +2880,7 @@ impl Editor {
         start..end
     }
 
-    pub(crate) fn add_cursor_to_all_selections(
-        &mut self,
-        context: &Context,
-    ) -> Result<(), anyhow::Error> {
+    pub fn add_cursor_to_all_selections(&mut self, context: &Context) -> Result<(), anyhow::Error> {
         self.mode = Mode::Normal;
         self.reveal = Some(Reveal::Cursor);
         self.selection_set
@@ -2904,7 +2889,7 @@ impl Editor {
         Ok(())
     }
 
-    pub(crate) fn dispatch_selection_changed(&self) -> Dispatch {
+    pub fn dispatch_selection_changed(&self) -> Dispatch {
         Dispatch::ToHostApp(ToHostApp::SelectionChanged {
             component_id: self.id(),
             selections: {
@@ -2926,7 +2911,7 @@ impl Editor {
         })
     }
 
-    pub(crate) fn cursor_keep_primary_only(&mut self) {
+    pub fn cursor_keep_primary_only(&mut self) {
         self.mode = Mode::Normal;
         if self.reveal == Some(Reveal::Cursor) {
             self.reveal = None;
@@ -2971,7 +2956,7 @@ impl Editor {
         }
     }
 
-    pub(crate) fn set_decorations(&mut self, decorations: &[super::suggestive_editor::Decoration]) {
+    pub fn set_decorations(&mut self, decorations: &[super::suggestive_editor::Decoration]) {
         self.buffer.borrow_mut().set_decorations(decorations)
     }
 
@@ -2989,11 +2974,7 @@ impl Editor {
     }
 
     #[cfg(test)]
-    pub(crate) fn match_literal(
-        &mut self,
-        search: &str,
-        context: &Context,
-    ) -> anyhow::Result<Dispatches> {
+    pub fn match_literal(&mut self, search: &str, context: &Context) -> anyhow::Result<Dispatches> {
         self.set_selection_mode(
             IfCurrentNotFound::LookForward,
             SelectionMode::Find {
@@ -3011,7 +2992,7 @@ impl Editor {
         )
     }
 
-    pub(crate) fn move_to_line_start(&mut self, context: &Context) -> anyhow::Result<Dispatches> {
+    pub fn move_to_line_start(&mut self, context: &Context) -> anyhow::Result<Dispatches> {
         let edit_transaction = EditTransaction::from_action_groups({
             let buffer = self.buffer();
             self.selection_set
@@ -3036,7 +3017,7 @@ impl Editor {
         self.apply_edit_transaction(edit_transaction, context)
     }
 
-    pub(crate) fn move_to_line_end(&mut self) -> anyhow::Result<Dispatches> {
+    pub fn move_to_line_end(&mut self) -> anyhow::Result<Dispatches> {
         Ok([
             Dispatch::ToEditor(SelectLine(Movement::Current(
                 IfCurrentNotFound::LookForward,
@@ -3047,7 +3028,7 @@ impl Editor {
         .into())
     }
 
-    pub(crate) fn select_all(&mut self, context: &mut Context) -> anyhow::Result<Dispatches> {
+    pub fn select_all(&mut self, context: &mut Context) -> anyhow::Result<Dispatches> {
         self.handle_dispatch_editors(
             context,
             [
@@ -3072,26 +3053,20 @@ impl Editor {
         Ok(dispatches)
     }
 
-    pub(crate) fn scroll_page_down(
-        &mut self,
-        context: &Context,
-    ) -> Result<Dispatches, anyhow::Error> {
+    pub fn scroll_page_down(&mut self, context: &Context) -> Result<Dispatches, anyhow::Error> {
         self.scroll(Direction::End, self.half_page_height(), context)
     }
 
-    pub(crate) fn scroll_page_up(
-        &mut self,
-        context: &Context,
-    ) -> Result<Dispatches, anyhow::Error> {
+    pub fn scroll_page_up(&mut self, context: &Context) -> Result<Dispatches, anyhow::Error> {
         self.scroll(Direction::Start, self.half_page_height(), context)
     }
 
     #[cfg(test)]
-    pub(crate) fn current_view_alignment(&self) -> Option<ViewAlignment> {
+    pub fn current_view_alignment(&self) -> Option<ViewAlignment> {
         self.current_view_alignment
     }
 
-    pub(crate) fn switch_view_alignment(&mut self, context: &Context) {
+    pub fn switch_view_alignment(&mut self, context: &Context) {
         self.current_view_alignment = Some(match self.current_view_alignment {
             Some(ViewAlignment::Top) => {
                 self.align_selection_to_center(context);
@@ -3153,19 +3128,16 @@ impl Editor {
     }
 
     #[cfg(test)]
-    pub(crate) fn set_scroll_offset(&mut self, scroll_offset: usize) {
+    pub fn set_scroll_offset(&mut self, scroll_offset: usize) {
         self.scroll_offset = scroll_offset
     }
 
     #[cfg(test)]
-    pub(crate) fn set_language(
-        &mut self,
-        language: shared::language::Language,
-    ) -> anyhow::Result<()> {
+    pub fn set_language(&mut self, language: shared::language::Language) -> anyhow::Result<()> {
         self.buffer_mut().set_language(language)
     }
 
-    pub(crate) fn render_area(&self, context: &Context) -> Dimension {
+    pub fn render_area(&self, context: &Context) -> Dimension {
         let Dimension { height, width } = self.dimension();
         Dimension {
             height: height.saturating_sub(self.window_title_height(context)),
@@ -3174,10 +3146,7 @@ impl Editor {
     }
 
     #[cfg(test)]
-    pub(crate) fn apply_syntax_highlighting(
-        &mut self,
-        context: &mut Context,
-    ) -> anyhow::Result<()> {
+    pub fn apply_syntax_highlighting(&mut self, context: &mut Context) -> anyhow::Result<()> {
         let source_code = self.text();
         let mut buffer = self.buffer_mut();
         if let Some(language) = buffer.language() {
@@ -3187,7 +3156,7 @@ impl Editor {
         Ok(())
     }
 
-    pub(crate) fn apply_dispatches(
+    pub fn apply_dispatches(
         &mut self,
         context: &mut Context,
         dispatches: Vec<DispatchEditor>,
@@ -3264,14 +3233,11 @@ impl Editor {
         self.mode = Mode::Replace
     }
 
-    pub(crate) fn scroll_offset(&self) -> usize {
+    pub fn scroll_offset(&self) -> usize {
         self.scroll_offset
     }
 
-    pub(crate) fn set_regex_highlight_rules(
-        &mut self,
-        regex_highlight_rules: Vec<RegexHighlightRule>,
-    ) {
+    pub fn set_regex_highlight_rules(&mut self, regex_highlight_rules: Vec<RegexHighlightRule>) {
         self.regex_highlight_rules = regex_highlight_rules
     }
 
@@ -3289,12 +3255,12 @@ impl Editor {
         }
     }
 
-    pub(crate) fn set_selection_set(&mut self, selection_set: SelectionSet, context: &Context) {
+    pub fn set_selection_set(&mut self, selection_set: SelectionSet, context: &Context) {
         self.selection_set = selection_set;
         self.recalculate_scroll_offset(context)
     }
 
-    pub(crate) fn set_char_index_range(
+    pub fn set_char_index_range(
         &mut self,
         range: CharIndexRange,
         context: &Context,
@@ -3496,7 +3462,7 @@ impl Editor {
     }
 
     #[cfg(test)]
-    pub(crate) fn copied_text_history_offset(&self) -> isize {
+    pub fn copied_text_history_offset(&self) -> isize {
         self.copied_text_history_offset.value()
     }
 
@@ -3671,7 +3637,7 @@ impl Editor {
     }
 
     #[cfg(test)]
-    pub(crate) fn primary_selection(&self) -> anyhow::Result<String> {
+    pub fn primary_selection(&self) -> anyhow::Result<String> {
         Ok(self
             .buffer()
             .slice(
@@ -3839,7 +3805,7 @@ impl Editor {
         self.apply_edit_transaction(edit_transaction, context)
     }
 
-    pub(crate) fn insert_mode_keymaps(
+    pub fn insert_mode_keymaps(
         &self,
         include_universal_keymaps: bool,
         context: &Context,
@@ -3848,7 +3814,7 @@ impl Editor {
             .keymaps()
     }
 
-    pub(crate) fn set_normal_mode_override(&mut self, normal_mode_override: NormalModeOverride) {
+    pub fn set_normal_mode_override(&mut self, normal_mode_override: NormalModeOverride) {
         self.normal_mode_override = Some(normal_mode_override)
     }
 
@@ -3875,16 +3841,16 @@ impl Editor {
         }
     }
 
-    pub(crate) fn reveal(&self) -> std::option::Option<Reveal> {
+    pub fn reveal(&self) -> std::option::Option<Reveal> {
         self.reveal.clone()
     }
 
     #[cfg(test)]
-    pub(crate) fn selection_extension_enabled(&self) -> bool {
+    pub fn selection_extension_enabled(&self) -> bool {
         self.selection_set.is_extended()
     }
 
-    pub(crate) fn current_primary_selection(&self) -> anyhow::Result<String> {
+    pub fn current_primary_selection(&self) -> anyhow::Result<String> {
         Ok(self
             .buffer()
             .slice(&self.selection_set.primary_selection().extended_range())?
@@ -3940,11 +3906,11 @@ impl Editor {
         dispatches
     }
 
-    pub(crate) fn current_selection_range(&self) -> CharIndexRange {
+    pub fn current_selection_range(&self) -> CharIndexRange {
         self.selection_set.primary_selection().extended_range()
     }
 
-    pub(crate) fn window_title_height(&self, context: &Context) -> usize {
+    pub fn window_title_height(&self, context: &Context) -> usize {
         self.title(context).lines().count()
     }
 
@@ -3974,7 +3940,7 @@ impl Editor {
         (self.render_area(context).height + self.scroll_offset).saturating_sub(1)
     }
 
-    pub(crate) fn update_current_line(
+    pub fn update_current_line(
         &mut self,
         context: &Context,
         replacement: &str,
@@ -4008,7 +3974,7 @@ impl Editor {
         self.apply_edit_transaction(edit_transaction, context)
     }
 
-    pub(crate) fn set_visible_line_ranges(&mut self, visible_line_ranges: Vec<Range<usize>>) {
+    pub fn set_visible_line_ranges(&mut self, visible_line_ranges: Vec<Range<usize>>) {
         let max_line_index = self.buffer().len_lines().saturating_sub(1);
         self.visible_line_ranges = Some(
             visible_line_ranges
@@ -4042,13 +4008,13 @@ impl Editor {
         })
     }
 
-    pub(crate) fn dispatch_selection_mode_changed(&self) -> Dispatch {
+    pub fn dispatch_selection_mode_changed(&self) -> Dispatch {
         Dispatch::ToHostApp(ToHostApp::SelectionModeChanged(
             self.selection_set.mode().clone(),
         ))
     }
 
-    pub(crate) fn update_content(
+    pub fn update_content(
         &mut self,
         new_content: &str,
         context: &Context,
@@ -4091,7 +4057,7 @@ impl Editor {
         self.handle_movement(context, movement)
     }
 
-    pub(crate) fn handle_prior_change(&mut self, prior_change: Option<PriorChange>) {
+    pub fn handle_prior_change(&mut self, prior_change: Option<PriorChange>) {
         if let Some(prior_change) = prior_change {
             match prior_change {
                 PriorChange::EnterMultiCursorMode => self.mode = Mode::MultiCursor,
@@ -4247,7 +4213,7 @@ impl Editor {
         self.incremental_search_matches = None
     }
 
-    pub(crate) fn set_incremental_search_config(&mut self, config: LocalSearchConfig) {
+    pub fn set_incremental_search_config(&mut self, config: LocalSearchConfig) {
         let content = self.content();
         let search = config.search();
         if search.is_empty() {
@@ -4280,7 +4246,7 @@ impl Editor {
         self.incremental_search_matches = Some(matches)
     }
 
-    pub(crate) fn initialize_incremental_search_matches(&mut self) {
+    pub fn initialize_incremental_search_matches(&mut self) {
         self.incremental_search_matches = Some(Vec::new())
     }
 
@@ -4453,7 +4419,7 @@ impl Editor {
         )
     }
 
-    pub(crate) fn get_selected_lines_indices(&self) -> anyhow::Result<Vec<usize>> {
+    pub fn get_selected_lines_indices(&self) -> anyhow::Result<Vec<usize>> {
         Ok(self
             .selection_set
             .selections()
@@ -4475,19 +4441,19 @@ impl Editor {
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug)]
-pub(crate) enum ViewAlignment {
+pub enum ViewAlignment {
     Top,
     Center,
     Bottom,
 }
 
-pub(crate) enum HandleEventResult {
+pub enum HandleEventResult {
     Handled(Dispatches),
     Ignored(KeyEvent),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) enum DispatchEditor {
+pub enum DispatchEditor {
     Surround(String, String),
     #[cfg(test)]
     SetScrollOffset(usize),
@@ -4636,7 +4602,7 @@ pub(crate) enum DispatchEditor {
 }
 
 #[derive(PartialEq, Eq, Debug, Clone)]
-pub(crate) enum SurroundKind {
+pub enum SurroundKind {
     Inside,
     Around,
 }

--- a/src/components/editor_keymap.rs
+++ b/src/components/editor_keymap.rs
@@ -7,7 +7,7 @@ use Meaning::*;
 
 use crate::{app::Scope, scripting::LEADER_KEYMAP_LAYOUT};
 
-pub(crate) const KEYMAP_SCORE: [[char; 10]; 3] = [
+pub const KEYMAP_SCORE: [[char; 10]; 3] = [
     // a = Easiest to access
     // o = Hardest to access
     // Left side (a-o)        Right side (a-o)
@@ -16,7 +16,7 @@ pub(crate) const KEYMAP_SCORE: [[char; 10]; 3] = [
     ['j', 'k', 'l', 'g', 'o', /*|*/ 'o', 'g', 'l', 'k', 'j'], // Bottom row
 ];
 
-pub(crate) const KEYMAP_NORMAL: [[Meaning; 10]; 3] = [
+pub const KEYMAP_NORMAL: [[Meaning; 10]; 3] = [
     [
         Char_, SWord, Mark_, MultC, Swap_, /****/ First, Prev_, Up___, Next_, Last_,
     ],
@@ -28,7 +28,7 @@ pub(crate) const KEYMAP_NORMAL: [[Meaning; 10]; 3] = [
     ],
 ];
 
-pub(crate) const KEYMAP_NORMAL_SHIFTED: [[Meaning; 10]; 3] = [
+pub const KEYMAP_NORMAL_SHIFTED: [[Meaning; 10]; 3] = [
     [
         _____, _____, _____, _____, Raise, /****/ AgSlL, RplcP, Join_, RplcN, AgSlR,
     ],
@@ -43,7 +43,7 @@ pub(crate) const KEYMAP_NORMAL_SHIFTED: [[Meaning; 10]; 3] = [
 ];
 
 /// Meta also means Alt (Windows) or Option (Mac).
-pub(crate) const KEYMAP_META: [[Meaning; 10]; 3] = [
+pub const KEYMAP_META: [[Meaning; 10]; 3] = [
     [
         KilLP, _____, MarkF, _____, KilLN, /****/ NBack, _____, ScrlU, _____, NForw,
     ],
@@ -55,12 +55,12 @@ pub(crate) const KEYMAP_META: [[Meaning; 10]; 3] = [
     ],
 ];
 
-pub(crate) type KeyboardMeaningLayout = [[Meaning; 10]; 3];
+pub type KeyboardMeaningLayout = [[Meaning; 10]; 3];
 
 /// Why only the left-side is used for Find Local/Global keybindings?
 /// This is to enable hand-alteration, as Find Local (Prev/Next) and Find Global
 /// are both located on the right-side.
-pub(crate) const KEYMAP_FIND_LOCAL: KeyboardMeaningLayout = [
+pub const KEYMAP_FIND_LOCAL: KeyboardMeaningLayout = [
     [
         DgHnt, DgWrn, Mark_, RSrch, Qkfix, /****/ OneCh, _____, _____, _____, _____,
     ],
@@ -71,7 +71,8 @@ pub(crate) const KEYMAP_FIND_LOCAL: KeyboardMeaningLayout = [
         _____, LDefn, LType, LRfrE, LImpl, /****/ LRept, _____, _____, _____, _____,
     ],
 ];
-pub(crate) const KEYMAP_FIND_LOCAL_SHIFTED: KeyboardMeaningLayout = [
+
+pub const KEYMAP_FIND_LOCAL_SHIFTED: KeyboardMeaningLayout = [
     [
         DgInf, _____, _____, _____, _____, /****/ NtrlN, _____, _____, _____, _____,
     ],
@@ -84,7 +85,7 @@ pub(crate) const KEYMAP_FIND_LOCAL_SHIFTED: KeyboardMeaningLayout = [
 ];
 
 /// This keymap should be almost identical with that of Find Local
-pub(crate) const KEYMAP_FIND_GLOBAL: KeyboardMeaningLayout = [
+pub const KEYMAP_FIND_GLOBAL: KeyboardMeaningLayout = [
     [
         DgHnt, DgWrn, Mark_, RSrch, Qkfix, /****/ _____, _____, _____, _____, _____,
     ],
@@ -95,7 +96,7 @@ pub(crate) const KEYMAP_FIND_GLOBAL: KeyboardMeaningLayout = [
         _____, LDefn, LType, LRfrE, LImpl, /****/ GRept, _____, _____, _____, _____,
     ],
 ];
-pub(crate) const KEYMAP_FIND_GLOBAL_SHIFTED: KeyboardMeaningLayout = [
+pub const KEYMAP_FIND_GLOBAL_SHIFTED: KeyboardMeaningLayout = [
     [
         DgInf, _____, _____, _____, _____, /****/ _____, _____, _____, _____, _____,
     ],
@@ -107,7 +108,7 @@ pub(crate) const KEYMAP_FIND_GLOBAL_SHIFTED: KeyboardMeaningLayout = [
     ],
 ];
 
-pub(crate) const KEYMAP_SURROUND: KeyboardMeaningLayout = [
+pub const KEYMAP_SURROUND: KeyboardMeaningLayout = [
     [
         _____, _____, _____, _____, _____, /****/ _____, SQuot, DQuot, BckTk, XML__,
     ],
@@ -119,7 +120,7 @@ pub(crate) const KEYMAP_SURROUND: KeyboardMeaningLayout = [
     ],
 ];
 
-pub(crate) const KEYMAP_SPACE: KeyboardMeaningLayout = [
+pub const KEYMAP_SPACE: KeyboardMeaningLayout = [
     [
         _____, _____, _____, _____, _____, /****/ _____, RevlS, RevlC, RevlM, _____,
     ],
@@ -131,7 +132,7 @@ pub(crate) const KEYMAP_SPACE: KeyboardMeaningLayout = [
     ],
 ];
 
-pub(crate) const KEYMAP_SPACE_EDITOR: KeyboardMeaningLayout = [
+pub const KEYMAP_SPACE_EDITOR: KeyboardMeaningLayout = [
     [
         _____, _____, _____, _____, _____, /****/ _____, _____, _____, _____, _____,
     ],
@@ -143,7 +144,7 @@ pub(crate) const KEYMAP_SPACE_EDITOR: KeyboardMeaningLayout = [
     ],
 ];
 
-pub(crate) const KEYMAP_SPACE_CONTEXT: KeyboardMeaningLayout = [
+pub const KEYMAP_SPACE_CONTEXT: KeyboardMeaningLayout = [
     [
         _____, _____, _____, _____, TSNSx, /****/ _____, _____, _____, _____, _____,
     ],
@@ -155,7 +156,7 @@ pub(crate) const KEYMAP_SPACE_CONTEXT: KeyboardMeaningLayout = [
     ],
 ];
 
-pub(crate) const KEYMAP_SPACE_CONTEXT_SHIFTED: KeyboardMeaningLayout = [
+pub const KEYMAP_SPACE_CONTEXT_SHIFTED: KeyboardMeaningLayout = [
     [
         _____, _____, _____, _____, _____, /****/ _____, _____, _____, _____, _____,
     ],
@@ -167,7 +168,7 @@ pub(crate) const KEYMAP_SPACE_CONTEXT_SHIFTED: KeyboardMeaningLayout = [
     ],
 ];
 
-pub(crate) const KEYMAP_SPACE_PICKER: KeyboardMeaningLayout = [
+pub const KEYMAP_SPACE_PICKER: KeyboardMeaningLayout = [
     [
         _____, _____, _____, _____, _____, /****/ _____, _____, _____, _____, _____,
     ],
@@ -179,7 +180,7 @@ pub(crate) const KEYMAP_SPACE_PICKER: KeyboardMeaningLayout = [
     ],
 ];
 
-pub(crate) const KEYMAP_SPACE_PICKER_SHIFTED: KeyboardMeaningLayout = [
+pub const KEYMAP_SPACE_PICKER_SHIFTED: KeyboardMeaningLayout = [
     [
         _____, _____, _____, _____, _____, /****/ _____, _____, _____, _____, _____,
     ],
@@ -191,7 +192,7 @@ pub(crate) const KEYMAP_SPACE_PICKER_SHIFTED: KeyboardMeaningLayout = [
     ],
 ];
 
-pub(crate) const KEYMAP_TRANSFORM: KeyboardMeaningLayout = [
+pub const KEYMAP_TRANSFORM: KeyboardMeaningLayout = [
     [
         Upper, USnke, Pscal, UKbab, Title, /****/ _____, _____, _____, _____, _____,
     ],
@@ -203,7 +204,7 @@ pub(crate) const KEYMAP_TRANSFORM: KeyboardMeaningLayout = [
     ],
 ];
 
-pub(crate) const KEYMAP_YES_NO: KeyboardMeaningLayout = [
+pub const KEYMAP_YES_NO: KeyboardMeaningLayout = [
     [
         _____, _____, _____, _____, _____, /****/ _____, _____, _____, _____, _____,
     ],
@@ -215,15 +216,15 @@ pub(crate) const KEYMAP_YES_NO: KeyboardMeaningLayout = [
     ],
 ];
 
-pub(crate) type KeyboardLayout = [[&'static str; 10]; 3];
+pub type KeyboardLayout = [[&'static str; 10]; 3];
 
-pub(crate) const QWERTY: KeyboardLayout = [
+pub const QWERTY: KeyboardLayout = [
     ["q", "w", "e", "r", "t", "y", "u", "i", "o", "p"],
     ["a", "s", "d", "f", "g", "h", "j", "k", "l", ";"],
     ["z", "x", "c", "v", "b", "n", "m", ",", ".", "/"],
 ];
 
-pub(crate) const DVORAK: KeyboardLayout = [
+pub const DVORAK: KeyboardLayout = [
     ["'", ",", ".", "p", "y", "f", "g", "c", "r", "l"],
     ["a", "o", "e", "u", "i", "d", "h", "t", "n", "s"],
     [";", "q", "j", "k", "x", "b", "m", "w", "v", "z"],
@@ -231,20 +232,20 @@ pub(crate) const DVORAK: KeyboardLayout = [
 
 /// I and U swapped.
 /// Refer https://www.reddit.com/r/dvorak/comments/tfz53r/have_anyone_tried_swapping_u_with_i/
-pub(crate) const DVORAK_IU: KeyboardLayout = [
+pub const DVORAK_IU: KeyboardLayout = [
     ["'", ",", ".", "p", "y", "f", "g", "c", "r", "l"],
     ["a", "o", "e", "i", "u", "d", "h", "t", "n", "s"],
     [";", "q", "j", "k", "x", "b", "m", "w", "v", "z"],
 ];
 
-pub(crate) const COLEMAK: KeyboardLayout = [
+pub const COLEMAK: KeyboardLayout = [
     ["q", "w", "f", "p", "b", "j", "l", "u", "y", ";"],
     ["a", "r", "s", "t", "g", "m", "n", "e", "i", "o"],
     ["z", "x", "c", "d", "v", "k", "h", ",", ".", "/"],
 ];
 
 /// Refer https://colemakmods.github.io/mod-dh/
-pub(crate) const COLEMAK_DH: KeyboardLayout = [
+pub const COLEMAK_DH: KeyboardLayout = [
     ["q", "w", "f", "p", "b", "j", "l", "u", "y", ";"],
     ["a", "r", "s", "t", "g", "m", "n", "e", "i", "o"],
     ["z", "x", "c", "d", "v", "k", "h", ",", ".", "/"],
@@ -252,34 +253,34 @@ pub(crate) const COLEMAK_DH: KeyboardLayout = [
 
 /// Semi-colon and Quote are swapped
 /// Refer https://colemakmods.github.io/mod-dh/
-pub(crate) const COLEMAK_DH_SEMI_QUOTE: KeyboardLayout = [
+pub const COLEMAK_DH_SEMI_QUOTE: KeyboardLayout = [
     ["q", "w", "f", "p", "b", "j", "l", "u", "y", "'"],
     ["a", "r", "s", "t", "g", "m", "n", "e", "i", "o"],
     ["z", "x", "c", "d", "v", "k", "h", ",", ".", "/"],
 ];
 
-pub(crate) const COLEMAK_ANSI: KeyboardLayout = [
+pub const COLEMAK_ANSI: KeyboardLayout = [
     ["q", "w", "f", "p", "g", "j", "l", "u", "y", ";"],
     ["a", "r", "s", "t", "d", "h", "n", "e", "i", "o"],
     ["z", "x", "c", "v", "b", "k", "m", ",", ".", "/"],
 ];
 
 // https://colemakmods.github.io/mod-dh/keyboards.html#ansi-keyboards
-pub(crate) const COLEMAK_ANSI_DH: KeyboardLayout = [
+pub const COLEMAK_ANSI_DH: KeyboardLayout = [
     ["q", "w", "f", "p", "b", "j", "l", "u", "y", ";"],
     ["a", "r", "s", "t", "g", "m", "n", "e", "i", "o"],
     ["x", "c", "d", "v", "z", "k", "h", ",", ".", "/"],
 ];
 
 /// Refer https://workmanlayout.org/
-pub(crate) const WORKMAN: KeyboardLayout = [
+pub const WORKMAN: KeyboardLayout = [
     ["q", "d", "r", "w", "b", "j", "f", "u", "p", ";"],
     ["a", "s", "h", "t", "g", "y", "n", "e", "o", "i"],
     ["z", "x", "m", "c", "v", "k", "l", ",", ".", "/"],
 ];
 
 /// Refer http://adnw.de/index.php?n=Main.OptimierungF%c3%bcrDieGeradeTastaturMitDaumen-Shift
-pub(crate) const PUQ: KeyboardLayout = [
+pub const PUQ: KeyboardLayout = [
     ["p", "u", ":", ",", "q", "g", "c", "l", "m", "f"],
     ["h", "i", "e", "a", "o", "d", "t", "r", "n", "s"],
     ["k", "y", ".", "'", "x", "j", "v", "w", "b", "z"],
@@ -438,7 +439,7 @@ static PUQ_KEYSET: Lazy<KeySet> = Lazy::new(|| KeySet::from(PUQ));
 #[derive(
     Debug, Clone, strum_macros::EnumIter, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Copy,
 )]
-pub(crate) enum KeyboardLayoutKind {
+pub enum KeyboardLayoutKind {
     Qwerty,
     Dvorak,
     DvorakIu,
@@ -452,7 +453,7 @@ pub(crate) enum KeyboardLayoutKind {
 }
 
 impl KeyboardLayoutKind {
-    pub(crate) const fn display(&self) -> &'static str {
+    pub const fn display(&self) -> &'static str {
         match self {
             Self::Qwerty => "QWERTY",
             Self::Dvorak => "DVORAK",
@@ -467,7 +468,7 @@ impl KeyboardLayoutKind {
         }
     }
 
-    pub(crate) fn get_keyboard_layout(&self) -> &KeyboardLayout {
+    pub fn get_keyboard_layout(&self) -> &KeyboardLayout {
         match self {
             Self::Qwerty => &QWERTY,
             Self::Dvorak => &DVORAK,
@@ -482,7 +483,7 @@ impl KeyboardLayoutKind {
         }
     }
 
-    pub(crate) fn get_key(&self, meaning: &Meaning) -> &'static str {
+    pub fn get_key(&self, meaning: &Meaning) -> &'static str {
         let keyset = self.get_keyset();
         keyset
             .normal
@@ -493,7 +494,7 @@ impl KeyboardLayoutKind {
             .unwrap_or_else(|| panic!("Unable to find key binding of {meaning:#?}"))
     }
 
-    pub(crate) fn get_insert_key(&self, meaning: &Meaning) -> &'static str {
+    pub fn get_insert_key(&self, meaning: &Meaning) -> &'static str {
         let keyset = self.get_keyset();
         keyset
             .insert_control
@@ -502,7 +503,7 @@ impl KeyboardLayoutKind {
             .unwrap_or_else(|| panic!("Unable to find key binding of {meaning:#?}"))
     }
 
-    pub(crate) fn get_find_keymap(&self, scope: Scope, meaning: &Meaning) -> &'static str {
+    pub fn get_find_keymap(&self, scope: Scope, meaning: &Meaning) -> &'static str {
         let keyset = self.get_keyset();
         match scope {
             Scope::Local => keyset
@@ -518,7 +519,7 @@ impl KeyboardLayoutKind {
         }
     }
 
-    pub(crate) fn get_leader_keymap(&self, meaning: &Meaning) -> &'static str {
+    pub fn get_leader_keymap(&self, meaning: &Meaning) -> &'static str {
         let keyset = self.get_keyset();
         keyset
             .leader
@@ -527,7 +528,7 @@ impl KeyboardLayoutKind {
             .unwrap_or_else(|| panic!("Unable to find key binding of {meaning:#?}"))
     }
 
-    pub(crate) fn get_space_keymap(&self, meaning: &Meaning) -> &'static str {
+    pub fn get_space_keymap(&self, meaning: &Meaning) -> &'static str {
         let keyset = self.get_keyset();
         keyset
             .space
@@ -536,7 +537,7 @@ impl KeyboardLayoutKind {
             .unwrap_or_else(|| panic!("Unable to find key binding of {meaning:#?}"))
     }
 
-    pub(crate) fn get_space_context_keymap(&self, meaning: &Meaning) -> &'static str {
+    pub fn get_space_context_keymap(&self, meaning: &Meaning) -> &'static str {
         let keyset = self.get_keyset();
         keyset
             .space_context
@@ -545,7 +546,7 @@ impl KeyboardLayoutKind {
             .unwrap_or_else(|| panic!("Unable to find key binding of {meaning:#?}"))
     }
 
-    pub(crate) fn get_space_editor_keymap(&self, meaning: &Meaning) -> &'static str {
+    pub fn get_space_editor_keymap(&self, meaning: &Meaning) -> &'static str {
         let keyset = self.get_keyset();
         keyset
             .space_editor
@@ -554,7 +555,7 @@ impl KeyboardLayoutKind {
             .unwrap_or_else(|| panic!("Unable to find key binding of {meaning:#?}"))
     }
 
-    pub(crate) fn get_space_picker_keymap(&self, meaning: &Meaning) -> &'static str {
+    pub fn get_space_picker_keymap(&self, meaning: &Meaning) -> &'static str {
         let keyset = self.get_keyset();
         keyset
             .space_picker
@@ -563,7 +564,7 @@ impl KeyboardLayoutKind {
             .unwrap_or_else(|| panic!("Unable to find key binding of {meaning:#?}"))
     }
 
-    pub(crate) fn get_surround_keymap(&self, meaning: &Meaning) -> &'static str {
+    pub fn get_surround_keymap(&self, meaning: &Meaning) -> &'static str {
         let keyset = self.get_keyset();
         keyset
             .surround
@@ -572,7 +573,7 @@ impl KeyboardLayoutKind {
             .unwrap_or_else(|| panic!("Unable to find key binding of {meaning:#?}"))
     }
 
-    pub(crate) fn get_transform_key(&self, meaning: &Meaning) -> &'static str {
+    pub fn get_transform_key(&self, meaning: &Meaning) -> &'static str {
         let keyset = self.get_keyset();
         keyset
             .transform
@@ -581,7 +582,7 @@ impl KeyboardLayoutKind {
             .unwrap_or_else(|| panic!("Unable to find key binding of {meaning:#?}"))
     }
 
-    pub(crate) fn get_yes_no_key(&self, meaning: &Meaning) -> &'static str {
+    pub fn get_yes_no_key(&self, meaning: &Meaning) -> &'static str {
         let keyset = self.get_keyset();
         keyset
             .yes_no
@@ -610,7 +611,7 @@ impl KeyboardLayoutKind {
 /// X means Swap/Cut
 /// Prefix W means Window
 #[derive(Hash, PartialEq, Eq, PartialOrd, Ord, Debug, Clone)]
-pub(crate) enum Meaning {
+pub enum Meaning {
     /// Empty, not assigned
     _____,
     /// Break line
@@ -970,7 +971,7 @@ pub(crate) enum Meaning {
     /// Align selections (based on right anchor)
     AgSlR,
 }
-pub(crate) fn shifted(c: &'static str) -> &'static str {
+pub fn shifted(c: &'static str) -> &'static str {
     match c {
         "." => ">",
         "," => "<",
@@ -1048,7 +1049,7 @@ pub(crate) fn shifted(c: &'static str) -> &'static str {
     }
 }
 
-pub(crate) fn shifted_char(c: char) -> char {
+pub fn shifted_char(c: char) -> char {
     match c {
         '.' => '>',
         ',' => '<',
@@ -1126,7 +1127,7 @@ pub(crate) fn shifted_char(c: char) -> char {
     }
 }
 
-pub(crate) fn alted(c: &'static str) -> &'static str {
+pub fn alted(c: &'static str) -> &'static str {
     match c {
         "." => "alt+.",
         "," => "alt+,",

--- a/src/components/editor_keymap_legend.rs
+++ b/src/components/editor_keymap_legend.rs
@@ -30,7 +30,7 @@ use super::{
 use DispatchEditor::*;
 use Movement::*;
 impl Editor {
-    pub(crate) fn keymap_core_movements(
+    pub fn keymap_core_movements(
         &self,
         context: &Context,
         prior_change: Option<PriorChange>,
@@ -123,7 +123,7 @@ impl Editor {
         }
     }
 
-    pub(crate) fn keymap_other_movements(&self, context: &Context) -> Vec<Keymap> {
+    pub fn keymap_other_movements(&self, context: &Context) -> Vec<Keymap> {
         [
             Keymap::new_extended(
                 context.keyboard_layout_kind().get_key(&Meaning::CrsrP),
@@ -202,7 +202,7 @@ impl Editor {
         .collect()
     }
 
-    pub(crate) fn keymap_primary_selection_modes(
+    pub fn keymap_primary_selection_modes(
         &self,
         context: &Context,
         prior_change: Option<PriorChange>,
@@ -293,7 +293,7 @@ impl Editor {
         .to_vec()
     }
 
-    pub(crate) fn keymap_secondary_selection_modes_init(
+    pub fn keymap_secondary_selection_modes_init(
         &self,
         context: &Context,
         prior_change: Option<PriorChange>,
@@ -312,7 +312,7 @@ impl Editor {
         .to_vec()
     }
 
-    pub(crate) fn keymap_actions(
+    pub fn keymap_actions(
         &self,
         normal_mode_override: &NormalModeOverride,
         none_if_no_override: bool,
@@ -436,7 +436,7 @@ impl Editor {
         .collect_vec()
     }
 
-    pub(crate) fn keymap_actions_overridable(
+    pub fn keymap_actions_overridable(
         &self,
         normal_mode_override: &NormalModeOverride,
         none_if_no_override: bool,
@@ -483,7 +483,7 @@ impl Editor {
         .collect_vec()
     }
 
-    pub(crate) fn keymap_overridable(
+    pub fn keymap_overridable(
         &self,
         normal_mode_override: &NormalModeOverride,
         none_if_no_override: bool,
@@ -575,7 +575,7 @@ impl Editor {
         .collect_vec()
     }
 
-    pub(crate) fn keymap_universal(&self, context: &Context) -> Vec<Keymap> {
+    pub fn keymap_universal(&self, context: &Context) -> Vec<Keymap> {
         [
             Keymap::new_extended(
                 context.keyboard_layout_kind().get_key(&Meaning::WClse),
@@ -601,7 +601,7 @@ impl Editor {
         .to_vec()
     }
 
-    pub(crate) fn insert_mode_keymap_legend_config(
+    pub fn insert_mode_keymap_legend_config(
         &self,
         include_universal_keymaps: bool,
         context: &Context,
@@ -720,7 +720,7 @@ impl Editor {
         }
     }
 
-    pub(crate) fn handle_insert_mode(
+    pub fn handle_insert_mode(
         &mut self,
         event: KeyEvent,
         context: &Context,
@@ -739,7 +739,7 @@ impl Editor {
         }
     }
 
-    pub(crate) fn handle_universal_key(
+    pub fn handle_universal_key(
         &mut self,
         event: KeyEvent,
         context: &Context,
@@ -751,7 +751,7 @@ impl Editor {
         }
     }
 
-    pub(crate) fn keymap_others(&self) -> Vec<Keymap> {
+    pub fn keymap_others(&self) -> Vec<Keymap> {
         [
             Keymap::new(
                 "space",
@@ -767,7 +767,7 @@ impl Editor {
         .to_vec()
     }
 
-    pub(crate) fn keymap_sub_modes(&self, context: &Context) -> Vec<Keymap> {
+    pub fn keymap_sub_modes(&self, context: &Context) -> Vec<Keymap> {
         [
             Some(Keymap::new(
                 "~",
@@ -812,7 +812,7 @@ impl Editor {
         .collect_vec()
     }
 
-    pub(crate) fn normal_mode_keymap_legend_config(
+    pub fn normal_mode_keymap_legend_config(
         &self,
         context: &Context,
         normal_mode_override: Option<NormalModeOverride>,
@@ -841,7 +841,7 @@ impl Editor {
         }
     }
 
-    pub(crate) fn normal_mode_keymaps(
+    pub fn normal_mode_keymaps(
         &self,
         context: &Context,
         normal_mode_override: Option<NormalModeOverride>,
@@ -863,10 +863,7 @@ impl Editor {
             .collect_vec()
     }
 
-    pub(crate) fn multicursor_mode_keymap_legend_config(
-        &self,
-        context: &Context,
-    ) -> KeymapLegendConfig {
+    pub fn multicursor_mode_keymap_legend_config(&self, context: &Context) -> KeymapLegendConfig {
         KeymapLegendConfig {
             title: "Multi-cursor".to_string(),
             keymaps: Keymaps::new(
@@ -888,7 +885,7 @@ impl Editor {
             ),
         }
     }
-    pub(crate) fn extend_mode_keymap_legend_config(&self, context: &Context) -> KeymapLegendConfig {
+    pub fn extend_mode_keymap_legend_config(&self, context: &Context) -> KeymapLegendConfig {
         KeymapLegendConfig {
             title: "Extend".to_string(),
             keymaps: Keymaps::new(
@@ -908,7 +905,7 @@ impl Editor {
             ),
         }
     }
-    pub(crate) fn keymap_transform(&self, context: &Context) -> Vec<Keymap> {
+    pub fn keymap_transform(&self, context: &Context) -> Vec<Keymap> {
         [
             (Meaning::Camel, "camelCase", Case::Camel),
             (Meaning::Lower, "lower case", Case::Lower),
@@ -958,7 +955,7 @@ impl Editor {
         )))
         .collect_vec()
     }
-    pub(crate) fn transform_keymap_legend_config(&self, context: &Context) -> KeymapLegendConfig {
+    pub fn transform_keymap_legend_config(&self, context: &Context) -> KeymapLegendConfig {
         KeymapLegendConfig {
             title: "Transform".to_string(),
 
@@ -966,7 +963,7 @@ impl Editor {
         }
     }
 
-    pub(crate) fn space_pick_keymap_legend_config(&self, context: &Context) -> KeymapLegendConfig {
+    pub fn space_pick_keymap_legend_config(&self, context: &Context) -> KeymapLegendConfig {
         KeymapLegendConfig {
             title: "Pick".to_string(),
 
@@ -1041,10 +1038,7 @@ impl Editor {
         }
     }
 
-    pub(crate) fn space_context_keymap_legend_config(
-        &self,
-        context: &Context,
-    ) -> KeymapLegendConfig {
+    pub fn space_context_keymap_legend_config(&self, context: &Context) -> KeymapLegendConfig {
         KeymapLegendConfig {
             title: "Context".to_string(),
 
@@ -1142,10 +1136,7 @@ impl Editor {
         }
     }
 
-    pub(crate) fn space_editor_keymap_legend_config(
-        &self,
-        context: &Context,
-    ) -> KeymapLegendConfig {
+    pub fn space_editor_keymap_legend_config(&self, context: &Context) -> KeymapLegendConfig {
         KeymapLegendConfig {
             title: "Editor".to_string(),
 
@@ -1203,7 +1194,7 @@ impl Editor {
         }
     }
 
-    pub(crate) fn space_keymap_legend_config(&self, context: &Context) -> KeymapLegendConfig {
+    pub fn space_keymap_legend_config(&self, context: &Context) -> KeymapLegendConfig {
         KeymapLegendConfig {
             title: "Space".to_string(),
 
@@ -1289,7 +1280,7 @@ impl Editor {
         }
     }
 
-    pub(crate) fn leader_keymap_legend_config(&self, context: &Context) -> KeymapLegendConfig {
+    pub fn leader_keymap_legend_config(&self, context: &Context) -> KeymapLegendConfig {
         KeymapLegendConfig {
             title: "Leader".to_string(),
 
@@ -1341,7 +1332,7 @@ impl Editor {
         .to_vec()
     }
 
-    pub(crate) fn secondary_selection_modes_keymap_legend_config(
+    pub fn secondary_selection_modes_keymap_legend_config(
         &self,
         context: &Context,
         scope: Scope,
@@ -1641,7 +1632,7 @@ impl Editor {
     }
 }
 
-pub(crate) fn paste_keymaps(context: &Context) -> Keymaps {
+pub fn paste_keymaps(context: &Context) -> Keymaps {
     Keymaps::new(
         [
             Keymap::new(
@@ -1674,7 +1665,7 @@ pub(crate) fn paste_keymaps(context: &Context) -> Keymaps {
     )
 }
 
-pub(crate) fn delete_keymaps(context: &Context) -> Keymaps {
+pub fn delete_keymaps(context: &Context) -> Keymaps {
     Keymaps::new(
         [
             Keymap::new(
@@ -1712,7 +1703,7 @@ pub(crate) fn delete_keymaps(context: &Context) -> Keymaps {
     )
 }
 
-pub(crate) fn delete_cut_keymaps(context: &Context) -> Keymaps {
+pub fn delete_cut_keymaps(context: &Context) -> Keymaps {
     Keymaps::new(
         [
             Keymap::new(
@@ -1746,21 +1737,21 @@ pub(crate) fn delete_cut_keymaps(context: &Context) -> Keymaps {
 }
 
 #[derive(Default, Clone)]
-pub(crate) struct NormalModeOverride {
-    pub(crate) change: Option<KeymapOverride>,
-    pub(crate) delete: Option<KeymapOverride>,
-    pub(crate) insert: Option<KeymapOverride>,
-    pub(crate) append: Option<KeymapOverride>,
-    pub(crate) open: Option<KeymapOverride>,
-    pub(crate) paste: Option<KeymapOverride>,
-    pub(crate) replace: Option<KeymapOverride>,
-    pub(crate) multicursor: Option<KeymapOverride>,
+pub struct NormalModeOverride {
+    pub change: Option<KeymapOverride>,
+    pub delete: Option<KeymapOverride>,
+    pub insert: Option<KeymapOverride>,
+    pub append: Option<KeymapOverride>,
+    pub open: Option<KeymapOverride>,
+    pub paste: Option<KeymapOverride>,
+    pub replace: Option<KeymapOverride>,
+    pub multicursor: Option<KeymapOverride>,
 }
 
 #[derive(Clone)]
-pub(crate) struct KeymapOverride {
-    pub(crate) description: &'static str,
-    pub(crate) dispatch: Dispatch,
+pub struct KeymapOverride {
+    pub description: &'static str,
+    pub dispatch: Dispatch,
 }
 
 fn generate_enclosures_keymaps(
@@ -1790,7 +1781,7 @@ fn generate_enclosures_keymaps(
     )
 }
 
-pub(crate) fn extend_mode_normal_mode_override(context: &Context) -> NormalModeOverride {
+pub fn extend_mode_normal_mode_override(context: &Context) -> NormalModeOverride {
     fn select_surround_keymap_legend_config(
         kind: SurroundKind,
         context: &Context,
@@ -1915,7 +1906,7 @@ pub(crate) fn extend_mode_normal_mode_override(context: &Context) -> NormalModeO
     }
 }
 
-pub(crate) fn multicursor_mode_normal_mode_override(direction: Direction) -> NormalModeOverride {
+pub fn multicursor_mode_normal_mode_override(direction: Direction) -> NormalModeOverride {
     NormalModeOverride {
         insert: Some(KeymapOverride {
             description: "Keep Match",

--- a/src/components/editor_keymap_printer.rs
+++ b/src/components/editor_keymap_printer.rs
@@ -27,21 +27,21 @@ use itertools::Itertools;
 use shared::canonicalized_path::CanonicalizedPath;
 
 #[derive(Debug, Clone)]
-pub(crate) struct KeymapPrintSection {
+pub struct KeymapPrintSection {
     name: String,
     keys: Vec<Vec<Key>>,
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct Key {
-    pub(crate) normal: Option<Keymap>,
-    pub(crate) shifted: Option<Keymap>,
-    pub(crate) alted: Option<Keymap>,
+pub struct Key {
+    pub normal: Option<Keymap>,
+    pub shifted: Option<Keymap>,
+    pub alted: Option<Keymap>,
 }
 
-pub(crate) struct KeymapDisplayOption {
-    pub(crate) show_alt: bool,
-    pub(crate) show_shift: bool,
+pub struct KeymapDisplayOption {
+    pub show_alt: bool,
+    pub show_shift: bool,
 }
 
 impl Key {
@@ -81,11 +81,7 @@ impl Key {
 }
 
 impl KeymapPrintSection {
-    pub(crate) fn from_keymaps(
-        name: String,
-        keymaps: &Keymaps,
-        keyboard_layout: &KeyboardLayout,
-    ) -> Self {
+    pub fn from_keymaps(name: String, keymaps: &Keymaps, keyboard_layout: &KeyboardLayout) -> Self {
         KeymapPrintSection {
             name,
             keys: keyboard_layout
@@ -114,14 +110,14 @@ impl KeymapPrintSection {
         }
     }
 
-    pub(crate) fn has_content(&self) -> bool {
+    pub fn has_content(&self) -> bool {
         self.keys
             .iter()
             .any(|keys| keys.iter().any(|key| key.has_content()))
     }
 
     /// Returns None if the terminal width is too small
-    pub(crate) fn display(&self, terminal_width: usize, option: &KeymapDisplayOption) -> String {
+    pub fn display(&self, terminal_width: usize, option: &KeymapDisplayOption) -> String {
         let table = self.display_full(terminal_width, option);
 
         fn get_content_width(table: &Table) -> usize {
@@ -145,12 +141,12 @@ impl KeymapPrintSection {
     }
 
     #[cfg(test)]
-    pub(crate) fn name(&self) -> &str {
+    pub fn name(&self) -> &str {
         &self.name
     }
 
     #[cfg(test)]
-    pub(crate) fn keys(&self) -> &Vec<Vec<Key>> {
+    pub fn keys(&self) -> &Vec<Vec<Key>> {
         &self.keys
     }
 
@@ -241,14 +237,14 @@ impl KeymapPrintSection {
     }
 }
 
-pub(crate) struct KeymapPrintSections {
+pub struct KeymapPrintSections {
     #[allow(unused)]
     context: Context,
     sections: Vec<KeymapPrintSection>,
 }
 
 impl KeymapPrintSections {
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         let context = Context::new(CanonicalizedPath::try_from(".").unwrap(), false, None);
         let layout = context.keyboard_layout_kind().get_keyboard_layout();
         let editor = Editor::from_text(Option::None, "");
@@ -393,13 +389,13 @@ impl KeymapPrintSections {
         }
     }
 
-    pub(crate) fn sections(&self) -> &Vec<KeymapPrintSection> {
+    pub fn sections(&self) -> &Vec<KeymapPrintSection> {
         &self.sections
     }
 }
 
 /// Print an ASCII representation of the keymap.
-pub(crate) fn print_keymap_table() -> anyhow::Result<()> {
+pub fn print_keymap_table() -> anyhow::Result<()> {
     KeymapPrintSections::new()
         .sections()
         .iter()
@@ -425,7 +421,7 @@ fn print_single_keymap_table(keymap: &KeymapPrintSection) {
 
 /// Print a YAML representation of the keymap suitable for use with keymap drawer,
 /// https://keymap-drawer.streamlit.app
-pub(crate) fn print_keymap_drawer_yaml() -> anyhow::Result<()> {
+pub fn print_keymap_drawer_yaml() -> anyhow::Result<()> {
     println!("layout:");
     println!("  qmk_keyboard: corne_rotated");
     println!("  layout_name: LAYOUT_split_3x5_3");

--- a/src/components/file_explorer.rs
+++ b/src/components/file_explorer.rs
@@ -15,12 +15,12 @@ use super::{
     editor_keymap_legend::{KeymapOverride, NormalModeOverride},
 };
 
-pub(crate) struct FileExplorer {
+pub struct FileExplorer {
     editor: Editor,
     tree: Tree,
 }
 
-pub(crate) fn file_explorer_normal_mode_override() -> NormalModeOverride {
+pub fn file_explorer_normal_mode_override() -> NormalModeOverride {
     NormalModeOverride {
         append: Some(KeymapOverride {
             description: "Add Path",
@@ -50,7 +50,7 @@ pub(crate) fn file_explorer_normal_mode_override() -> NormalModeOverride {
     }
 }
 impl FileExplorer {
-    pub(crate) fn new(path: &CanonicalizedPath) -> anyhow::Result<Self> {
+    pub fn new(path: &CanonicalizedPath) -> anyhow::Result<Self> {
         let tree = Tree::new(path)?;
         let text = tree.render();
         let mut editor = Editor::from_text(
@@ -63,7 +63,7 @@ impl FileExplorer {
         Ok(Self { editor, tree })
     }
 
-    pub(crate) fn expanded_folders(&self) -> Vec<CanonicalizedPath> {
+    pub fn expanded_folders(&self) -> Vec<CanonicalizedPath> {
         self.tree
             .walk_visible(Vec::new(), |result, node| Continuation {
                 state: if matches!(node.kind, NodeKind::Directory { open: true, .. }) {
@@ -75,7 +75,7 @@ impl FileExplorer {
             })
     }
 
-    pub(crate) fn reveal(
+    pub fn reveal(
         &mut self,
         path: &CanonicalizedPath,
         context: &Context,
@@ -105,7 +105,7 @@ impl FileExplorer {
         }
     }
 
-    pub(crate) fn refresh(&mut self, context: &Context) -> anyhow::Result<()> {
+    pub fn refresh(&mut self, context: &Context) -> anyhow::Result<()> {
         let tree = std::mem::take(&mut self.tree);
         self.tree = tree.refresh(context.current_working_directory())?;
         self.refresh_editor(context)?;
@@ -130,20 +130,17 @@ impl FileExplorer {
             .collect_vec())
     }
 
-    pub(crate) fn get_selected_paths(&self) -> anyhow::Result<Vec<CanonicalizedPath>> {
+    pub fn get_selected_paths(&self) -> anyhow::Result<Vec<CanonicalizedPath>> {
         self.get_selected_nodes()
             .map(|nodes| nodes.into_iter().map(|node| node.path).collect_vec())
     }
 
-    pub(crate) fn get_current_path(&self) -> anyhow::Result<Option<CanonicalizedPath>> {
+    pub fn get_current_path(&self) -> anyhow::Result<Option<CanonicalizedPath>> {
         self.get_current_node()
             .map(|node| node.map(|node| node.path))
     }
 
-    pub(crate) fn toggle_or_open_paths(
-        &mut self,
-        context: &Context,
-    ) -> Result<Dispatches, anyhow::Error> {
+    pub fn toggle_or_open_paths(&mut self, context: &Context) -> Result<Dispatches, anyhow::Error> {
         let nodes = self.get_selected_nodes()?;
         let Some(nodes) = NonEmpty::from_vec(nodes) else {
             return Err(anyhow::anyhow!("No paths are selected."));

--- a/src/components/keymap_legend.rs
+++ b/src/components/keymap_legend.rs
@@ -17,7 +17,7 @@ use super::{
     editor_keymap_printer::KeymapPrintSection,
 };
 
-pub(crate) struct KeymapLegend {
+pub struct KeymapLegend {
     editor: Editor,
     config: KeymapLegendConfig,
     option: KeymapDisplayOption,
@@ -25,13 +25,13 @@ pub(crate) struct KeymapLegend {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) struct KeymapLegendConfig {
-    pub(crate) title: String,
-    pub(crate) keymaps: Keymaps,
+pub struct KeymapLegendConfig {
+    pub title: String,
+    pub keymaps: Keymaps,
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) struct Keymaps(Vec<Keymap>);
+pub struct Keymaps(Vec<Keymap>);
 impl Keymaps {
     fn display(
         &self,
@@ -46,25 +46,25 @@ impl Keymaps {
         )
         .display(terminal_width, option)
     }
-    pub(crate) fn new(keymaps: &[Keymap]) -> Self {
+    pub fn new(keymaps: &[Keymap]) -> Self {
         Self(keymaps.to_vec())
     }
 
-    pub(crate) fn get(&self, event: &KeyEvent) -> std::option::Option<&Keymap> {
+    pub fn get(&self, event: &KeyEvent) -> std::option::Option<&Keymap> {
         self.0.iter().find(|key| &key.event == event)
     }
 
-    pub(crate) fn iter(&self) -> std::slice::Iter<'_, Keymap> {
+    pub fn iter(&self) -> std::slice::Iter<'_, Keymap> {
         self.0.iter()
     }
 
-    pub(crate) fn into_vec(self) -> Vec<Keymap> {
+    pub fn into_vec(self) -> Vec<Keymap> {
         self.0
     }
 }
 
 impl KeymapLegendConfig {
-    pub(crate) fn display(
+    pub fn display(
         &self,
         keyboard_layout_kind: &KeyboardLayoutKind,
         width: usize,
@@ -73,7 +73,7 @@ impl KeymapLegendConfig {
         self.keymaps.display(keyboard_layout_kind, width, option)
     }
 
-    pub(crate) fn keymaps(&self) -> Keymaps {
+    pub fn keymaps(&self) -> Keymaps {
         let keymaps = &self.keymaps;
         #[cfg(test)]
         {
@@ -94,7 +94,7 @@ impl KeymapLegendConfig {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) struct Keymap {
+pub struct Keymap {
     key: &'static str,
     pub short_description: Option<String>,
     pub description: String,
@@ -103,7 +103,7 @@ pub(crate) struct Keymap {
 }
 
 impl Keymap {
-    pub(crate) fn new(key: &'static str, description: String, dispatch: Dispatch) -> Keymap {
+    pub fn new(key: &'static str, description: String, dispatch: Dispatch) -> Keymap {
         Keymap {
             key,
             short_description: None,
@@ -113,7 +113,7 @@ impl Keymap {
         }
     }
 
-    pub(crate) fn new_extended(
+    pub fn new_extended(
         key: &'static str,
         short_description: String,
         description: String,
@@ -128,18 +128,18 @@ impl Keymap {
         }
     }
 
-    pub(crate) fn get_dispatches(&self) -> Dispatches {
+    pub fn get_dispatches(&self) -> Dispatches {
         Dispatches::one(self.dispatch.clone()).append(Dispatch::SetLastActionDescription {
             long_description: self.description.clone(),
             short_description: self.short_description.clone(),
         })
     }
 
-    pub(crate) fn event(&self) -> &KeyEvent {
+    pub fn event(&self) -> &KeyEvent {
         &self.event
     }
 
-    pub(crate) fn override_keymap(
+    pub fn override_keymap(
         self,
         keymap_override: Option<&super::editor_keymap_legend::KeymapOverride>,
         none_if_no_override: bool,
@@ -161,7 +161,7 @@ impl Keymap {
         }
     }
 
-    pub(crate) fn display(&self) -> String {
+    pub fn display(&self) -> String {
         self.short_description
             .clone()
             .unwrap_or_else(|| self.description.clone())
@@ -169,7 +169,7 @@ impl Keymap {
 }
 
 impl KeymapLegend {
-    pub(crate) fn new(config: KeymapLegendConfig, context: &Context) -> KeymapLegend {
+    pub fn new(config: KeymapLegendConfig, context: &Context) -> KeymapLegend {
         // Check for duplicate keys
         let duplicates = config
             .keymaps()

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -1,15 +1,15 @@
-pub(crate) mod component;
-pub(crate) mod dropdown;
-pub(crate) mod prompt;
+pub mod component;
+pub mod dropdown;
+pub mod prompt;
 
-pub(crate) mod editor;
-pub(crate) mod editor_keymap;
+pub mod editor;
+pub mod editor_keymap;
 mod editor_keymap_legend;
-pub(crate) mod editor_keymap_printer;
-pub(crate) mod file_explorer;
-pub(crate) mod keymap_legend;
-pub(crate) mod render_editor;
-pub(crate) mod suggestive_editor;
+pub mod editor_keymap_printer;
+pub mod file_explorer;
+pub mod keymap_legend;
+pub mod render_editor;
+pub mod suggestive_editor;
 #[cfg(test)]
 mod test_editor;
 #[cfg(test)]

--- a/src/components/prompt.rs
+++ b/src/components/prompt.rs
@@ -24,7 +24,7 @@ use super::{
 };
 
 #[derive(Clone, PartialEq)]
-pub(crate) enum PromptOnEnter {
+pub enum PromptOnEnter {
     ParseCurrentLine {
         parser: DispatchParser,
         history_key: PromptHistoryKey,
@@ -40,7 +40,7 @@ pub(crate) enum PromptOnEnter {
     },
 }
 
-pub(crate) struct Prompt {
+pub struct Prompt {
     editor: SuggestiveEditor,
     on_enter: PromptOnEnter,
     on_change: Option<PromptOnChangeDispatch>,
@@ -49,7 +49,7 @@ pub(crate) struct Prompt {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) enum PromptOnChangeDispatch {
+pub enum PromptOnChangeDispatch {
     RequestWorkspaceSymbol(CanonicalizedPath),
     SetIncrementalSearchConfig { component_id: ComponentId },
 }
@@ -126,17 +126,17 @@ impl PromptMatcher {
 }
 
 #[derive(Clone, PartialEq)]
-pub(crate) struct PromptConfig {
-    pub(crate) on_enter: PromptOnEnter,
-    pub(crate) title: String,
+pub struct PromptConfig {
+    pub on_enter: PromptOnEnter,
+    pub title: String,
 
     /// If defined, the `Dispatches` here is used for undoing the dispatches fired on change.
-    pub(crate) on_cancelled: Option<Dispatches>,
-    pub(crate) on_change: Option<PromptOnChangeDispatch>,
+    pub on_cancelled: Option<Dispatches>,
+    pub on_change: Option<PromptOnChangeDispatch>,
 }
 
 impl PromptConfig {
-    pub(crate) fn new(title: String, on_enter: PromptOnEnter) -> Self {
+    pub fn new(title: String, on_enter: PromptOnEnter) -> Self {
         Self {
             title,
             on_enter,
@@ -144,7 +144,7 @@ impl PromptConfig {
             on_change: Default::default(),
         }
     }
-    pub(crate) fn items(&self) -> Vec<DropdownItem> {
+    pub fn items(&self) -> Vec<DropdownItem> {
         match &self.on_enter {
             PromptOnEnter::ParseCurrentLine {
                 suggested_items, ..
@@ -158,11 +158,11 @@ impl PromptConfig {
         }
     }
 
-    pub(crate) fn set_on_change(self, on_change: Option<PromptOnChangeDispatch>) -> Self {
+    pub fn set_on_change(self, on_change: Option<PromptOnChangeDispatch>) -> Self {
         Self { on_change, ..self }
     }
 
-    pub(crate) fn set_on_cancelled(self, on_cancelled: Option<Dispatches>) -> PromptConfig {
+    pub fn set_on_cancelled(self, on_cancelled: Option<Dispatches>) -> PromptConfig {
         Self {
             on_cancelled,
             ..self
@@ -180,7 +180,7 @@ impl std::fmt::Debug for PromptConfig {
 }
 
 #[derive(Clone, PartialEq)]
-pub(crate) enum PromptItems {
+pub enum PromptItems {
     None,
     Precomputed(Vec<DropdownItem>),
     BackgroundTask {
@@ -196,7 +196,7 @@ impl Default for PromptItems {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub(crate) enum PromptItemsBackgroundTask {
+pub enum PromptItemsBackgroundTask {
     NonGitIgnoredFiles {
         working_directory: CanonicalizedPath,
     },
@@ -229,7 +229,7 @@ impl PromptItemsBackgroundTask {
 }
 
 #[derive(Hash, PartialEq, Eq, Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
-pub(crate) enum PromptHistoryKey {
+pub enum PromptHistoryKey {
     MoveToIndex,
     Search,
     Rename,
@@ -256,7 +256,7 @@ impl Default for PromptHistoryKey {
 }
 
 impl Prompt {
-    pub(crate) fn new(config: PromptConfig, context: &Context) -> (Self, Dispatches) {
+    pub fn new(config: PromptConfig, context: &Context) -> (Self, Dispatches) {
         let (text, leaves_current_line_empty) = match &config.on_enter {
             PromptOnEnter::ParseCurrentLine {
                 history_key,
@@ -362,11 +362,11 @@ impl Prompt {
         }
     }
 
-    pub(crate) fn render_completion_dropdown(&self) -> Dispatches {
+    pub fn render_completion_dropdown(&self) -> Dispatches {
         self.editor.render_completion_dropdown(true)
     }
 
-    pub(crate) fn handle_nucleo_updated(&mut self, viewport_height: usize) -> Dispatches {
+    pub fn handle_nucleo_updated(&mut self, viewport_height: usize) -> Dispatches {
         let Some(matcher) = self.matcher.as_mut() else {
             return Default::default();
         };
@@ -378,13 +378,13 @@ impl Prompt {
         self.render_completion_dropdown()
     }
 
-    pub(crate) fn reparse_pattern(&mut self, filter: &str) {
+    pub fn reparse_pattern(&mut self, filter: &str) {
         if let Some(matcher) = self.matcher.as_mut() {
             matcher.reparse(filter);
         }
     }
 
-    pub(crate) fn clear_and_update_matcher_items(&mut self, items: Vec<DropdownItem>) {
+    pub fn clear_and_update_matcher_items(&mut self, items: Vec<DropdownItem>) {
         let Some(matcher) = self.matcher.as_mut() else {
             return Default::default();
         };
@@ -401,7 +401,7 @@ impl Prompt {
         }
     }
 
-    pub(crate) fn get_on_change_dispatches(&self) -> Dispatches {
+    pub fn get_on_change_dispatches(&self) -> Dispatches {
         self.on_change
             .as_ref()
             .map(|on_change| {
@@ -493,7 +493,7 @@ impl Component for Prompt {
     }
 }
 impl Prompt {
-    pub(crate) fn handle_dispatch_suggestive_editor(
+    pub fn handle_dispatch_suggestive_editor(
         &mut self,
         dispatch: DispatchSuggestiveEditor,
     ) -> anyhow::Result<Dispatches> {

--- a/src/components/render_editor.rs
+++ b/src/components/render_editor.rs
@@ -37,16 +37,16 @@ static FOCUSED_TAB_REGEX: &Lazy<regex::Regex> =
     // We need multiline string so that wrapped filename will be highlighted as well
     lazy_regex::regex!("(?s)(?<focused_tab>\u{200B}(.*)\u{200B})");
 
-pub(crate) fn markup_focused_tab(path: &str) -> String {
+pub fn markup_focused_tab(path: &str) -> String {
     format!("\u{200B}{path}\u{200B}")
 }
 
 impl Editor {
-    pub(crate) fn get_grid(&mut self, context: &Context, focused: bool) -> GetGridResult {
+    pub fn get_grid(&mut self, context: &Context, focused: bool) -> GetGridResult {
         let hunks = self.buffer_mut().simple_hunks(context).unwrap_or_default();
         self.get_grid_with_scroll_offset(context, focused, self.scroll_offset(), &hunks)
     }
-    pub(crate) fn get_grid_with_scroll_offset(
+    pub fn get_grid_with_scroll_offset(
         &self,
         context: &Context,
         focused: bool,
@@ -143,7 +143,7 @@ impl Editor {
         }
     }
 
-    pub(crate) fn title_impl(&self, context: &Context) -> Option<String> {
+    pub fn title_impl(&self, context: &Context) -> Option<String> {
         let dimension = self.dimension();
         let result = if dimension.height <= 1 {
             vec![]
@@ -911,7 +911,7 @@ impl Editor {
             .collect_vec()
     }
 
-    pub(crate) fn possible_selections_in_line_number_range(
+    pub fn possible_selections_in_line_number_range(
         &self,
         selection: &Selection,
         working_directory: &CanonicalizedPath,
@@ -940,7 +940,7 @@ impl Editor {
         )
     }
 
-    pub(crate) fn revealed_selections(
+    pub fn revealed_selections(
         &self,
         selection: &Selection,
         working_directory: &CanonicalizedPath,
@@ -963,11 +963,11 @@ impl Editor {
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
-pub(crate) struct HighlightSpan {
-    pub(crate) source: Source,
-    pub(crate) range: HighlightSpanRange,
-    pub(crate) set_symbol: Option<char>,
-    pub(crate) is_cursor: bool,
+pub struct HighlightSpan {
+    pub source: Source,
+    pub range: HighlightSpanRange,
+    pub set_symbol: Option<char>,
+    pub is_cursor: bool,
     is_protected_range_start: bool,
 }
 
@@ -1183,13 +1183,13 @@ fn range_intersection<T: Ord + Copy>(a: &Range<T>, b: &Range<T>) -> Option<Range
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub(crate) enum Source {
+pub enum Source {
     StyleKey(StyleKey),
     Style(Style),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub(crate) enum HighlightSpanRange {
+pub enum HighlightSpanRange {
     CharIndexRange(CharIndexRange),
     ByteRange(Range<usize>),
     CharIndex(CharIndex),

--- a/src/components/suggestive_editor.rs
+++ b/src/components/suggestive_editor.rs
@@ -25,7 +25,7 @@ use super::{
 };
 
 /// Editor with auto-complete
-pub(crate) struct SuggestiveEditor {
+pub struct SuggestiveEditor {
     editor: Editor,
     completion_dropdown: Dropdown,
     trigger_characters: Vec<String>,
@@ -33,7 +33,7 @@ pub(crate) struct SuggestiveEditor {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) enum SuggestiveEditorFilter {
+pub enum SuggestiveEditorFilter {
     CurrentWord,
     CurrentLine,
 }
@@ -130,7 +130,7 @@ impl Component for SuggestiveEditor {
 }
 
 impl SuggestiveEditor {
-    pub(crate) fn from_buffer(buffer: Rc<RefCell<Buffer>>, filter: SuggestiveEditorFilter) -> Self {
+    pub fn from_buffer(buffer: Rc<RefCell<Buffer>>, filter: SuggestiveEditorFilter) -> Self {
         Self {
             editor: Editor::from_buffer(buffer),
             completion_dropdown: Dropdown::new(DropdownConfig {
@@ -141,7 +141,7 @@ impl SuggestiveEditor {
         }
     }
 
-    pub(crate) fn handle_dispatch(
+    pub fn handle_dispatch(
         &mut self,
         dispatch: DispatchSuggestiveEditor,
     ) -> anyhow::Result<Dispatches> {
@@ -173,20 +173,20 @@ impl SuggestiveEditor {
         }
     }
 
-    pub(crate) fn completion_dropdown_current_item(&mut self) -> Option<DropdownItem> {
+    pub fn completion_dropdown_current_item(&mut self) -> Option<DropdownItem> {
         self.completion_dropdown.current_item()
     }
 
-    pub(crate) fn completion_dropdown_opened(&self) -> bool {
+    pub fn completion_dropdown_opened(&self) -> bool {
         !self.completion_dropdown.items().is_empty()
     }
 
-    pub(crate) fn set_completion(&mut self, completion: Completion) {
+    pub fn set_completion(&mut self, completion: Completion) {
         self.completion_dropdown.set_items(completion.items);
         self.trigger_characters = completion.trigger_characters;
     }
 
-    pub(crate) fn render_completion_dropdown(&self, ignore_insert_mode: bool) -> Dispatches {
+    pub fn render_completion_dropdown(&self, ignore_insert_mode: bool) -> Dispatches {
         log::info!(
             "ignore_insert_mode = {ignore_insert_mode} mode = {:?}",
             self.editor.mode
@@ -274,7 +274,7 @@ impl SuggestiveEditor {
         }
     }
 
-    pub(crate) fn update_current_line(
+    pub fn update_current_line(
         &mut self,
         context: &Context,
         display: &str,
@@ -282,13 +282,13 @@ impl SuggestiveEditor {
         self.editor_mut().update_current_line(context, display)
     }
 
-    pub(crate) fn update_items(&mut self, items: Vec<DropdownItem>) {
+    pub fn update_items(&mut self, items: Vec<DropdownItem>) {
         self.completion_dropdown.set_items(items)
     }
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) enum DispatchSuggestiveEditor {
+pub enum DispatchSuggestiveEditor {
     #[cfg(test)]
     CompletionFilter(SuggestiveEditorFilter),
     Completion(Completion),
@@ -1064,13 +1064,13 @@ mod test_suggestive_editor {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Default)]
-pub(crate) struct Info {
+pub struct Info {
     title: String,
     content: String,
     decorations: Vec<Decoration>,
 }
 impl Info {
-    pub(crate) fn new(title: String, content: String) -> Info {
+    pub fn new(title: String, content: String) -> Info {
         Info {
             title,
             content,
@@ -1078,22 +1078,22 @@ impl Info {
         }
     }
 
-    pub(crate) fn content(&self) -> &String {
+    pub fn content(&self) -> &String {
         &self.content
     }
 
-    pub(crate) fn decorations(&self) -> &Vec<Decoration> {
+    pub fn decorations(&self) -> &Vec<Decoration> {
         &self.decorations
     }
 
-    pub(crate) fn set_decorations(self, decorations: Vec<Decoration>) -> Info {
+    pub fn set_decorations(self, decorations: Vec<Decoration>) -> Info {
         Info {
             decorations,
             ..self
         }
     }
 
-    pub(crate) fn join(self, other: Info) -> Info {
+    pub fn join(self, other: Info) -> Info {
         let separator = "=".repeat(10).to_string();
         let content = format!("{}\n{}\n{}", self.content, separator, other.content);
         let other_decorations = other
@@ -1113,17 +1113,17 @@ impl Info {
         }
     }
 
-    pub(crate) fn title(&self) -> String {
+    pub fn title(&self) -> String {
         self.title.clone()
     }
 
-    pub(crate) fn display(&self) -> String {
+    pub fn display(&self) -> String {
         format!("{}\n\n{}", self.title(), self.content())
     }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub(crate) struct Decoration {
+pub struct Decoration {
     selection_range: SelectionRange,
     style_key: StyleKey,
     adjustments: Vec<Adjustment>,
@@ -1140,15 +1140,15 @@ impl Decoration {
         self
     }
 
-    pub(crate) fn selection_range(&self) -> &SelectionRange {
+    pub fn selection_range(&self) -> &SelectionRange {
         &self.selection_range
     }
 
-    pub(crate) fn style_key(&self) -> &StyleKey {
+    pub fn style_key(&self) -> &StyleKey {
         &self.style_key
     }
 
-    pub(crate) fn new(selection_range: SelectionRange, style_key: StyleKey) -> Decoration {
+    pub fn new(selection_range: SelectionRange, style_key: StyleKey) -> Decoration {
         Decoration {
             selection_range,
             style_key,
@@ -1156,7 +1156,7 @@ impl Decoration {
         }
     }
 
-    pub(crate) fn move_left(self, count: usize) -> Decoration {
+    pub fn move_left(self, count: usize) -> Decoration {
         Decoration {
             selection_range: self.selection_range.move_left(count),
             ..self
@@ -1164,7 +1164,7 @@ impl Decoration {
     }
 }
 
-pub(crate) fn completion_item_keymaps(context: &Context) -> Keymaps {
+pub fn completion_item_keymaps(context: &Context) -> Keymaps {
     Keymaps::new(&[
         Keymap::new_extended(
             alted(context.keyboard_layout_kind().get_key(&Meaning::Right)),

--- a/src/components/test_editor.rs
+++ b/src/components/test_editor.rs
@@ -5437,9 +5437,21 @@ fn git_hunk_gutter() -> anyhow::Result<()> {
 6│}
 7│"#,
             )),
-            Expect(GridCellBackground(2, 1, GitGutterStyles::new().insertion)),
-            Expect(GridCellBackground(4, 1, GitGutterStyles::new().replacement)),
-            Expect(GridCellBackground(6, 1, GitGutterStyles::new().deletion)),
+            Expect(GridCellBackground(
+                2,
+                1,
+                GitGutterStyles::default().insertion,
+            )),
+            Expect(GridCellBackground(
+                4,
+                1,
+                GitGutterStyles::default().replacement,
+            )),
+            Expect(GridCellBackground(
+                6,
+                1,
+                GitGutterStyles::default().deletion,
+            )),
         ])
     })
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,7 +18,7 @@ use shared::language::{self, Language};
 
 #[derive(Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
-pub(crate) struct AppConfig {
+pub struct AppConfig {
     languages: HashMap<String, Language>,
     keyboard_layout: KeyboardLayoutKind,
     theme: ConfigTheme,
@@ -34,9 +34,9 @@ pub(crate) struct AppConfig {
 /// 2nd row is "asdfghjkl;",  
 /// and 3rd row is "zxcvbnm,./".  
 #[derive(Clone, Deserialize, Serialize, JsonSchema)]
-pub(crate) struct LeaderKeymap([[Option<Keybinding>; 10]; 3]);
+pub struct LeaderKeymap([[Option<Keybinding>; 10]; 3]);
 impl LeaderKeymap {
-    pub(crate) fn keybindings(&self) -> &[[Option<Keybinding>; 10]; 3] {
+    pub fn keybindings(&self) -> &[[Option<Keybinding>; 10]; 3] {
         &self.0
     }
 }
@@ -92,7 +92,7 @@ fn ki_global_directory() -> PathBuf {
     ::grammar::config_dir()
 }
 
-pub(crate) fn load_script(script_name: &str) -> anyhow::Result<Script> {
+pub fn load_script(script_name: &str) -> anyhow::Result<Script> {
     // Trying reading from workspace directory first
     let workspace_path = ki_workspace_directory()?.join("scripts").join(script_name);
     let global_path = ki_global_directory().join("scripts").join(script_name);
@@ -128,7 +128,7 @@ impl AppConfig {
         }
     }
 
-    pub(crate) fn load_from_current_directory() -> anyhow::Result<Self> {
+    pub fn load_from_current_directory() -> anyhow::Result<Self> {
         let workspace_dir = ki_workspace_directory()?;
         let workspace_config = |extension: &str| workspace_dir.join(format!("config.{extension}"));
         let global_config =
@@ -145,7 +145,7 @@ impl AppConfig {
         Ok(config)
     }
 
-    pub(crate) fn singleton() -> &'static AppConfig {
+    pub fn singleton() -> &'static AppConfig {
         static INSTANCE: OnceCell<AppConfig> = OnceCell::new();
         INSTANCE.get_or_init(|| match AppConfig::load_from_current_directory() {
             Ok(config) => config,
@@ -159,34 +159,34 @@ impl AppConfig {
         })
     }
 
-    pub(crate) fn languages(&self) -> &HashMap<std::string::String, language::Language> {
+    pub fn languages(&self) -> &HashMap<std::string::String, language::Language> {
         &self.languages
     }
 
-    pub(crate) fn keyboard_layout_kind(&self) -> KeyboardLayoutKind {
+    pub fn keyboard_layout_kind(&self) -> KeyboardLayoutKind {
         self.keyboard_layout
     }
 
-    pub(crate) fn theme(&self) -> &Theme {
+    pub fn theme(&self) -> &Theme {
         &self.theme.0
     }
 
-    pub(crate) fn status_lines(&self) -> Vec<crate::app::StatusLine> {
+    pub fn status_lines(&self) -> Vec<crate::app::StatusLine> {
         self.status_lines.clone()
     }
 
-    pub(crate) fn leader_keymap(&self) -> &LeaderKeymap {
+    pub fn leader_keymap(&self) -> &LeaderKeymap {
         &self.leader_keymap
     }
 }
 
-pub(crate) fn from_path(path: &CanonicalizedPath) -> Option<Language> {
+pub fn from_path(path: &CanonicalizedPath) -> Option<Language> {
     path.extension()
         .and_then(from_extension)
         .or_else(|| from_filename(path))
 }
 
-pub(crate) fn from_extension(extension: &str) -> Option<Language> {
+pub fn from_extension(extension: &str) -> Option<Language> {
     AppConfig::singleton()
         .languages()
         .iter()
@@ -194,7 +194,7 @@ pub(crate) fn from_extension(extension: &str) -> Option<Language> {
         .map(|(_, language)| (*language).clone())
 }
 
-pub(crate) fn from_filename(path: &CanonicalizedPath) -> Option<Language> {
+pub fn from_filename(path: &CanonicalizedPath) -> Option<Language> {
     let file_name = path.file_name()?;
     AppConfig::singleton()
         .languages()
@@ -216,7 +216,7 @@ pub(crate) fn from_filename(path: &CanonicalizedPath) -> Option<Language> {
 /// - `# mode: bash
 ///
 /// Spaces and other content on the line do not matter.
-pub(crate) fn from_content_directive(content: &str) -> Option<Language> {
+pub fn from_content_directive(content: &str) -> Option<Language> {
     let first_line = content.lines().next()?;
 
     let re = Regex::new(r"(?:(?:^#!.*/)|(?:mode:)|(?:ft\s*=))\s*(\w+)").unwrap();

--- a/src/context.rs
+++ b/src/context.rs
@@ -18,7 +18,7 @@ use crate::{
     themes::Theme,
 };
 
-pub(crate) struct Context {
+pub struct Context {
     clipboard: Clipboard,
     mode: Option<GlobalMode>,
     theme: Theme,
@@ -48,24 +48,24 @@ pub(crate) struct Context {
     persistence: Option<Persistence>,
 }
 
-pub(crate) struct QuickfixListState {
-    pub(crate) title: String,
-    pub(crate) source: QuickfixListSource,
-    pub(crate) current_item_index: usize,
+pub struct QuickfixListState {
+    pub title: String,
+    pub source: QuickfixListSource,
+    pub current_item_index: usize,
 }
 
-pub(crate) enum QuickfixListSource {
+pub enum QuickfixListSource {
     Diagnostic(DiagnosticSeverityRange),
     Mark,
     Custom(Vec<QuickfixListItem>),
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
-pub(crate) enum GlobalMode {
+pub enum GlobalMode {
     QuickfixListItem,
 }
 impl GlobalMode {
-    pub(crate) fn display(&self) -> String {
+    pub fn display(&self) -> String {
         match self {
             GlobalMode::QuickfixListItem => "QFIX".to_string(),
         }
@@ -73,18 +73,18 @@ impl GlobalMode {
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
-pub(crate) struct Search {
-    pub(crate) mode: LocalSearchConfigMode,
-    pub(crate) search: String,
+pub struct Search {
+    pub mode: LocalSearchConfigMode,
+    pub search: String,
 }
 
 impl Context {
     #[cfg(test)]
-    pub(crate) fn default() -> Self {
+    pub fn default() -> Self {
         Self::new(CanonicalizedPath::try_from(".").unwrap(), false, None)
     }
 
-    pub(crate) fn persist_data(&mut self) {
+    pub fn persist_data(&mut self) {
         if let Some(persistence) = self.persistence.as_mut() {
             let current_working_directory = self.current_working_directory.to_path_buf();
             persistence.set_workspace_session(
@@ -110,7 +110,7 @@ impl Context {
         }
     }
 
-    pub(crate) fn extend_quickfix_list_items(&mut self, new_items: Vec<QuickfixListItem>) {
+    pub fn extend_quickfix_list_items(&mut self, new_items: Vec<QuickfixListItem>) {
         if let Some(QuickfixListState {
             source: QuickfixListSource::Custom(items),
             ..
@@ -120,7 +120,7 @@ impl Context {
         }
     }
 
-    pub(crate) fn quickfix_list_items(&self) -> Vec<&QuickfixListItem> {
+    pub fn quickfix_list_items(&self) -> Vec<&QuickfixListItem> {
         if let Some(QuickfixListState {
             source: QuickfixListSource::Custom(items),
             ..
@@ -132,11 +132,7 @@ impl Context {
         }
     }
 
-    pub(crate) fn handle_applied_edits(
-        &mut self,
-        path: CanonicalizedPath,
-        edits: Vec<crate::edit::Edit>,
-    ) {
+    pub fn handle_applied_edits(&mut self, path: CanonicalizedPath, edits: Vec<crate::edit::Edit>) {
         if let Some(state) = self.quickfix_list_state.take() {
             self.quickfix_list_state = Some(match state.source {
                 QuickfixListSource::Diagnostic(_) => state,
@@ -184,7 +180,7 @@ impl Context {
             .collect();
     }
 
-    pub(crate) fn save_marks(&mut self, path: CanonicalizedPath, marks: Vec<CharIndexRange>) {
+    pub fn save_marks(&mut self, path: CanonicalizedPath, marks: Vec<CharIndexRange>) {
         let old_ranges = self
             .marks
             .get(&path)
@@ -206,16 +202,16 @@ impl Context {
         );
     }
 
-    pub(crate) fn get_marks(&self, path: Option<CanonicalizedPath>) -> Vec<CharIndexRange> {
+    pub fn get_marks(&self, path: Option<CanonicalizedPath>) -> Vec<CharIndexRange> {
         path.map(|path| self.marks.get(&path).cloned().unwrap_or_default().to_vec())
             .unwrap_or_default()
     }
 
-    pub(crate) fn marks(&self) -> &HashMap<CanonicalizedPath, Vec<CharIndexRange>> {
+    pub fn marks(&self) -> &HashMap<CanonicalizedPath, Vec<CharIndexRange>> {
         &self.marks
     }
 
-    pub(crate) fn handle_file_renamed(
+    pub fn handle_file_renamed(
         &mut self,
         source: std::path::PathBuf,
         destination: CanonicalizedPath,
@@ -230,20 +226,20 @@ impl Context {
         }
     }
 
-    pub(crate) fn mark_files(&mut self, paths: nonempty::NonEmpty<CanonicalizedPath>) {
+    pub fn mark_files(&mut self, paths: nonempty::NonEmpty<CanonicalizedPath>) {
         for path in paths {
             self.mark_file(path);
         }
     }
 
     #[cfg(test)]
-    pub(crate) fn change_working_directory(&mut self, path: CanonicalizedPath) {
+    pub fn change_working_directory(&mut self, path: CanonicalizedPath) {
         self.current_working_directory = path
     }
 }
 
 impl Context {
-    pub(crate) fn new(
+    pub fn new(
         current_working_directory: CanonicalizedPath,
         is_running_as_embedded: bool,
         persistence: Option<Persistence>,
@@ -304,7 +300,7 @@ impl Context {
     }
 
     /// Checks if the contents in both the system clipboard and the app clipboard is the same
-    pub(crate) fn clipboards_synced(&self) -> bool {
+    pub fn clipboards_synced(&self) -> bool {
         let history_offset = 0;
         let Some(app_clipboard_content) = self.clipboard.get(history_offset) else {
             return false;
@@ -317,7 +313,7 @@ impl Context {
         app_clipboard_content == system_clipboard_content
     }
 
-    pub(crate) fn add_clipboard_history(&mut self, item: CopiedTexts) {
+    pub fn add_clipboard_history(&mut self, item: CopiedTexts) {
         self.clipboard.add_clipboard_history(item)
     }
 
@@ -325,7 +321,7 @@ impl Context {
     ///
     /// This method should never fail, if `use_system_clipboard` is true but
     /// the system clipboard is inaccessible, the app clipboard will be used.
-    pub(crate) fn get_clipboard_content(&self, history_offset: isize) -> Option<CopiedTexts> {
+    pub fn get_clipboard_content(&self, history_offset: isize) -> Option<CopiedTexts> {
         // Always use the system clipboard if the content of the system clipboard is no longer the same
         // with the content of the app clipboard
         let use_system_clipboard = !self.clipboards_synced();
@@ -342,29 +338,29 @@ impl Context {
         self.clipboard.get(history_offset)
     }
 
-    pub(crate) fn set_clipboard_content(&mut self, contents: CopiedTexts) -> anyhow::Result<()> {
+    pub fn set_clipboard_content(&mut self, contents: CopiedTexts) -> anyhow::Result<()> {
         self.clipboard.set(contents.clone())
     }
-    pub(crate) fn mode(&self) -> Option<GlobalMode> {
+    pub fn mode(&self) -> Option<GlobalMode> {
         self.mode.clone()
     }
-    pub(crate) fn set_mode(&mut self, mode: Option<GlobalMode>) {
+    pub fn set_mode(&mut self, mode: Option<GlobalMode>) {
         self.mode = mode.clone();
         if let Some(mode) = mode {
             self.last_non_contiguous_selection_mode = Some(Either::Right(mode))
         }
     }
 
-    pub(crate) fn theme(&self) -> &Theme {
+    pub fn theme(&self) -> &Theme {
         &self.theme
     }
 
-    pub(crate) fn set_theme(&mut self, theme: Theme) {
+    pub fn set_theme(&mut self, theme: Theme) {
         self.theme = theme
     }
 
     #[cfg(test)]
-    pub(crate) fn highlight(
+    pub fn highlight(
         &mut self,
         language: shared::language::Language,
         source_code: &str,
@@ -375,19 +371,15 @@ impl Context {
             .highlight(language, source_code, &AtomicUsize::new(0))
     }
 
-    pub(crate) fn current_working_directory(&self) -> &CanonicalizedPath {
+    pub fn current_working_directory(&self) -> &CanonicalizedPath {
         &self.current_working_directory
     }
 
-    pub(crate) fn global_search_config(&self) -> &GlobalSearchConfig {
+    pub fn global_search_config(&self) -> &GlobalSearchConfig {
         &self.global_search_config
     }
 
-    pub(crate) fn update_local_search_config(
-        &mut self,
-        update: LocalSearchConfigUpdate,
-        scope: Scope,
-    ) {
+    pub fn update_local_search_config(&mut self, update: LocalSearchConfigUpdate, scope: Scope) {
         match scope {
             Scope::Local => &mut self.local_search_config,
             Scope::Global => &mut self.global_search_config.local_config,
@@ -395,7 +387,7 @@ impl Context {
         .update(update)
     }
 
-    pub(crate) fn update_global_search_config(
+    pub fn update_global_search_config(
         &mut self,
         update: GlobalSearchConfigUpdate,
     ) -> anyhow::Result<()> {
@@ -405,18 +397,18 @@ impl Context {
         Ok(())
     }
 
-    pub(crate) fn local_search_config(&self, scope: Scope) -> &LocalSearchConfig {
+    pub fn local_search_config(&self, scope: Scope) -> &LocalSearchConfig {
         match scope {
             Scope::Local => &self.local_search_config,
             Scope::Global => &self.global_search_config.local_config,
         }
     }
 
-    pub(crate) fn quickfix_list_state(&self) -> &Option<QuickfixListState> {
+    pub fn quickfix_list_state(&self) -> &Option<QuickfixListState> {
         &self.quickfix_list_state
     }
 
-    pub(crate) fn set_quickfix_list_current_item_index(&mut self, current_item_index: usize) {
+    pub fn set_quickfix_list_current_item_index(&mut self, current_item_index: usize) {
         if let Some(state) = self.quickfix_list_state.take() {
             self.quickfix_list_state = Some(QuickfixListState {
                 current_item_index,
@@ -425,7 +417,7 @@ impl Context {
         }
     }
 
-    pub(crate) fn set_quickfix_list_source(&mut self, title: String, source: QuickfixListSource) {
+    pub fn set_quickfix_list_source(&mut self, title: String, source: QuickfixListSource) {
         self.quickfix_list_state = Some(QuickfixListState {
             title,
             source,
@@ -433,7 +425,7 @@ impl Context {
         })
     }
 
-    pub(crate) fn push_history_prompt(&mut self, key: PromptHistoryKey, line: String) {
+    pub fn push_history_prompt(&mut self, key: PromptHistoryKey, line: String) {
         if let Some(map) = self.prompt_histories.get_mut(&key) {
             map.shift_remove(&line);
             let inserted = map.insert(line);
@@ -447,7 +439,7 @@ impl Context {
         }
     }
 
-    pub(crate) fn get_prompt_history(&self, key: PromptHistoryKey) -> Vec<String> {
+    pub fn get_prompt_history(&self, key: PromptHistoryKey) -> Vec<String> {
         self.prompt_histories
             .get(&key)
             .cloned()
@@ -456,28 +448,28 @@ impl Context {
             .collect_vec()
     }
 
-    pub(crate) fn set_last_non_contiguous_selection_mode(
+    pub fn set_last_non_contiguous_selection_mode(
         &mut self,
         selection_mode: Either<crate::selection::SelectionMode, GlobalMode>,
     ) {
         self.last_non_contiguous_selection_mode = Some(selection_mode)
     }
 
-    pub(crate) fn last_non_contiguous_selection_mode(
+    pub fn last_non_contiguous_selection_mode(
         &self,
     ) -> Option<&Either<crate::selection::SelectionMode, GlobalMode>> {
         self.last_non_contiguous_selection_mode.as_ref()
     }
 
-    pub(crate) fn keyboard_layout_kind(&self) -> &KeyboardLayoutKind {
+    pub fn keyboard_layout_kind(&self) -> &KeyboardLayoutKind {
         &self.keyboard_layout_kind
     }
 
-    pub(crate) fn set_keyboard_layout_kind(&mut self, keyboard_layout_kind: KeyboardLayoutKind) {
+    pub fn set_keyboard_layout_kind(&mut self, keyboard_layout_kind: KeyboardLayoutKind) {
         self.keyboard_layout_kind = keyboard_layout_kind
     }
 
-    pub(crate) fn push_location_history(&mut self, location: Location, backward: bool) {
+    pub fn push_location_history(&mut self, location: Location, backward: bool) {
         if backward {
             self.location_history_backward.push(location);
             self.location_history_forward.clear();
@@ -486,25 +478,22 @@ impl Context {
         }
     }
 
-    pub(crate) fn location_previous(&mut self) -> Option<Location> {
+    pub fn location_previous(&mut self) -> Option<Location> {
         self.location_history_backward.pop()
     }
 
-    pub(crate) fn location_next(&mut self) -> Option<Location> {
+    pub fn location_next(&mut self) -> Option<Location> {
         self.location_history_forward.pop()
     }
 
-    pub(crate) fn get_marked_files(&self) -> Vec<&CanonicalizedPath> {
+    pub fn get_marked_files(&self) -> Vec<&CanonicalizedPath> {
         self.marked_files.iter().collect()
     }
 
     /// Returns some path if we should focus another file.
     /// If the action is to unmark a file, and the file is not the only marked file left,
     /// then we return the nearest neighbor.
-    pub(crate) fn toggle_path_mark(
-        &mut self,
-        path: CanonicalizedPath,
-    ) -> Option<&CanonicalizedPath> {
+    pub fn toggle_path_mark(&mut self, path: CanonicalizedPath) -> Option<&CanonicalizedPath> {
         if let Some(index) = self.marked_files.get_index_of(&path) {
             self.unmark_path_impl(index, path)
         } else {
@@ -513,12 +502,12 @@ impl Context {
         }
     }
 
-    pub(crate) fn mark_file(&mut self, path: CanonicalizedPath) -> (usize, bool) {
+    pub fn mark_file(&mut self, path: CanonicalizedPath) -> (usize, bool) {
         self.marked_files.insert_sorted(path)
     }
 
     /// Returns true if the path to be removed is in the list
-    pub(crate) fn unmark_path(&mut self, path: CanonicalizedPath) -> Option<&CanonicalizedPath> {
+    pub fn unmark_path(&mut self, path: CanonicalizedPath) -> Option<&CanonicalizedPath> {
         if let Some(index) = self.marked_files.get_index_of(&path) {
             self.unmark_path_impl(index, path)
         } else {
@@ -540,44 +529,44 @@ impl Context {
             })
     }
 
-    pub(crate) fn is_running_as_embedded(&self) -> bool {
+    pub fn is_running_as_embedded(&self) -> bool {
         self.is_running_as_embedded
     }
 
-    pub(crate) fn rename_path_mark(&mut self, from: &CanonicalizedPath, to: &CanonicalizedPath) {
+    pub fn rename_path_mark(&mut self, from: &CanonicalizedPath, to: &CanonicalizedPath) {
         self.marked_files.shift_remove(from);
         self.marked_files.insert_sorted(to.clone());
     }
 }
 
 #[derive(Default, Clone, Debug, PartialEq, Eq)]
-pub(crate) struct GlobalSearchConfig {
-    pub(crate) include_glob: Option<Glob>,
-    pub(crate) exclude_glob: Option<Glob>,
-    pub(crate) local_config: LocalSearchConfig,
+pub struct GlobalSearchConfig {
+    pub include_glob: Option<Glob>,
+    pub exclude_glob: Option<Glob>,
+    pub local_config: LocalSearchConfig,
 }
 impl GlobalSearchConfig {
-    pub(crate) fn local_config(&self) -> &LocalSearchConfig {
+    pub fn local_config(&self) -> &LocalSearchConfig {
         &self.local_config
     }
 
-    pub(crate) fn include_glob(&self) -> Option<Glob> {
+    pub fn include_glob(&self) -> Option<Glob> {
         self.include_glob.clone()
     }
 
-    pub(crate) fn exclude_glob(&self) -> Option<Glob> {
+    pub fn exclude_glob(&self) -> Option<Glob> {
         self.exclude_glob.clone()
     }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Copy)]
-pub(crate) enum LocalSearchConfigMode {
+pub enum LocalSearchConfigMode {
     Regex(RegexConfig),
     AstGrep,
     NamingConventionAgnostic,
 }
 impl LocalSearchConfigMode {
-    pub(crate) fn display(&self) -> String {
+    pub fn display(&self) -> String {
         match self {
             LocalSearchConfigMode::Regex(regex) => regex.display(),
 
@@ -615,14 +604,14 @@ impl RegexConfig {
 }
 
 #[derive(Default, Clone, Debug, PartialEq, Eq)]
-pub(crate) struct LocalSearchConfig {
-    pub(crate) mode: LocalSearchConfigMode,
+pub struct LocalSearchConfig {
+    pub mode: LocalSearchConfigMode,
     search: Option<String>,
     replacement: Option<String>,
 }
 
 impl LocalSearchConfig {
-    pub(crate) fn new(mode: LocalSearchConfigMode) -> Self {
+    pub fn new(mode: LocalSearchConfigMode) -> Self {
         Self {
             mode,
             search: Default::default(),
@@ -646,32 +635,32 @@ impl LocalSearchConfig {
         }
     }
 
-    pub(crate) fn set_search(&mut self, search: String) -> &mut Self {
+    pub fn set_search(&mut self, search: String) -> &mut Self {
         let _ = self.search.insert(search);
         self
     }
 
-    pub(crate) fn search(&self) -> String {
+    pub fn search(&self) -> String {
         self.search.clone().unwrap_or_default()
     }
 
-    pub(crate) fn set_replacment(&mut self, replacement: String) -> &mut Self {
+    pub fn set_replacment(&mut self, replacement: String) -> &mut Self {
         let _ = self.replacement.insert(replacement);
         self
     }
 
-    pub(crate) fn last_search(&self) -> Option<Search> {
+    pub fn last_search(&self) -> Option<Search> {
         self.search.clone().map(|search| Search {
             search,
             mode: self.mode,
         })
     }
 
-    pub(crate) fn replacement(&self) -> String {
+    pub fn replacement(&self) -> String {
         self.replacement.clone().unwrap_or_default()
     }
 
-    pub(crate) fn require_tree_sitter(&self) -> bool {
+    pub fn require_tree_sitter(&self) -> bool {
         self.mode == LocalSearchConfigMode::AstGrep
     }
 }

--- a/src/divide_viewport.rs
+++ b/src/divide_viewport.rs
@@ -3,7 +3,7 @@ use itertools::Itertools;
 
 use crate::utils::{distribute_items, distribute_items_by_2};
 
-pub(crate) fn divide_viewport<T: Clone + std::fmt::Debug + Eq>(
+pub fn divide_viewport<T: Clone + std::fmt::Debug + Eq>(
     items: &Vec<T>,
     viewport_height: usize,
     focused_item: T,
@@ -39,21 +39,21 @@ pub(crate) fn divide_viewport<T: Clone + std::fmt::Debug + Eq>(
 }
 
 #[derive(Debug)]
-pub(crate) struct ViewportSection<T> {
+pub struct ViewportSection<T> {
     item: T,
     height: usize,
 }
 impl<T: Clone> ViewportSection<T> {
-    pub(crate) fn height(&self) -> usize {
+    pub fn height(&self) -> usize {
         self.height
     }
 
-    pub(crate) fn item(&self) -> T {
+    pub fn item(&self) -> T {
         self.item.clone()
     }
 }
 
-pub(crate) fn extract_centered_window<T: Eq + Clone + std::fmt::Debug, F: Fn(&T) -> bool>(
+pub fn extract_centered_window<T: Eq + Clone + std::fmt::Debug, F: Fn(&T) -> bool>(
     elements: &[T],
     predicate: F,
     window_size: usize,
@@ -156,17 +156,17 @@ mod test_divide_viewport {
 }
 
 #[derive(Debug, Eq, PartialEq)]
-pub(crate) struct WindowPosition {
+pub struct WindowPosition {
     /// Start index of the window (inclusive)
-    pub(crate) start: usize,
+    pub start: usize,
     /// End index of the window (inclusive)
-    pub(crate) end: usize,
+    pub end: usize,
 }
 
 impl WindowPosition {
     /// Returns the size of the window
     #[cfg(test)]
-    pub(crate) fn size(&self) -> usize {
+    pub fn size(&self) -> usize {
         self.end - self.start + 1
     }
 }
@@ -209,7 +209,7 @@ impl WindowPosition {
 /// let pos = calculate_window_position(98, 100, 5, ViewAlignment::Bottom);
 /// assert_eq!(pos.end, 99);
 /// ```
-pub(crate) fn calculate_window_position(
+pub fn calculate_window_position(
     index: usize,
     total_len: usize,
     window_size: usize,

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -9,13 +9,13 @@ use crate::{
 };
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub(crate) struct Edit {
-    pub(crate) range: CharIndexRange,
-    pub(crate) new: Rope,
-    pub(crate) old: Rope,
+pub struct Edit {
+    pub range: CharIndexRange,
+    pub new: Rope,
+    pub old: Rope,
 }
 impl Edit {
-    pub(crate) fn new(rope: &Rope, range: CharIndexRange, new: Rope) -> Self {
+    pub fn new(rope: &Rope, range: CharIndexRange, new: Rope) -> Self {
         Self {
             range,
             old: rope.slice(range.as_usize_range()).into(),
@@ -30,15 +30,15 @@ impl Edit {
         }
     }
 
-    pub(crate) fn end(&self) -> CharIndex {
+    pub fn end(&self) -> CharIndex {
         self.range.end
     }
 
-    pub(crate) fn range(&self) -> CharIndexRange {
+    pub fn range(&self) -> CharIndexRange {
         self.range
     }
 
-    pub(crate) fn chars_offset(&self) -> isize {
+    pub fn chars_offset(&self) -> isize {
         self.new.len_chars() as isize - self.range.len() as isize
     }
 
@@ -46,7 +46,7 @@ impl Edit {
         self.range().intersects_with(&other.range())
     }
 
-    pub(crate) fn to_vscode_diff_edit(
+    pub fn to_vscode_diff_edit(
         &self,
         buffer: &Buffer,
     ) -> anyhow::Result<ki_protocol_types::DiffEdit> {
@@ -80,7 +80,7 @@ impl ApplyOffset for CharIndexRange {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub(crate) enum Action {
+pub enum Action {
     Select(Selection),
     Edit(Edit),
 }
@@ -118,7 +118,7 @@ impl Action {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct EditTransaction {
+pub struct EditTransaction {
     /// This `action_group` should be always normalized.
     action_group: ActionGroup,
 
@@ -144,7 +144,7 @@ impl EditTransaction {
         (selections, rope)
     }
 
-    pub(crate) fn edits(&self) -> Vec<&Edit> {
+    pub fn edits(&self) -> Vec<&Edit> {
         self.action_group
             .actions
             .iter()
@@ -155,7 +155,7 @@ impl EditTransaction {
             .collect_vec()
     }
 
-    pub(crate) fn from_action_groups(action_groups: Vec<ActionGroup>) -> Self {
+    pub fn from_action_groups(action_groups: Vec<ActionGroup>) -> Self {
         let unnormalized_edits = action_groups
             .iter()
             .flat_map(|action_group| {
@@ -176,7 +176,7 @@ impl EditTransaction {
     }
 
     #[cfg(test)]
-    pub(crate) fn from_tuples(action_groups: Vec<ActionGroup>) -> Self {
+    pub fn from_tuples(action_groups: Vec<ActionGroup>) -> Self {
         Self {
             action_group: Self::normalize_action_groups(action_groups),
             unnormalized_edits: Default::default(),
@@ -206,7 +206,7 @@ impl EditTransaction {
         ActionGroup { actions: result }
     }
 
-    pub(crate) fn min_char_index(&self) -> CharIndex {
+    pub fn min_char_index(&self) -> CharIndex {
         self.action_group
             .actions
             .iter()
@@ -215,7 +215,7 @@ impl EditTransaction {
             .unwrap_or(CharIndex(0))
     }
 
-    pub(crate) fn max_char_index(&self) -> CharIndex {
+    pub fn max_char_index(&self) -> CharIndex {
         self.action_group
             .actions
             .iter()
@@ -224,7 +224,7 @@ impl EditTransaction {
             .unwrap_or(CharIndex(0))
     }
 
-    pub(crate) fn merge(edit_transactions: Vec<EditTransaction>) -> EditTransaction {
+    pub fn merge(edit_transactions: Vec<EditTransaction>) -> EditTransaction {
         let unnormalized_edits = edit_transactions
             .iter()
             .flat_map(|edit_transaction| edit_transaction.unnormalized_edits.clone())
@@ -241,7 +241,7 @@ impl EditTransaction {
         }
     }
 
-    pub(crate) fn selections(&self) -> Vec<&Selection> {
+    pub fn selections(&self) -> Vec<&Selection> {
         self.action_group
             .actions
             .iter()
@@ -252,11 +252,11 @@ impl EditTransaction {
             .collect_vec()
     }
 
-    pub(crate) fn range(&self) -> CharIndexRange {
+    pub fn range(&self) -> CharIndexRange {
         (self.min_char_index()..self.max_char_index()).into()
     }
 
-    pub(crate) fn non_empty_selections(&self) -> Option<NonEmpty<Selection>> {
+    pub fn non_empty_selections(&self) -> Option<NonEmpty<Selection>> {
         if let Some((head, tail)) = self.selections().split_first() {
             Some(NonEmpty {
                 head: (*head).to_owned(),
@@ -267,7 +267,7 @@ impl EditTransaction {
         }
     }
 
-    pub(crate) fn inverse(&self) -> EditTransaction {
+    pub fn inverse(&self) -> EditTransaction {
         let action_group = ActionGroup::new(
             self.action_group
                 .actions
@@ -296,19 +296,19 @@ impl EditTransaction {
         }
     }
 
-    pub(crate) fn unnormalized_edits(&self) -> Vec<Edit> {
+    pub fn unnormalized_edits(&self) -> Vec<Edit> {
         self.unnormalized_edits.clone()
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 /// This is for grouping actions that should not offset each other
-pub(crate) struct ActionGroup {
-    pub(crate) actions: Vec<Action>,
+pub struct ActionGroup {
+    pub actions: Vec<Action>,
 }
 
 impl ActionGroup {
-    pub(crate) fn new(actions: Vec<Action>) -> Self {
+    pub fn new(actions: Vec<Action>) -> Self {
         Self { actions }
     }
     fn get_net_offset(&self) -> isize {

--- a/src/embed/app.rs
+++ b/src/embed/app.rs
@@ -22,18 +22,17 @@ use super::logger::HostLogger;
 use super::utils::*;
 use crate::embed::handlers;
 
-pub(crate) struct EmbeddedApp {
-    pub(crate) app: Rc<Mutex<App<Crossterm>>>,
-    pub(crate) app_sender: mpsc::Sender<AppMessage>,
-    pub(crate) integration_event_receiver:
-        mpsc::Receiver<crate::integration_event::IntegrationEvent>,
-    pub(crate) app_message_receiver: mpsc::Receiver<AppMessage>,
-    pub(crate) ipc_handler: WebSocketIpc,
-    pub(crate) context: Context,
+pub struct EmbeddedApp {
+    pub app: Rc<Mutex<App<Crossterm>>>,
+    pub app_sender: mpsc::Sender<AppMessage>,
+    pub integration_event_receiver: mpsc::Receiver<crate::integration_event::IntegrationEvent>,
+    pub app_message_receiver: mpsc::Receiver<AppMessage>,
+    pub ipc_handler: WebSocketIpc,
+    pub context: Context,
 }
 
 impl EmbeddedApp {
-    pub(crate) fn new(working_directory: Option<CanonicalizedPath>) -> Result<Self> {
+    pub fn new(working_directory: Option<CanonicalizedPath>) -> Result<Self> {
         let log_level = if std::env::var("KI_DEBUG").is_ok() {
             log::LevelFilter::Debug
         } else {
@@ -83,13 +82,13 @@ impl EmbeddedApp {
         })
     }
 
-    pub(crate) fn send_message_to_host(&self, message: OutputMessageWrapper) -> Result<()> {
+    pub fn send_message_to_host(&self, message: OutputMessageWrapper) -> Result<()> {
         self.ipc_handler
             .send_message_to_host(message)
             .map_err(|e| anyhow::anyhow!("Failed to send message to IPC handler: {}", e))
     }
 
-    pub(crate) fn send_notification(&self, wrapper: OutputMessageWrapper) -> Result<()> {
+    pub fn send_notification(&self, wrapper: OutputMessageWrapper) -> Result<()> {
         let notification_type = format!("{:?}", wrapper.message);
         trace!(
             "SENDING Notification: Type={:?}, ID={}",
@@ -143,7 +142,7 @@ impl EmbeddedApp {
         result
     }
 
-    pub(crate) fn run(&mut self) -> Result<()> {
+    pub fn run(&mut self) -> Result<()> {
         trace!("Starting Host main loop");
 
         loop {
@@ -236,7 +235,7 @@ impl EmbeddedApp {
         Ok(())
     }
 
-    pub(crate) fn get_editor_component_by_path(
+    pub fn get_editor_component_by_path(
         &self,
         path: &CanonicalizedPath,
     ) -> Option<std::rc::Rc<std::cell::RefCell<dyn crate::components::component::Component>>> {
@@ -262,7 +261,7 @@ impl EmbeddedApp {
         None
     }
 
-    pub(crate) fn send_response(&self, id: u32, message: OutputMessage) -> Result<()> {
+    pub fn send_response(&self, id: u32, message: OutputMessage) -> Result<()> {
         info!("Sending response for request ID {id}: {message:?}");
         let wrapper = OutputMessageWrapper {
             id,
@@ -272,7 +271,7 @@ impl EmbeddedApp {
         self.send_message_to_host(wrapper)
     }
 
-    pub(crate) fn send_error_response(&self, id: u32, error_message: &str) -> Result<()> {
+    pub fn send_error_response(&self, id: u32, error_message: &str) -> Result<()> {
         let error_response = OutputMessageWrapper {
             id,
             message: OutputMessage::Error(error_message.to_string()),
@@ -808,7 +807,7 @@ impl EmbeddedApp {
     }
 }
 
-pub(crate) fn run_embedded_ki(working_directory: CanonicalizedPath) -> anyhow::Result<()> {
+pub fn run_embedded_ki(working_directory: CanonicalizedPath) -> anyhow::Result<()> {
     eprintln!("== Ki running as embedded app ==");
 
     let mut embedded_app = EmbeddedApp::new(Some(working_directory))?;

--- a/src/embed/handlers/buffer.rs
+++ b/src/embed/handlers/buffer.rs
@@ -18,7 +18,7 @@ use ropey::Rope;
 
 impl EmbeddedApp {
     /// Handle buffer open request from Host
-    pub(crate) fn handle_buffer_open_request(&mut self, params: BufferOpenParams) -> Result<()> {
+    pub fn handle_buffer_open_request(&mut self, params: BufferOpenParams) -> Result<()> {
         let BufferOpenParams {
             uri,
             content,
@@ -53,7 +53,7 @@ impl EmbeddedApp {
     }
 
     /// Handle buffer active request from Host
-    pub(crate) fn handle_buffer_active_request(&mut self, params: BufferParams) -> Result<()> {
+    pub fn handle_buffer_active_request(&mut self, params: BufferParams) -> Result<()> {
         let path = uri_to_path(&params.uri)?;
         self.app
             .lock()
@@ -68,10 +68,7 @@ impl EmbeddedApp {
     }
 
     /// Handle buffer change request from Host
-    pub(crate) fn handle_buffer_change_request(
-        &mut self,
-        params: BufferDiffParams,
-    ) -> anyhow::Result<()> {
+    pub fn handle_buffer_change_request(&mut self, params: BufferDiffParams) -> anyhow::Result<()> {
         let BufferDiffParams { buffer_id, edits } = params;
 
         let path = uri_to_path(&buffer_id)?;
@@ -126,7 +123,7 @@ impl EmbeddedApp {
         Ok(())
     }
 
-    pub(crate) fn handle_sync_buffer_response(
+    pub fn handle_sync_buffer_response(
         &self,
         params: SyncBufferResponseParams,
     ) -> std::result::Result<(), anyhow::Error> {

--- a/src/embed/handlers/keyboard.rs
+++ b/src/embed/handlers/keyboard.rs
@@ -58,7 +58,7 @@ impl EmbeddedApp {
     }
 
     /// Handle keyboard.input request
-    pub(crate) fn handle_keyboard_input_request(
+    pub fn handle_keyboard_input_request(
         &self,
         id: u32,
         params: ki_protocol_types::KeyboardParams,

--- a/src/embed/handlers/mod.rs
+++ b/src/embed/handlers/mod.rs
@@ -3,18 +3,18 @@
 //! This module contains handlers for various Host IPC messages, including
 //! requests, notifications, and responses.
 
-pub(crate) mod buffer;
-pub(crate) mod keyboard;
-pub(crate) mod ping;
-pub(crate) mod selection;
-pub(crate) mod viewport;
+pub mod buffer;
+pub mod keyboard;
+pub mod ping;
+pub mod selection;
+pub mod viewport;
 
 /// Common imports and types for handlers
-pub(crate) mod prelude {
+pub mod prelude {
     pub use anyhow::Result;
     pub use log::{error, info};
 
     // Use these types internally within the handlers module
-    pub(crate) use crate::embed::utils::*;
-    pub(crate) use crate::position::Position;
+    pub use crate::embed::utils::*;
+    pub use crate::position::Position;
 }

--- a/src/embed/handlers/ping.rs
+++ b/src/embed/handlers/ping.rs
@@ -4,7 +4,7 @@ use ki_protocol_types::OutputMessage;
 
 /// Handle ping requests from Host
 ///
-pub(crate) fn handle_ping_request(app: &mut EmbeddedApp, id: u32, value: String) -> Result<()> {
+pub fn handle_ping_request(app: &mut EmbeddedApp, id: u32, value: String) -> Result<()> {
     info!("Received ping: {value}");
     let response_message = format!("pong: {value}");
     app.send_response(id, OutputMessage::Ping(response_message))

--- a/src/embed/handlers/selection.rs
+++ b/src/embed/handlers/selection.rs
@@ -4,10 +4,7 @@ use ki_protocol_types::SelectionSetParams;
 
 impl EmbeddedApp {
     /// Handle selection.set notification from Host
-    pub(crate) fn handle_selection_set_notification(
-        &mut self,
-        params: SelectionSetParams,
-    ) -> Result<()> {
+    pub fn handle_selection_set_notification(&mut self, params: SelectionSetParams) -> Result<()> {
         let Some(uri) = params.uri else {
             log::info!("EmbeddedApp::handle_selection_set_notification: params.uri is None");
             return Ok(());
@@ -81,15 +78,12 @@ impl EmbeddedApp {
         Ok(())
     }
 
-    pub(crate) fn handle_selection_set_request(
-        &mut self,
-        params: SelectionSetParams,
-    ) -> Result<()> {
+    pub fn handle_selection_set_request(&mut self, params: SelectionSetParams) -> Result<()> {
         self.handle_selection_set_notification(params)
     }
 }
 
-pub(crate) fn to_ki_position(position: &ki_protocol_types::Position) -> Position {
+pub fn to_ki_position(position: &ki_protocol_types::Position) -> Position {
     Position {
         line: position.line as usize,
         column: position.character as usize,

--- a/src/embed/handlers/viewport.rs
+++ b/src/embed/handlers/viewport.rs
@@ -5,7 +5,7 @@ use ki_protocol_types::ViewportParams;
 
 impl EmbeddedApp {
     /// Handle viewport change request from Host
-    pub(crate) fn handle_viewport_change_request(&mut self, params: ViewportParams) -> Result<()> {
+    pub fn handle_viewport_change_request(&mut self, params: ViewportParams) -> Result<()> {
         let component = self.app.lock().unwrap().current_component();
         let mut component_ref = component.borrow_mut();
         let editor = component_ref.editor_mut();

--- a/src/embed/ipc.rs
+++ b/src/embed/ipc.rs
@@ -13,7 +13,7 @@ use tungstenite::{
 use uuid::Uuid;
 
 #[derive(Debug, Error)]
-pub(crate) enum IpcError {
+pub enum IpcError {
     #[error("Network IO error: {0}")]
     Network(#[from] std::io::Error),
 
@@ -34,7 +34,7 @@ pub(crate) enum IpcError {
 type WsStream = WebSocket<TcpStream>;
 
 /// Manages the WebSocket IPC communication with the Host extension.
-pub(crate) struct WebSocketIpc {
+pub struct WebSocketIpc {
     to_host_sender: Sender<OutputMessageWrapper>, // Sends messages *to* the WebSocket thread
     from_host_receiver: Receiver<(u32, InputMessage, String)>, // Receives messages *from* the WebSocket thread
     // JoinHandle is stored to ensure the thread is properly waited for on drop
@@ -45,7 +45,7 @@ impl WebSocketIpc {
     /// Sets up WebSocket IPC.
     /// Binds a TCP listener, prints the port, and spawns a handler thread.
     #[allow(clippy::result_large_err)]
-    pub(crate) fn new() -> Result<(Self, u16), IpcError> {
+    pub fn new() -> Result<(Self, u16), IpcError> {
         info!("Setting up Host WebSocket IPC...");
 
         let listener = TcpListener::bind("127.0.0.1:0")?;
@@ -228,10 +228,7 @@ impl WebSocketIpc {
 
     /// Sends a message to the Host extension via the handler thread.
     #[allow(clippy::result_large_err)]
-    pub(crate) fn send_message_to_host(
-        &self,
-        message: OutputMessageWrapper,
-    ) -> Result<(), IpcError> {
+    pub fn send_message_to_host(&self, message: OutputMessageWrapper) -> Result<(), IpcError> {
         let id = message.id;
         let message_type = format!("{:?}", message.message);
 
@@ -253,9 +250,7 @@ impl WebSocketIpc {
 
     /// Receives a message from the Host extension via the handler thread.
     /// This is non-blocking.
-    pub(crate) fn try_receive_from_host(
-        &self,
-    ) -> Result<(u32, InputMessage, String), TryRecvError> {
+    pub fn try_receive_from_host(&self) -> Result<(u32, InputMessage, String), TryRecvError> {
         self.from_host_receiver.try_recv()
     }
 }

--- a/src/embed/logger.rs
+++ b/src/embed/logger.rs
@@ -2,12 +2,12 @@ use log::{LevelFilter, Log, Metadata, Record};
 use std::io::{self, Write};
 
 /// Forwards log messages to host app
-pub(crate) struct HostLogger {
+pub struct HostLogger {
     min_level: LevelFilter,
 }
 
 impl HostLogger {
-    pub(crate) fn new(min_level: LevelFilter) -> Self {
+    pub fn new(min_level: LevelFilter) -> Self {
         Self { min_level }
     }
 }

--- a/src/embed/mod.rs
+++ b/src/embed/mod.rs
@@ -4,10 +4,10 @@
 //! It handles communication with the Host extension host process, and provides
 //! functionality for converting between Ki and Host data structures.
 
-pub(crate) mod app;
-pub(crate) mod handlers;
-pub(crate) mod ipc;
-pub(crate) mod logger;
-pub(crate) mod utils;
+pub mod app;
+pub mod handlers;
+pub mod ipc;
+pub mod logger;
+pub mod utils;
 
-pub(crate) use app::EmbeddedApp;
+pub use app::EmbeddedApp;

--- a/src/embed/utils.rs
+++ b/src/embed/utils.rs
@@ -4,7 +4,7 @@ use shared::canonicalized_path::CanonicalizedPath;
 use url::Url;
 
 // Convert Host protocol position to Ki editor position
-pub(crate) fn host_position_to_ki_position(pos: &HostPosition) -> KiPosition {
+pub fn host_position_to_ki_position(pos: &HostPosition) -> KiPosition {
     KiPosition {
         line: pos.line as usize,
         column: pos.character as usize,
@@ -12,14 +12,14 @@ pub(crate) fn host_position_to_ki_position(pos: &HostPosition) -> KiPosition {
 }
 
 // Convert a CanonicalizedPath to a file URI string
-pub(crate) fn path_to_uri(path: &CanonicalizedPath) -> String {
+pub fn path_to_uri(path: &CanonicalizedPath) -> String {
     Url::from_file_path(path.as_ref())
         .map(|url| url.to_string())
         .unwrap_or_else(|_| path.display_absolute()) // Fallback to absolute path if URL conversion fails
 }
 
 // Convert a file URI string back to a CanonicalizedPath
-pub(crate) fn uri_to_path(uri: &str) -> anyhow::Result<CanonicalizedPath> {
+pub fn uri_to_path(uri: &str) -> anyhow::Result<CanonicalizedPath> {
     // First, check if the URI is already in the form of a CanonicalizedPath string
     if let Some(path_str) = extract_canonicalized_path(uri) {
         return path_str.try_into().map_err(|e| {

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,4 +1,4 @@
-pub(crate) fn parse_env<T: Clone>(
+pub fn parse_env<T: Clone>(
     env_name: &'static str,
     choices: &[T],
     to_string: fn(&T) -> &str,

--- a/src/file_watcher/mod.rs
+++ b/src/file_watcher/mod.rs
@@ -19,14 +19,14 @@ use crate::{
 };
 
 #[derive(Debug)]
-pub(crate) enum FileWatcherInput {
+pub enum FileWatcherInput {
     SyncOpenedPaths(Vec<CanonicalizedPath>),
     FileWatcherEvent(FileWatcherEvent),
     SyncFileExplorerExpandedFolders(Vec<CanonicalizedPath>),
 }
 
 #[derive(Default)]
-pub(crate) struct FileWatcherState {
+pub struct FileWatcherState {
     opened_paths: Vec<CanonicalizedPath>,
     expanded_folders: Vec<CanonicalizedPath>,
 }
@@ -60,7 +60,7 @@ impl FileWatcherState {
     }
 }
 
-pub(crate) fn watch_file_changes(
+pub fn watch_file_changes(
     path: &CanonicalizedPath,
     app_message_sender: Sender<AppMessage>,
 ) -> anyhow::Result<Sender<FileWatcherInput>> {
@@ -178,7 +178,7 @@ impl EventHandler {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) enum FileWatcherEvent {
+pub enum FileWatcherEvent {
     ContentModified(CanonicalizedPath),
     /// We don't attached the Path so that all PathCreated event can be grouped together
     /// by the debouncer, since we don't really care what files are added.

--- a/src/format_path_list.rs
+++ b/src/format_path_list.rs
@@ -17,7 +17,7 @@ fn format_path_list(
     formatted_paths.join("")
 }
 
-pub(crate) fn get_formatted_paths(
+pub fn get_formatted_paths(
     paths: &[&CanonicalizedPath],
     current_path: &CanonicalizedPath,
     current_working_directory: &CanonicalizedPath,

--- a/src/frontend/crossterm.rs
+++ b/src/frontend/crossterm.rs
@@ -3,7 +3,7 @@ use std::io::{self};
 
 use super::{Frontend, MyWriter};
 
-pub(crate) struct Crossterm {
+pub struct Crossterm {
     stdout: Box<dyn MyWriter>,
     /// Used for diffing to reduce unnecessary re-painting.
     previous_screen: Screen,
@@ -17,7 +17,7 @@ impl MyWriter for std::io::Stdout {
 }
 
 impl Crossterm {
-    pub(crate) fn new() -> anyhow::Result<Crossterm> {
+    pub fn new() -> anyhow::Result<Crossterm> {
         Ok(Crossterm {
             stdout: Box::new(io::stdout()),
             previous_screen: Screen::default(),

--- a/src/frontend/mock.rs
+++ b/src/frontend/mock.rs
@@ -4,7 +4,7 @@ use crate::{components::component::Cursor, screen::Screen};
 
 use super::{MyWriter, StringWriter};
 
-pub(crate) struct MockFrontend {
+pub struct MockFrontend {
     /// Used for diffing to reduce unnecessary re-painting.
     previous_screen: Screen,
     writer: Box<dyn MyWriter>,
@@ -18,7 +18,7 @@ const DIMENSION: crate::app::Dimension = crate::app::Dimension {
 };
 
 impl MockFrontend {
-    pub(crate) fn new(writer: Box<dyn MyWriter>) -> Self {
+    pub fn new(writer: Box<dyn MyWriter>) -> Self {
         Self {
             previous_screen: Default::default(),
             writer,
@@ -82,7 +82,7 @@ impl super::Frontend for MockFrontend {
 
 #[cfg(test)]
 impl MockFrontend {
-    pub(crate) fn string_content(&self) -> Option<String> {
+    pub fn string_content(&self) -> Option<String> {
         self.writer
             .as_any()
             .downcast_ref::<StringWriter>()

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -1,6 +1,6 @@
-pub(crate) mod crossterm;
+pub mod crossterm;
 #[cfg(test)]
-pub(crate) mod mock;
+pub mod mock;
 
 use std::any::Any;
 use std::io::Write;
@@ -18,7 +18,7 @@ use ::crossterm::{
 };
 use itertools::Itertools;
 
-pub(crate) trait Frontend {
+pub trait Frontend {
     fn get_terminal_dimension(&self) -> anyhow::Result<Dimension>;
     fn enter_alternate_screen(&mut self) -> anyhow::Result<()>;
     fn enable_mouse_capture(&mut self) -> anyhow::Result<()>;
@@ -99,7 +99,7 @@ fn reveal(s: char) -> char {
     }
 }
 
-pub(crate) trait MyWriter: Write + Any {
+pub trait MyWriter: Write + Any {
     #[cfg(test)]
     fn as_any(&self) -> &dyn Any;
 }
@@ -119,17 +119,18 @@ impl MyWriter for NullWriter {
 }
 
 #[cfg(test)]
-pub(crate) struct StringWriter {
+#[derive(Default)]
+pub struct StringWriter {
     buffer: Vec<u8>,
 }
 
 #[cfg(test)]
 impl StringWriter {
-    pub(crate) fn new() -> Self {
-        StringWriter { buffer: Vec::new() }
+    pub fn new() -> Self {
+        Self::default()
     }
 
-    pub(crate) fn get_string(&self) -> String {
+    pub fn get_string(&self) -> String {
         String::from_utf8(self.buffer.clone()).unwrap_or_default()
     }
 }
@@ -147,7 +148,7 @@ impl Write for StringWriter {
 }
 
 #[cfg(test)]
-pub(crate) struct NullWriter;
+pub struct NullWriter;
 
 #[cfg(test)]
 impl Write for NullWriter {

--- a/src/generate_recipes.rs
+++ b/src/generate_recipes.rs
@@ -139,43 +139,43 @@ fn doc_assets_generate_recipes() -> anyhow::Result<()> {
 }
 
 #[derive(Clone)]
-pub(crate) struct RecipeGroup {
-    pub(crate) filename: &'static str,
-    pub(crate) recipes: Vec<Recipe>,
+pub struct RecipeGroup {
+    pub filename: &'static str,
+    pub recipes: Vec<Recipe>,
 }
 
 #[derive(Clone)]
-pub(crate) struct Recipe {
-    pub(crate) description: &'static str,
-    pub(crate) content: &'static str,
-    pub(crate) file_extension: &'static str,
-    pub(crate) prepare_events: &'static [event::KeyEvent],
-    pub(crate) events: &'static [event::KeyEvent],
-    pub(crate) expectations: Box<[ExpectKind]>,
-    pub(crate) terminal_height: Option<usize>,
-    pub(crate) similar_vim_combos: &'static [&'static str],
-    pub(crate) only: bool,
+pub struct Recipe {
+    pub description: &'static str,
+    pub content: &'static str,
+    pub file_extension: &'static str,
+    pub prepare_events: &'static [event::KeyEvent],
+    pub events: &'static [event::KeyEvent],
+    pub expectations: Box<[ExpectKind]>,
+    pub terminal_height: Option<usize>,
+    pub similar_vim_combos: &'static [&'static str],
+    pub only: bool,
 }
 #[derive(serde::Serialize)]
-pub(crate) struct StepOutput {
-    pub(crate) key: String,
-    pub(crate) description: String,
-    pub(crate) term_output: String,
-    pub(crate) buffer_contents_map: HashMap<String, String>,
-}
-
-#[derive(serde::Serialize)]
-pub(crate) struct RecipeOutput {
-    pub(crate) description: String,
-    pub(crate) steps: Vec<StepOutput>,
-    pub(crate) terminal_height: usize,
-    pub(crate) terminal_width: usize,
-    pub(crate) similar_vim_combos: &'static [&'static str],
+pub struct StepOutput {
+    pub key: String,
+    pub description: String,
+    pub term_output: String,
+    pub buffer_contents_map: HashMap<String, String>,
 }
 
 #[derive(serde::Serialize)]
-pub(crate) struct RecipesOutput {
-    pub(crate) recipes_output: Vec<RecipeOutput>,
+pub struct RecipeOutput {
+    pub description: String,
+    pub steps: Vec<StepOutput>,
+    pub terminal_height: usize,
+    pub terminal_width: usize,
+    pub similar_vim_combos: &'static [&'static str],
+}
+
+#[derive(serde::Serialize)]
+pub struct RecipesOutput {
+    pub recipes_output: Vec<RecipeOutput>,
 }
 
 fn create_nested_vectors<T: Clone>(input: &[T]) -> Vec<Vec<T>> {

--- a/src/git/blame.rs
+++ b/src/git/blame.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use git2::{BlameOptions, Repository};
 use shared::canonicalized_path::CanonicalizedPath;
 
-pub(crate) struct GitBlameInfo {
+pub struct GitBlameInfo {
     commit: String,
     author: String,
     date: String,
@@ -12,7 +12,7 @@ pub(crate) struct GitBlameInfo {
 }
 
 impl GitBlameInfo {
-    pub(crate) fn display(&self) -> String {
+    pub fn display(&self) -> String {
         format!(
             "Commit: {}
 Author: {}
@@ -33,7 +33,7 @@ URL: {}
 }
 
 /// `line_index` is 0-based.
-pub(crate) fn blame_line(
+pub fn blame_line(
     repo_path: &CanonicalizedPath,
     file_path: &CanonicalizedPath,
     line_index: usize,

--- a/src/git/hunk.rs
+++ b/src/git/hunk.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 #[derive(Debug, Clone)]
-pub(crate) struct Hunk {
+pub struct Hunk {
     /// 0-based index
     new_line_range: Range<usize>,
 
@@ -25,24 +25,24 @@ pub(crate) struct Hunk {
 /// Simple Hunk is used for Git Gutter,
 /// it is less expensive to compute as it needs less data
 /// than `Hunk`.
-pub(crate) struct SimpleHunk {
+pub struct SimpleHunk {
     /// 0-based index
-    pub(crate) new_line_range: Range<usize>,
-    pub(crate) new_content: String,
-    pub(crate) old_content: String,
+    pub new_line_range: Range<usize>,
+    pub new_content: String,
+    pub old_content: String,
 
-    pub(crate) kind: SimpleHunkKind,
+    pub kind: SimpleHunkKind,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum SimpleHunkKind {
+pub enum SimpleHunkKind {
     Delete,
     Insert,
     Replace,
 }
 
 impl Hunk {
-    pub(crate) fn get_simple_hunks(old: &str, new: &str) -> Vec<SimpleHunk> {
+    pub fn get_simple_hunks(old: &str, new: &str) -> Vec<SimpleHunk> {
         // We use imara_diff instead of `similar` because
         // imara_diff is much more faster, and more suitable
         // for computing git gutter.
@@ -64,7 +64,7 @@ impl Hunk {
             .collect_vec()
     }
 
-    pub(crate) fn get_hunks(old: &str, new: &str) -> Vec<Hunk> {
+    pub fn get_hunks(old: &str, new: &str) -> Vec<Hunk> {
         let simple_hunks = Self::get_simple_hunks(old, new);
         simple_hunks
             .into_iter()
@@ -86,7 +86,7 @@ impl Hunk {
             .collect_vec()
     }
 
-    pub(crate) fn get_detailed_hunk(old: &str, new: &str) -> (String, Vec<Decoration>) {
+    pub fn get_detailed_hunk(old: &str, new: &str) -> (String, Vec<Decoration>) {
         let diff = TextDiff::from_lines(old, new);
 
         #[derive(PartialEq)]
@@ -155,11 +155,11 @@ impl Hunk {
         (content, decorations)
     }
 
-    pub(crate) fn line_range(&self) -> &Range<usize> {
+    pub fn line_range(&self) -> &Range<usize> {
         &self.new_line_range
     }
 
-    pub(crate) fn one_insert(message: &str) -> Hunk {
+    pub fn one_insert(message: &str) -> Hunk {
         Hunk {
             new_line_range: 0..0,
             content: message.to_string(),
@@ -167,7 +167,7 @@ impl Hunk {
         }
     }
 
-    pub(crate) fn to_info(&self) -> Option<crate::components::suggestive_editor::Info> {
+    pub fn to_info(&self) -> Option<crate::components::suggestive_editor::Info> {
         let info = Info::new("Git Hunk Diff".to_string(), self.content.clone())
             .set_decorations(self.decorations.clone());
         Some(info)

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -1,5 +1,5 @@
-pub(crate) mod blame;
-pub(crate) mod hunk;
+pub mod blame;
+pub mod hunk;
 
 use anyhow::bail;
 use rayon::prelude::*;
@@ -13,7 +13,7 @@ use crate::git::hunk::SimpleHunk;
 
 use self::hunk::Hunk;
 
-pub(crate) struct GitRepo {
+pub struct GitRepo {
     repo: Repository,
     path: CanonicalizedPath,
 }
@@ -33,7 +33,7 @@ impl TryFrom<&CanonicalizedPath> for GitRepo {
 }
 
 impl GitRepo {
-    pub(crate) fn diffs(&self, diff_mode: DiffMode) -> anyhow::Result<Vec<FileDiff>> {
+    pub fn diffs(&self, diff_mode: DiffMode) -> anyhow::Result<Vec<FileDiff>> {
         Ok(self
             .diff_entries(diff_mode)?
             .into_iter()
@@ -46,7 +46,7 @@ impl GitRepo {
         &self.path
     }
 
-    pub(crate) fn diff_entries(&self, diff_mode: DiffMode) -> anyhow::Result<Vec<DiffEntry>> {
+    pub fn diff_entries(&self, diff_mode: DiffMode) -> anyhow::Result<Vec<DiffEntry>> {
         // Open the repository
         let repo = &self.repo;
 
@@ -132,16 +132,16 @@ impl GitRepo {
     }
 }
 
-pub(crate) struct FileDiff {
+pub struct FileDiff {
     path: CanonicalizedPath,
     hunks: Vec<Hunk>,
 }
 impl FileDiff {
-    pub(crate) fn hunks(&self) -> &Vec<Hunk> {
+    pub fn hunks(&self) -> &Vec<Hunk> {
         &self.hunks
     }
 
-    pub(crate) fn path(&self) -> &CanonicalizedPath {
+    pub fn path(&self) -> &CanonicalizedPath {
         &self.path
     }
 }
@@ -226,7 +226,7 @@ use git2::DiffOptions;
 use std::str;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct DiffEntry {
+pub struct DiffEntry {
     new_path: CanonicalizedPath,
     old_content: Option<String>,
     new_content: String,
@@ -248,19 +248,19 @@ impl DiffEntry {
         }
     }
 
-    pub(crate) fn new_path(&self) -> CanonicalizedPath {
+    pub fn new_path(&self) -> CanonicalizedPath {
         self.new_path.clone()
     }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum DiffMode {
+pub enum DiffMode {
     UnstagedAgainstMainBranch,
     UnstagedAgainstCurrentBranch,
 }
 
 impl DiffMode {
-    pub(crate) fn display(&self) -> String {
+    pub fn display(&self) -> String {
         match self {
             DiffMode::UnstagedAgainstMainBranch => "^".to_string(),
             DiffMode::UnstagedAgainstCurrentBranch => "@".to_string(),

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -15,44 +15,44 @@ use strum::IntoEnumIterator;
 use unicode_width::UnicodeWidthChar;
 
 #[derive(Clone, Debug, PartialEq)]
-pub(crate) struct Grid {
-    pub(crate) rows: Vec<Vec<Cell>>,
-    pub(crate) width: usize,
+pub struct Grid {
+    pub rows: Vec<Vec<Cell>>,
+    pub width: usize,
 }
 
 const DEFAULT_TAB_SIZE: usize = 4;
-pub(crate) const LINE_NUMBER_VERTICAL_BORDER: &str = "│";
+pub const LINE_NUMBER_VERTICAL_BORDER: &str = "│";
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
-pub(crate) struct Cell {
-    pub(crate) symbol: char,
-    pub(crate) foreground_color: Color,
-    pub(crate) background_color: Color,
-    pub(crate) line: Option<CellLine>,
-    pub(crate) is_cursor: bool,
+pub struct Cell {
+    pub symbol: char,
+    pub foreground_color: Color,
+    pub background_color: Color,
+    pub line: Option<CellLine>,
+    pub is_cursor: bool,
     /// Need for folded sections where the cursor is not in them
-    pub(crate) is_protected_range_start: bool,
+    pub is_protected_range_start: bool,
     /// For debugging purposes, so that we can trace this Cell is updated by which
     /// decoration, e.g. Diagnostic
-    pub(crate) source: Option<StyleKey>,
-    pub(crate) is_bold: bool,
+    pub source: Option<StyleKey>,
+    pub is_bold: bool,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, Copy, PartialOrd, Ord)]
-pub(crate) struct CellLine {
-    pub(crate) color: Color,
-    pub(crate) style: CellLineStyle,
+pub struct CellLine {
+    pub color: Color,
+    pub style: CellLineStyle,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, Copy, PartialOrd, Ord)]
-pub(crate) enum CellLineStyle {
+pub enum CellLineStyle {
     Undercurl,
     Underline,
 }
 
 impl Cell {
     #[cfg(test)]
-    pub(crate) fn from_char(c: char) -> Self {
+    pub fn from_char(c: char) -> Self {
         Cell {
             symbol: c,
             ..Default::default()
@@ -96,19 +96,19 @@ impl Default for Cell {
 }
 
 #[derive(Clone, Debug, Default)]
-pub(crate) struct CellUpdate {
-    pub(crate) position: Position,
-    pub(crate) symbol: Option<char>,
-    pub(crate) style: Style,
-    pub(crate) is_cursor: bool,
+pub struct CellUpdate {
+    pub position: Position,
+    pub symbol: Option<char>,
+    pub style: Style,
+    pub is_cursor: bool,
 
     /// For debugging purposes
-    pub(crate) source: Option<StyleKey>,
-    pub(crate) is_protected_range_start: bool,
+    pub source: Option<StyleKey>,
+    pub is_protected_range_start: bool,
 }
 
 impl CellUpdate {
-    pub(crate) fn new(position: Position) -> Self {
+    pub fn new(position: Position) -> Self {
         CellUpdate {
             position,
             symbol: None,
@@ -119,11 +119,11 @@ impl CellUpdate {
         }
     }
 
-    pub(crate) fn set_is_cursor(self, is_cursor: bool) -> CellUpdate {
+    pub fn set_is_cursor(self, is_cursor: bool) -> CellUpdate {
         CellUpdate { is_cursor, ..self }
     }
 
-    pub(crate) fn set_position_line(self, line: usize) -> CellUpdate {
+    pub fn set_position_line(self, line: usize) -> CellUpdate {
         CellUpdate {
             position: self.position.set_line(line),
             ..self
@@ -131,11 +131,11 @@ impl CellUpdate {
     }
 
     #[cfg(test)]
-    pub(crate) fn set_symbol(self, symbol: Option<char>) -> CellUpdate {
+    pub fn set_symbol(self, symbol: Option<char>) -> CellUpdate {
         CellUpdate { symbol, ..self }
     }
 
-    pub(crate) fn set_is_protected_range_start(self, is_protected_range_start: bool) -> Self {
+    pub fn set_is_protected_range_start(self, is_protected_range_start: bool) -> Self {
         CellUpdate {
             is_protected_range_start,
             ..self
@@ -148,9 +148,9 @@ impl CellUpdate {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Default, Hash)]
-pub(crate) struct PositionedCell {
-    pub(crate) cell: Cell,
-    pub(crate) position: Position,
+pub struct PositionedCell {
+    pub cell: Cell,
+    pub position: Position,
 }
 
 impl PartialOrd for PositionedCell {
@@ -184,7 +184,7 @@ impl std::fmt::Display for Grid {
     }
 }
 
-pub(crate) enum RenderContentLineNumber {
+pub enum RenderContentLineNumber {
     NoLineNumber,
     LineNumber {
         /// 0-based
@@ -194,7 +194,7 @@ pub(crate) enum RenderContentLineNumber {
 }
 
 impl Grid {
-    pub(crate) fn new(dimension: Dimension) -> Grid {
+    pub fn new(dimension: Dimension) -> Grid {
         let mut cells: Vec<Vec<Cell>> = vec![];
         cells.resize_with(dimension.height, || {
             let mut cells = vec![];
@@ -207,7 +207,7 @@ impl Grid {
         }
     }
 
-    pub(crate) fn to_positioned_cells(&self) -> Vec<PositionedCell> {
+    pub fn to_positioned_cells(&self) -> Vec<PositionedCell> {
         self.rows
             .iter()
             .enumerate()
@@ -225,7 +225,7 @@ impl Grid {
     }
 
     #[cfg(test)]
-    pub(crate) fn from_text(dimension: Dimension, text: &str) -> Grid {
+    pub fn from_text(dimension: Dimension, text: &str) -> Grid {
         Grid::from_rope(dimension, &Rope::from_str(text))
     }
 
@@ -247,14 +247,14 @@ impl Grid {
         grid
     }
 
-    pub(crate) fn dimension(&self) -> Dimension {
+    pub fn dimension(&self) -> Dimension {
         Dimension {
             height: self.rows.len(),
             width: self.width,
         }
     }
 
-    pub(crate) fn apply_cell_update(mut self, update: CellUpdate) -> Grid {
+    pub fn apply_cell_update(mut self, update: CellUpdate) -> Grid {
         let Position { line, column } = update.position;
         if line < self.rows.len() && column < self.rows[line].len() {
             self.rows[line][column] = self.rows[line][column].apply_update(update);
@@ -262,19 +262,19 @@ impl Grid {
         self
     }
 
-    pub(crate) fn apply_cell_updates(self, updates: Vec<CellUpdate>) -> Grid {
+    pub fn apply_cell_updates(self, updates: Vec<CellUpdate>) -> Grid {
         updates
             .into_iter()
             .fold(self, |grid, update| grid.apply_cell_update(update))
     }
 
-    pub(crate) fn merge_vertical(self, bottom: Grid) -> Grid {
+    pub fn merge_vertical(self, bottom: Grid) -> Grid {
         let mut top = self;
         top.rows.extend(bottom.rows);
         top
     }
 
-    pub(crate) fn clamp_bottom(self, by: usize) -> Grid {
+    pub fn clamp_bottom(self, by: usize) -> Grid {
         let mut grid = self;
         let dimension = grid.dimension();
         let height = dimension.height.saturating_sub(by);
@@ -285,7 +285,7 @@ impl Grid {
         grid
     }
 
-    pub(crate) fn get_cursor_position(&self) -> Option<Position> {
+    pub fn get_cursor_position(&self) -> Option<Position> {
         self.to_positioned_cells().into_iter().find_map(|cell| {
             if cell.cell.is_cursor {
                 Some(cell.position)
@@ -295,7 +295,7 @@ impl Grid {
         })
     }
 
-    pub(crate) fn get_row_cell_updates(
+    pub fn get_row_cell_updates(
         &self,
         row_index: usize,
         column_start: Option<usize>,
@@ -337,7 +337,7 @@ impl Grid {
     /// - `line_index_start` is 0-based.
     /// - If `max_line_number` is
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn render_content(
+    pub fn render_content(
         self,
         content: &str,
         line_number: RenderContentLineNumber,
@@ -557,7 +557,7 @@ impl Grid {
                     if let Ok(calibrated_position) =
                         wrapped_lines.calibrate(update.cell_update.position)
                     {
-                        Box::new(calibrated_position.into_iter().enumerate().map(
+                        Box::new(calibrated_position.into_inner().enumerate().map(
                             move |(index, position)| CellUpdate {
                                 position:
                                     position.move_right(
@@ -631,7 +631,7 @@ impl Grid {
         self
     }
 
-    pub(crate) fn get_protected_range_start_position(&self) -> Option<Position> {
+    pub fn get_protected_range_start_position(&self) -> Option<Position> {
         self.to_positioned_cells().into_iter().find_map(|cell| {
             if cell.cell.is_protected_range_start {
                 Some(cell.position)
@@ -641,7 +641,7 @@ impl Grid {
         })
     }
 
-    pub(crate) fn height(&self) -> usize {
+    pub fn height(&self) -> usize {
         self.rows.len()
     }
 }
@@ -653,27 +653,27 @@ impl Grid {
 /// there are over 50,000 highlight spans,
 /// and copying the style key as strings are very expensive.
 #[derive(Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord)]
-pub(crate) struct IndexedHighlightGroup(usize);
+pub struct IndexedHighlightGroup(usize);
 impl IndexedHighlightGroup {
-    pub(crate) fn new(index: usize) -> Self {
+    pub fn new(index: usize) -> Self {
         Self(index)
     }
 
     #[cfg(test)]
-    pub(crate) fn from_str(name: &str) -> Option<Self> {
+    pub fn from_str(name: &str) -> Option<Self> {
         crate::themes::highlight_names()
             .iter()
             .position(|highlight_name| highlight_name == &name)
             .map(Self)
     }
 
-    pub(crate) fn to_highlight_name(&self) -> Option<crate::themes::HighlightName> {
+    pub fn to_highlight_name(&self) -> Option<crate::themes::HighlightName> {
         HighlightName::iter().nth(self.0)
     }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord)]
-pub(crate) enum StyleKey {
+pub enum StyleKey {
     Syntax(IndexedHighlightGroup),
     UiPrimarySelection,
 
@@ -705,7 +705,7 @@ pub(crate) enum StyleKey {
 
 impl StyleKey {
     #[cfg(test)]
-    pub(crate) fn display(&self) -> String {
+    pub fn display(&self) -> String {
         match self {
             StyleKey::Syntax(highlight_group) => {
                 let str: &'static str = highlight_group.to_highlight_name().unwrap().into();
@@ -717,11 +717,11 @@ impl StyleKey {
 }
 
 /// TODO: in the future, tab size should be configurable
-pub(crate) fn get_string_width(str: &str) -> usize {
+pub fn get_string_width(str: &str) -> usize {
     str.chars().map(get_char_width).sum()
 }
 
-pub(crate) fn get_char_width(c: char) -> usize {
+pub fn get_char_width(c: char) -> usize {
     match c {
         '\t' => DEFAULT_TAB_SIZE,
         _ => UnicodeWidthChar::width(c).unwrap_or(1),
@@ -729,10 +729,10 @@ pub(crate) fn get_char_width(c: char) -> usize {
 }
 
 #[derive(Clone)]
-pub(crate) struct LineUpdate {
+pub struct LineUpdate {
     /// 0-based
-    pub(crate) line_index: usize,
-    pub(crate) style: Style,
+    pub line_index: usize,
+    pub style: Style,
 }
 
 #[cfg(test)]

--- a/src/history.rs
+++ b/src/history.rs
@@ -1,19 +1,19 @@
 use itertools::Itertools;
 
 #[derive(Clone, Debug)]
-pub(crate) struct History<T: Clone + std::fmt::Debug> {
+pub struct History<T: Clone + std::fmt::Debug> {
     backward_history: Vec<T>,
     forward_history: Vec<T>,
 }
 
 impl<T: Eq + Clone + std::fmt::Debug> History<T> {
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             backward_history: Default::default(),
             forward_history: Default::default(),
         }
     }
-    pub(crate) fn push(&mut self, item: T) {
+    pub fn push(&mut self, item: T) {
         if self.backward_history.last() == Some(&item) {
             return;
         }
@@ -22,7 +22,7 @@ impl<T: Eq + Clone + std::fmt::Debug> History<T> {
         self.forward_history.clear();
     }
 
-    pub(crate) fn undo(&mut self) -> Option<T> {
+    pub fn undo(&mut self) -> Option<T> {
         let item = self.backward_history.pop();
         if let Some(item) = &item {
             self.forward_history.push(item.clone());
@@ -30,7 +30,7 @@ impl<T: Eq + Clone + std::fmt::Debug> History<T> {
         self.backward_history.last().cloned()
     }
 
-    pub(crate) fn redo(&mut self) -> Option<T> {
+    pub fn redo(&mut self) -> Option<T> {
         let item = self.forward_history.pop();
         if let Some(item) = &item {
             self.backward_history.push(item.clone());
@@ -38,7 +38,7 @@ impl<T: Eq + Clone + std::fmt::Debug> History<T> {
         item
     }
 
-    pub(crate) fn apply(mut self, f: impl Fn(T) -> T) -> History<T> {
+    pub fn apply(mut self, f: impl Fn(T) -> T) -> History<T> {
         self.forward_history = std::mem::take(&mut self.forward_history)
             .into_iter()
             .map(&f)

--- a/src/integration_test.rs
+++ b/src/integration_test.rs
@@ -6,7 +6,7 @@ use shared::canonicalized_path::CanonicalizedPath;
 #[cfg(test)]
 use crate::layout::BufferContentsMap;
 
-pub(crate) struct TestRunner {
+pub struct TestRunner {
     temp_dir: CanonicalizedPath,
 }
 
@@ -17,13 +17,13 @@ impl Drop for TestRunner {
 }
 
 #[derive(Debug)]
-pub(crate) struct TestOutput {
-    pub(crate) term_output: Option<String>,
-    pub(crate) buffer_contents_map: BufferContentsMap,
+pub struct TestOutput {
+    pub term_output: Option<String>,
+    pub buffer_contents_map: BufferContentsMap,
 }
 
 impl TestRunner {
-    pub(crate) fn run(
+    pub fn run(
         callback: impl Fn(CanonicalizedPath) -> anyhow::Result<TestOutput>,
     ) -> anyhow::Result<TestOutput> {
         let (runner, _) = Self::new()?;

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -27,13 +27,13 @@ use shared::canonicalized_path::CanonicalizedPath;
 use std::{cell::RefCell, rc::Rc};
 
 #[cfg(test)]
-pub(crate) type BufferContentsMap = std::collections::HashMap<String, String>;
+pub type BufferContentsMap = std::collections::HashMap<String, String>;
 
 /// The layout of the app is split into multiple sections: the main panel, info panel, quickfix
 /// lists, prompts, and etc.
 /// The main panel is where the user edits code, and the info panel is for displaying info like
 /// hover text, diagnostics, etc.
-pub(crate) struct Layout {
+pub struct Layout {
     background_suggestive_editors: IndexMap<CanonicalizedPath, Rc<RefCell<SuggestiveEditor>>>,
     background_file_explorer: Rc<RefCell<FileExplorer>>,
     background_quickfix_list: Option<Rc<RefCell<Editor>>>,
@@ -46,7 +46,7 @@ pub(crate) struct Layout {
 }
 
 impl Layout {
-    pub(crate) fn new(
+    pub fn new(
         terminal_dimension: Dimension,
         working_directory: &CanonicalizedPath,
     ) -> anyhow::Result<Layout> {
@@ -64,31 +64,28 @@ impl Layout {
         })
     }
 
-    pub(crate) fn components(&self) -> Vec<KindedComponent> {
+    pub fn components(&self) -> Vec<KindedComponent> {
         self.tree.components()
     }
 
-    pub(crate) fn get_current_component(&self) -> Rc<RefCell<dyn Component>> {
+    pub fn get_current_component(&self) -> Rc<RefCell<dyn Component>> {
         self.get_component(self.tree.focused_component_id())
     }
 
-    pub(crate) fn get_current_component_kind(&self) -> Option<ComponentKind> {
+    pub fn get_current_component_kind(&self) -> Option<ComponentKind> {
         self.tree
             .get(self.tree.focused_component_id())
             .map(|node| node.data().kind())
     }
 
-    pub(crate) fn get_component(&self, id: NodeId) -> Rc<RefCell<dyn Component>> {
+    pub fn get_component(&self, id: NodeId) -> Rc<RefCell<dyn Component>> {
         self.tree
             .get(id)
             .map(|node| node.data().component())
             .unwrap_or_else(|| self.tree.root().data().component().clone())
     }
 
-    pub(crate) fn remove_current_component(
-        &mut self,
-        context: &Context,
-    ) -> Option<CanonicalizedPath> {
+    pub fn remove_current_component(&mut self, context: &Context) -> Option<CanonicalizedPath> {
         let node = self.tree.get_current_node();
         let removed_path = node.data().component().borrow().path();
         if let Some(path) = &removed_path {
@@ -110,15 +107,15 @@ impl Layout {
         removed_path
     }
 
-    pub(crate) fn cycle_window(&mut self) {
+    pub fn cycle_window(&mut self) {
         self.tree.cycle_component()
     }
 
-    pub(crate) fn close_current_window(&mut self, context: &Context) -> Option<CanonicalizedPath> {
+    pub fn close_current_window(&mut self, context: &Context) -> Option<CanonicalizedPath> {
         self.remove_current_component(context)
     }
 
-    pub(crate) fn add_and_focus_prompt(
+    pub fn add_and_focus_prompt(
         &mut self,
         kind: ComponentKind,
         component: Rc<RefCell<Prompt>>,
@@ -129,7 +126,7 @@ impl Layout {
         self.recalculate_layout(context);
     }
 
-    pub(crate) fn recalculate_layout(&mut self, context: &Context) {
+    pub fn recalculate_layout(&mut self, context: &Context) {
         let (layout_kind, ratio) = layout_kind();
 
         let (rectangles, borders) = Rectangle::generate(
@@ -152,14 +149,14 @@ impl Layout {
             });
     }
 
-    pub(crate) fn get_existing_editor(
+    pub fn get_existing_editor(
         &self,
         path: &CanonicalizedPath,
     ) -> Option<Rc<RefCell<SuggestiveEditor>>> {
         self.background_suggestive_editors.get(path).cloned()
     }
 
-    pub(crate) fn open_file(
+    pub fn open_file(
         &mut self,
         path: &CanonicalizedPath,
         focus_editor: bool,
@@ -174,27 +171,24 @@ impl Layout {
         }
     }
 
-    pub(crate) fn set_terminal_dimension(&mut self, dimension: Dimension, context: &Context) {
+    pub fn set_terminal_dimension(&mut self, dimension: Dimension, context: &Context) {
         self.terminal_dimension = dimension;
         self.recalculate_layout(context)
     }
 
-    pub(crate) fn terminal_dimension(&self) -> Dimension {
+    pub fn terminal_dimension(&self) -> Dimension {
         self.terminal_dimension
     }
 
-    pub(crate) fn focused_component_id(&self) -> ComponentId {
+    pub fn focused_component_id(&self) -> ComponentId {
         self.tree.current_component().borrow().id()
     }
 
-    pub(crate) fn borders(&self) -> Vec<Border> {
+    pub fn borders(&self) -> Vec<Border> {
         self.borders.clone()
     }
 
-    pub(crate) fn add_suggestive_editor(
-        &mut self,
-        suggestive_editor: Rc<RefCell<SuggestiveEditor>>,
-    ) {
+    pub fn add_suggestive_editor(&mut self, suggestive_editor: Rc<RefCell<SuggestiveEditor>>) {
         let path = suggestive_editor.borrow().path();
         if let Some(path) = path {
             self.background_suggestive_editors
@@ -216,7 +210,7 @@ impl Layout {
         Ok(())
     }
 
-    pub(crate) fn show_global_info(&mut self, info: Info, context: &Context) -> anyhow::Result<()> {
+    pub fn show_global_info(&mut self, info: Info, context: &Context) -> anyhow::Result<()> {
         self.show_info_on(
             self.tree.root_id(),
             info,
@@ -225,7 +219,7 @@ impl Layout {
         )
     }
 
-    pub(crate) fn show_keymap_legend(
+    pub fn show_keymap_legend(
         &mut self,
         keymap_legend_config: KeymapLegendConfig,
         context: &Context,
@@ -242,11 +236,11 @@ impl Layout {
         )
     }
 
-    pub(crate) fn remain_only_current_component(&mut self) {
+    pub fn remain_only_current_component(&mut self) {
         self.tree.remain_only_current_component()
     }
 
-    pub(crate) fn get_opened_files(&self) -> Vec<CanonicalizedPath> {
+    pub fn get_opened_files(&self) -> Vec<CanonicalizedPath> {
         self.background_suggestive_editors
             .iter()
             .filter(|(_, editor)| editor.borrow().editor().buffer().owner() == BufferOwner::User)
@@ -255,7 +249,7 @@ impl Layout {
     }
 
     #[cfg(test)]
-    pub(crate) fn get_buffer_contents_map(&self) -> BufferContentsMap {
+    pub fn get_buffer_contents_map(&self) -> BufferContentsMap {
         self.background_suggestive_editors
             .iter()
             .map(|(path, editor)| {
@@ -267,7 +261,7 @@ impl Layout {
             .collect()
     }
 
-    pub(crate) fn save_all(&self, context: &Context) -> Result<(), anyhow::Error> {
+    pub fn save_all(&self, context: &Context) -> Result<(), anyhow::Error> {
         self.background_suggestive_editors
             .iter()
             .map(|(_, editor)| editor.borrow_mut().editor_mut().save(context))
@@ -275,7 +269,7 @@ impl Layout {
         Ok(())
     }
 
-    pub(crate) fn reveal_path_in_explorer(
+    pub fn reveal_path_in_explorer(
         &mut self,
         path: &CanonicalizedPath,
         context: &Context,
@@ -304,15 +298,15 @@ impl Layout {
         Ok(dispatches)
     }
 
-    pub(crate) fn remove_suggestive_editor(&mut self, path: &CanonicalizedPath) {
+    pub fn remove_suggestive_editor(&mut self, path: &CanonicalizedPath) {
         self.background_suggestive_editors.shift_remove(path);
     }
 
-    pub(crate) fn refresh_file_explorer(&self, context: &Context) -> anyhow::Result<()> {
+    pub fn refresh_file_explorer(&self, context: &Context) -> anyhow::Result<()> {
         self.background_file_explorer.borrow_mut().refresh(context)
     }
 
-    pub(crate) fn open_file_explorer(&mut self) {
+    pub fn open_file_explorer(&mut self) {
         self.tree.remove_all_root_children();
         self.tree.replace_root_node_child(
             ComponentKind::FileExplorer,
@@ -322,7 +316,7 @@ impl Layout {
         debug_assert_eq!(self.tree.root().children().count(), 1);
     }
 
-    pub(crate) fn update_highlighted_spans(
+    pub fn update_highlighted_spans(
         &self,
         component_id: ComponentId,
         batch_id: SyntaxHighlightRequestBatchId,
@@ -349,14 +343,14 @@ impl Layout {
         Ok(())
     }
 
-    pub(crate) fn buffers(&self) -> Vec<Rc<RefCell<Buffer>>> {
+    pub fn buffers(&self) -> Vec<Rc<RefCell<Buffer>>> {
         self.background_suggestive_editors
             .iter()
             .map(|(_, editor)| editor.borrow().editor().buffer_rc())
             .collect_vec()
     }
 
-    pub(crate) fn reload_buffers(
+    pub fn reload_buffers(
         &self,
         affected_paths: Vec<CanonicalizedPath>,
     ) -> anyhow::Result<Dispatches> {
@@ -377,16 +371,16 @@ impl Layout {
     }
 
     #[cfg(test)]
-    pub(crate) fn completion_dropdown_is_open(&self) -> bool {
+    pub fn completion_dropdown_is_open(&self) -> bool {
         self.current_completion_dropdown().is_some()
     }
 
-    pub(crate) fn current_completion_dropdown(&self) -> Option<Rc<RefCell<dyn Component>>> {
+    pub fn current_completion_dropdown(&self) -> Option<Rc<RefCell<dyn Component>>> {
         self.get_current_node_child_id(ComponentKind::Dropdown)
             .and_then(|node_id| Some(self.tree.get(node_id)?.data().component().clone()))
     }
 
-    pub(crate) fn open_dropdown(&mut self, context: &Context) -> Option<Rc<RefCell<Editor>>> {
+    pub fn open_dropdown(&mut self, context: &Context) -> Option<Rc<RefCell<Editor>>> {
         let dropdown = Rc::new(RefCell::new(Editor::from_text(
             Some(tree_sitter_quickfix::language()),
             "",
@@ -404,11 +398,11 @@ impl Layout {
         Some(dropdown)
     }
 
-    pub(crate) fn close_dropdown(&mut self) {
+    pub fn close_dropdown(&mut self) {
         self.tree.remove_current_child(ComponentKind::Dropdown);
     }
 
-    pub(crate) fn close_editor_info(&mut self) {
+    pub fn close_editor_info(&mut self) {
         self.tree.remove_current_child(ComponentKind::EditorInfo);
     }
 
@@ -424,11 +418,7 @@ impl Layout {
         self.tree.remove_node_child(node_id, kind)
     }
 
-    pub(crate) fn show_dropdown_info(
-        &mut self,
-        info: Info,
-        context: &Context,
-    ) -> anyhow::Result<()> {
+    pub fn show_dropdown_info(&mut self, info: Info, context: &Context) -> anyhow::Result<()> {
         if let Some(node_id) = self.tree.get_current_node_child_id(ComponentKind::Dropdown) {
             self.show_info_on(node_id, info, ComponentKind::DropdownInfo, context)?;
         }
@@ -436,13 +426,13 @@ impl Layout {
         Ok(())
     }
 
-    pub(crate) fn hide_dropdown_info(&mut self) {
+    pub fn hide_dropdown_info(&mut self) {
         if let Some(node_id) = self.get_current_node_child_id(ComponentKind::Dropdown) {
             self.remove_node_child(node_id, ComponentKind::DropdownInfo);
         }
     }
 
-    pub(crate) fn show_quickfix_list(
+    pub fn show_quickfix_list(
         &mut self,
         quickfix_list: QuickfixList,
         context: &Context,
@@ -492,11 +482,11 @@ impl Layout {
     }
 
     #[cfg(test)]
-    pub(crate) fn get_dropdown_infos_count(&self) -> usize {
+    pub fn get_dropdown_infos_count(&self) -> usize {
         self.tree.count_by_kind(ComponentKind::DropdownInfo)
     }
 
-    pub(crate) fn show_editor_info(&mut self, info: Info, context: &Context) -> anyhow::Result<()> {
+    pub fn show_editor_info(&mut self, info: Info, context: &Context) -> anyhow::Result<()> {
         self.show_info_on(
             self.tree.focused_component_id(),
             info,
@@ -516,7 +506,7 @@ impl Layout {
     }
 
     #[cfg(test)]
-    pub(crate) fn editor_info_contents(&self) -> Vec<String> {
+    pub fn editor_info_contents(&self) -> Vec<String> {
         self.tree
             .root()
             .traverse_pre_order()
@@ -526,7 +516,7 @@ impl Layout {
     }
 
     #[cfg(test)]
-    pub(crate) fn global_info_contents(&self) -> Vec<String> {
+    pub fn global_info_contents(&self) -> Vec<String> {
         self.tree
             .root()
             .traverse_pre_order()
@@ -536,15 +526,15 @@ impl Layout {
     }
 
     #[cfg(test)]
-    pub(crate) fn file_explorer_content(&self) -> String {
+    pub fn file_explorer_content(&self) -> String {
         self.background_file_explorer.borrow().content()
     }
 
-    pub(crate) fn file_explorer_expanded_folders(&self) -> Vec<CanonicalizedPath> {
+    pub fn file_explorer_expanded_folders(&self) -> Vec<CanonicalizedPath> {
         self.background_file_explorer.borrow().expanded_folders()
     }
 
-    pub(crate) fn get_quickfix_list_items(
+    pub fn get_quickfix_list_items(
         &self,
         source: &QuickfixListSource,
         context: &Context,
@@ -598,7 +588,7 @@ impl Layout {
         }
     }
 
-    pub(crate) fn replace_and_focus_current_suggestive_editor(
+    pub fn replace_and_focus_current_suggestive_editor(
         &mut self,
         editor: Rc<RefCell<SuggestiveEditor>>,
     ) {
@@ -611,12 +601,12 @@ impl Layout {
         );
     }
 
-    pub(crate) fn close_current_window_and_focus_parent(&mut self) {
+    pub fn close_current_window_and_focus_parent(&mut self) {
         self.tree.close_current_and_focus_parent()
     }
 
     #[cfg(test)]
-    pub(crate) fn global_info(&self) -> Option<String> {
+    pub fn global_info(&self) -> Option<String> {
         Some(
             self.tree
                 .get_component_by_kind(ComponentKind::GlobalInfo)?
@@ -625,23 +615,20 @@ impl Layout {
         )
     }
 
-    pub(crate) fn get_component_by_kind(
-        &self,
-        kind: ComponentKind,
-    ) -> Option<Rc<RefCell<dyn Component>>> {
+    pub fn get_component_by_kind(&self, kind: ComponentKind) -> Option<Rc<RefCell<dyn Component>>> {
         self.tree.get_component_by_kind(kind)
     }
 
-    pub(crate) fn hide_editor_info(&mut self) {
+    pub fn hide_editor_info(&mut self) {
         self.tree.remove_current_child(ComponentKind::EditorInfo);
     }
 
-    pub(crate) fn close_global_info(&mut self) {
+    pub fn close_global_info(&mut self) {
         self.tree
             .remove_node_child(self.tree.root_id(), ComponentKind::GlobalInfo);
     }
 
-    pub(crate) fn get_component_by_id(
+    pub fn get_component_by_id(
         &self,
         component_id: ComponentId,
     ) -> Option<Rc<RefCell<dyn Component>>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,13 @@
 mod buffer;
 mod git;
 
-pub(crate) mod char_index_range;
+pub mod char_index_range;
 mod cli;
 mod clipboard;
 mod components;
 mod context;
 mod edit;
-pub(crate) mod frontend;
+pub mod frontend;
 mod grid;
 mod integration_event;
 #[cfg(test)]
@@ -16,14 +16,14 @@ mod render_flex_layout;
 mod search;
 
 mod layout;
-pub(crate) mod list;
+pub mod list;
 mod lsp;
 mod position;
 
 mod app;
 #[cfg(test)]
 mod generate_recipes;
-pub(crate) mod history;
+pub mod history;
 mod non_empty_extensions;
 mod osc52;
 mod quickfix_list;
@@ -32,29 +32,29 @@ mod recipes;
 mod rectangle;
 mod screen;
 mod selection;
-pub(crate) mod selection_mode;
-pub(crate) mod selection_range;
-pub(crate) mod soft_wrap;
-pub(crate) mod style;
-pub(crate) mod surround;
-pub(crate) mod syntax_highlight;
+pub mod selection_mode;
+pub mod selection_range;
+pub mod soft_wrap;
+pub mod style;
+pub mod surround;
+pub mod syntax_highlight;
 #[cfg(test)]
 mod test_app;
-pub(crate) mod themes;
-pub(crate) mod transformation;
-pub(crate) mod ui_tree;
+pub mod themes;
+pub mod transformation;
+pub mod ui_tree;
 mod utils;
 
 mod embed;
 
 mod alternator;
-pub(crate) mod config;
+pub mod config;
 mod divide_viewport;
 mod env;
-pub(crate) mod file_watcher;
+pub mod file_watcher;
 mod format_path_list;
-pub(crate) mod persistence;
-pub(crate) mod scripting;
+pub mod persistence;
+pub mod scripting;
 #[cfg(test)]
 mod test_lsp;
 #[cfg(test)]
@@ -76,12 +76,12 @@ pub fn main() {
 }
 
 #[derive(Default)]
-pub(crate) struct RunConfig {
-    pub(crate) entry_path: Option<CanonicalizedPath>,
-    pub(crate) working_directory: Option<CanonicalizedPath>,
+pub struct RunConfig {
+    pub entry_path: Option<CanonicalizedPath>,
+    pub working_directory: Option<CanonicalizedPath>,
 }
 
-pub(crate) fn run(config: RunConfig) -> anyhow::Result<()> {
+pub fn run(config: RunConfig) -> anyhow::Result<()> {
     std::fs::create_dir_all(grammar::cache_dir()).context("Failed to create cache_dir")?;
     simple_logging::log_to_file(grammar::default_log_file(), LevelFilter::Info)?;
     let (sender, receiver) = std::sync::mpsc::channel();

--- a/src/list/ast_grep.rs
+++ b/src/list/ast_grep.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use super::WalkBuilderConfig;
 
-pub(crate) fn run(
+pub fn run(
     pattern: String,
     walk_builder_config: WalkBuilderConfig,
     send_match: Arc<dyn Fn(Match) -> SendResult + Send + Sync>,

--- a/src/list/grep.rs
+++ b/src/list/grep.rs
@@ -14,18 +14,18 @@ use shared::canonicalized_path::CanonicalizedPath;
 use super::WalkBuilderConfig;
 
 #[derive(Clone, Debug, PartialEq, Eq, Copy)]
-pub(crate) struct RegexConfig {
-    pub(crate) escaped: bool,
-    pub(crate) case_sensitive: bool,
-    pub(crate) match_whole_word: bool,
+pub struct RegexConfig {
+    pub escaped: bool,
+    pub case_sensitive: bool,
+    pub match_whole_word: bool,
 }
 
 impl RegexConfig {
-    pub(crate) fn to_regex(self, pattern: &str) -> Result<Regex, anyhow::Error> {
+    pub fn to_regex(self, pattern: &str) -> Result<Regex, anyhow::Error> {
         get_regex(pattern, self)
     }
 
-    pub(crate) fn literal() -> RegexConfig {
+    pub fn literal() -> RegexConfig {
         RegexConfig {
             case_sensitive: false,
             escaped: true,
@@ -33,7 +33,7 @@ impl RegexConfig {
         }
     }
 
-    pub(crate) fn strict() -> RegexConfig {
+    pub fn strict() -> RegexConfig {
         RegexConfig {
             escaped: true,
             match_whole_word: true,
@@ -41,7 +41,7 @@ impl RegexConfig {
         }
     }
 
-    pub(crate) fn regex() -> RegexConfig {
+    pub fn regex() -> RegexConfig {
         RegexConfig {
             escaped: false,
             match_whole_word: false,
@@ -49,7 +49,7 @@ impl RegexConfig {
         }
     }
 
-    pub(crate) fn match_whole_word() -> RegexConfig {
+    pub fn match_whole_word() -> RegexConfig {
         RegexConfig {
             escaped: true,
             match_whole_word: true,
@@ -57,7 +57,7 @@ impl RegexConfig {
         }
     }
 
-    pub(crate) fn case_sensitive() -> RegexConfig {
+    pub fn case_sensitive() -> RegexConfig {
         RegexConfig {
             escaped: true,
             match_whole_word: false,
@@ -77,7 +77,7 @@ impl Default for RegexConfig {
 }
 
 /// Returns list of affected files
-pub(crate) fn replace(
+pub fn replace(
     walk_builder_config: WalkBuilderConfig,
     local_search_config: LocalSearchConfig,
 ) -> anyhow::Result<(Dispatches, Vec<CanonicalizedPath>)> {
@@ -105,7 +105,7 @@ pub(crate) fn replace(
     Ok((dispatches, paths))
 }
 
-pub(crate) fn run(
+pub fn run(
     pattern: &str,
     walk_builder_config: WalkBuilderConfig,
     grep_config: RegexConfig,

--- a/src/list/mod.rs
+++ b/src/list/mod.rs
@@ -10,20 +10,20 @@ use shared::canonicalized_path::CanonicalizedPath;
 
 use crate::{buffer::Buffer, quickfix_list::Location, thread::SendResult};
 
-pub(crate) mod ast_grep;
+pub mod ast_grep;
 
-pub(crate) mod grep;
-pub(crate) mod naming_convention_agnostic;
+pub mod grep;
+pub mod naming_convention_agnostic;
 
-pub(crate) struct WalkBuilderConfig {
-    pub(crate) root: PathBuf,
-    pub(crate) include: Option<Glob>,
-    pub(crate) exclude: Option<Glob>,
+pub struct WalkBuilderConfig {
+    pub root: PathBuf,
+    pub include: Option<Glob>,
+    pub exclude: Option<Glob>,
 }
 type GetRange = dyn Fn(&Buffer) -> Vec<Range<usize>> + Send + Sync;
 
 impl WalkBuilderConfig {
-    pub(crate) fn run_with_search(
+    pub fn run_with_search(
         self,
         enable_tree_sitter: bool,
         send_match: Arc<dyn Fn(Match) -> SendResult + Send + Sync>,
@@ -51,7 +51,7 @@ impl WalkBuilderConfig {
             }),
         )
     }
-    pub(crate) fn run<T: Send>(
+    pub fn run<T: Send>(
         self,
         f: Box<dyn Fn(PathBuf, Sender<T>) -> anyhow::Result<()> + Send + Sync>,
     ) -> anyhow::Result<Vec<T>> {
@@ -113,7 +113,7 @@ impl WalkBuilderConfig {
         Ok(receiver.into_iter().collect::<Vec<_>>())
     }
 
-    pub(crate) fn run_async(
+    pub fn run_async(
         self,
         enable_tree_sitter: bool,
         on_visit_buffer: Arc<dyn Fn(CanonicalizedPath, Buffer) + Send + Sync>,
@@ -177,10 +177,7 @@ impl WalkBuilderConfig {
     /// `on_entry` takes `PathBuf` instead of `CanonicalizedPath`
     /// because constructing `CanonicalizedPath` is expensive.
     /// For reference: read https://blobfolio.com/2021/faster-path-canonicalization-rust/
-    pub(crate) fn get_non_git_ignored_files(
-        root: PathBuf,
-        on_entry: Arc<dyn Fn(PathBuf) + Send + Sync>,
-    ) {
+    pub fn get_non_git_ignored_files(root: PathBuf, on_entry: Arc<dyn Fn(PathBuf) + Send + Sync>) {
         WalkBuilder::new(root)
             .hidden(false)
             .build_parallel()
@@ -204,9 +201,9 @@ impl WalkBuilderConfig {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct Match {
-    pub(crate) location: Location,
-    pub(crate) line: String,
+pub struct Match {
+    pub location: Location,
+    pub line: String,
 }
 
 #[cfg(test)]

--- a/src/list/naming_convention_agnostic.rs
+++ b/src/list/naming_convention_agnostic.rs
@@ -4,7 +4,7 @@ use crate::{list::Match, selection_mode::NamingConventionAgnostic, thread::SendR
 
 use super::WalkBuilderConfig;
 
-pub(crate) fn run(
+pub fn run(
     pattern: String,
     walk_builder_config: WalkBuilderConfig,
     send_match: Arc<dyn Fn(Match) -> SendResult + Send + Sync>,

--- a/src/lsp/code_action.rs
+++ b/src/lsp/code_action.rs
@@ -6,21 +6,21 @@ use super::workspace_edit::WorkspaceEdit;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// Refer https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeAction
-pub(crate) struct CodeAction {
-    pub(crate) title: String,
-    pub(crate) kind: Option<String>,
-    pub(crate) edit: Option<WorkspaceEdit>,
-    pub(crate) command: Option<Command>,
+pub struct CodeAction {
+    pub title: String,
+    pub kind: Option<String>,
+    pub edit: Option<WorkspaceEdit>,
+    pub command: Option<Command>,
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct Command(lsp_types::Command);
+pub struct Command(lsp_types::Command);
 impl Command {
-    pub(crate) fn arguments(&self) -> Vec<serde_json::Value> {
+    pub fn arguments(&self) -> Vec<serde_json::Value> {
         self.0.arguments.clone().unwrap_or_default()
     }
 
-    pub(crate) fn command(&self) -> String {
+    pub fn command(&self) -> String {
         self.0.command.clone()
     }
 }

--- a/src/lsp/completion.rs
+++ b/src/lsp/completion.rs
@@ -13,31 +13,31 @@ use crate::{
 use super::documentation::Documentation;
 
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) struct Completion {
-    pub(crate) items: Vec<DropdownItem>,
-    pub(crate) trigger_characters: Vec<String>,
+pub struct Completion {
+    pub items: Vec<DropdownItem>,
+    pub trigger_characters: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) struct CompletionItem {
-    pub(crate) label: String,
-    pub(crate) kind: Option<CompletionItemKind>,
-    pub(crate) detail: Option<String>,
-    pub(crate) documentation: Option<Documentation>,
-    pub(crate) sort_text: Option<String>,
-    pub(crate) insert_text: Option<String>,
-    pub(crate) edit: Option<CompletionItemEdit>,
-    pub(crate) completion_item: lsp_types::CompletionItem,
+pub struct CompletionItem {
+    pub label: String,
+    pub kind: Option<CompletionItemKind>,
+    pub detail: Option<String>,
+    pub documentation: Option<Documentation>,
+    pub sort_text: Option<String>,
+    pub insert_text: Option<String>,
+    pub edit: Option<CompletionItemEdit>,
+    pub completion_item: lsp_types::CompletionItem,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum CompletionItemEdit {
+pub enum CompletionItemEdit {
     PositionalEdit(PositionalEdit),
 }
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct PositionalEdit {
-    pub(crate) range: Range<Position>,
-    pub(crate) new_text: String,
+pub struct PositionalEdit {
+    pub range: Range<Position>,
+    pub new_text: String,
 }
 
 impl TryFrom<lsp_types::AnnotatedTextEdit> for PositionalEdit {
@@ -60,7 +60,7 @@ impl TryFrom<lsp_types::TextEdit> for PositionalEdit {
 }
 
 impl CompletionItem {
-    pub(crate) fn emoji(&self) -> String {
+    pub fn emoji(&self) -> String {
         self.kind
             .map(|kind| {
                 get_icon_config()
@@ -71,7 +71,7 @@ impl CompletionItem {
             })
             .unwrap_or_default()
     }
-    pub(crate) fn info(&self) -> Option<Info> {
+    pub fn info(&self) -> Option<Info> {
         let kind = self.kind.map(|kind| {
             convert_case::Casing::to_case(&format!("{kind:?}"), convert_case::Case::Title)
         });
@@ -91,7 +91,7 @@ impl CompletionItem {
         }
     }
     #[cfg(test)]
-    pub(crate) fn from_label(label: String) -> Self {
+    pub fn from_label(label: String) -> Self {
         Self {
             label,
             kind: None,
@@ -104,15 +104,15 @@ impl CompletionItem {
         }
     }
 
-    pub(crate) fn label(&self) -> String {
+    pub fn label(&self) -> String {
         self.label.clone()
     }
 
-    pub(crate) fn documentation(&self) -> Option<Documentation> {
+    pub fn documentation(&self) -> Option<Documentation> {
         self.documentation.clone()
     }
 
-    pub(crate) fn additional_text_edits(&self) -> Vec<CompletionItemEdit> {
+    pub fn additional_text_edits(&self) -> Vec<CompletionItemEdit> {
         self.completion_item
             .additional_text_edits
             .as_ref()
@@ -131,7 +131,7 @@ impl CompletionItem {
     }
 
     #[cfg(test)]
-    pub(crate) fn set_documentation(self, description: Option<Documentation>) -> CompletionItem {
+    pub fn set_documentation(self, description: Option<Documentation>) -> CompletionItem {
         CompletionItem {
             documentation: description,
             ..self
@@ -139,18 +139,18 @@ impl CompletionItem {
     }
 
     #[cfg(test)]
-    pub(crate) fn set_insert_text(self, insert_text: Option<String>) -> CompletionItem {
+    pub fn set_insert_text(self, insert_text: Option<String>) -> CompletionItem {
         CompletionItem {
             insert_text,
             ..self
         }
     }
 
-    pub(crate) fn insert_text(&self) -> Option<String> {
+    pub fn insert_text(&self) -> Option<String> {
         self.insert_text.clone()
     }
 
-    pub(crate) fn dispatches(&self) -> crate::app::Dispatches {
+    pub fn dispatches(&self) -> crate::app::Dispatches {
         Dispatches::one(Dispatch::ToEditor(DispatchEditor::ExecuteCompletion {
             replacement: self
                 .insert_text()
@@ -170,7 +170,7 @@ impl CompletionItem {
         )
     }
 
-    pub(crate) fn completion_item(&self) -> lsp_types::CompletionItem {
+    pub fn completion_item(&self) -> lsp_types::CompletionItem {
         self.completion_item.clone()
     }
 

--- a/src/lsp/diagnostic.rs
+++ b/src/lsp/diagnostic.rs
@@ -5,17 +5,17 @@ use crate::{
 use lsp_types::DiagnosticSeverity;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct Diagnostic {
-    pub(crate) range: CharIndexRange,
-    pub(crate) message: String,
-    pub(crate) severity: Option<DiagnosticSeverity>,
-    pub(crate) related_information: Option<Vec<DiagnosticRelatedInformation>>,
-    pub(crate) code_description: Option<lsp_types::CodeDescription>,
-    pub(crate) original_value: Option<lsp_types::Diagnostic>,
+pub struct Diagnostic {
+    pub range: CharIndexRange,
+    pub message: String,
+    pub severity: Option<DiagnosticSeverity>,
+    pub related_information: Option<Vec<DiagnosticRelatedInformation>>,
+    pub code_description: Option<lsp_types::CodeDescription>,
+    pub original_value: Option<lsp_types::Diagnostic>,
 }
 
 impl Diagnostic {
-    pub(crate) fn try_from(buffer: &Buffer, value: lsp_types::Diagnostic) -> anyhow::Result<Self> {
+    pub fn try_from(buffer: &Buffer, value: lsp_types::Diagnostic) -> anyhow::Result<Self> {
         Ok(Self {
             range: buffer.position_range_to_char_index_range(
                 &(Position::from(value.range.start)..Position::from(value.range.end)),
@@ -41,7 +41,7 @@ impl Diagnostic {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct DiagnosticRelatedInformation {
+pub struct DiagnosticRelatedInformation {
     location: Location,
     message: String,
 }

--- a/src/lsp/documentation.rs
+++ b/src/lsp/documentation.rs
@@ -1,10 +1,10 @@
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct Documentation {
-    pub(crate) content: String,
+pub struct Documentation {
+    pub content: String,
 }
 impl Documentation {
     #[cfg(test)]
-    pub(crate) fn new(content: &str) -> Documentation {
+    pub fn new(content: &str) -> Documentation {
         Documentation {
             content: content.to_string(),
         }

--- a/src/lsp/goto_definition_response.rs
+++ b/src/lsp/goto_definition_response.rs
@@ -1,7 +1,7 @@
 use crate::quickfix_list::Location;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum GotoDefinitionResponse {
+pub enum GotoDefinitionResponse {
     Single(Location),
     Multiple(Vec<Location>),
 }

--- a/src/lsp/hover.rs
+++ b/src/lsp/hover.rs
@@ -1,6 +1,6 @@
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct Hover {
-    pub(crate) contents: Vec<String>,
+pub struct Hover {
+    pub contents: Vec<String>,
 }
 
 impl From<lsp_types::Hover> for Hover {
@@ -19,7 +19,7 @@ impl From<lsp_types::Hover> for Hover {
     }
 }
 
-pub(crate) fn marked_string_to_string(marked_string: lsp_types::MarkedString) -> String {
+pub fn marked_string_to_string(marked_string: lsp_types::MarkedString) -> String {
     match marked_string {
         lsp_types::MarkedString::String(string) => string,
         lsp_types::MarkedString::LanguageString(language_string) => language_string.value,

--- a/src/lsp/manager.rs
+++ b/src/lsp/manager.rs
@@ -8,7 +8,7 @@ use shared::{
     language::{Language, LanguageId},
 };
 
-pub(crate) struct LspManager {
+pub struct LspManager {
     lsp_server_process_channels: HashMap<LanguageId, LspServerProcessChannel>,
     sender: Sender<AppMessage>,
     current_working_directory: CanonicalizedPath,
@@ -30,7 +30,7 @@ impl Drop for LspManager {
 }
 
 impl LspManager {
-    pub(crate) fn new(
+    pub fn new(
         sender: Sender<AppMessage>,
         current_working_directory: CanonicalizedPath,
     ) -> LspManager {
@@ -57,7 +57,7 @@ impl LspManager {
             .unwrap_or_else(|| Ok(()))
     }
 
-    pub(crate) fn send_message(
+    pub fn send_message(
         &mut self,
         path: CanonicalizedPath,
         from_editor: FromEditor,
@@ -77,7 +77,7 @@ impl LspManager {
     /// 1. Start a new LSP server process if it is not started yet.
     /// 2. Notify the LSP server process that a new file is opened.
     /// 3. Do nothing if the LSP server process is spawned but not yet initialized.
-    pub(crate) fn open_file(&mut self, path: CanonicalizedPath) -> Result<(), anyhow::Error> {
+    pub fn open_file(&mut self, path: CanonicalizedPath) -> Result<(), anyhow::Error> {
         let Some(language) = crate::config::from_path(&path) else {
             return Ok(());
         };
@@ -108,11 +108,7 @@ impl LspManager {
         }
     }
 
-    pub(crate) fn initialized(
-        &mut self,
-        language: Language,
-        opened_documents: Vec<CanonicalizedPath>,
-    ) {
+    pub fn initialized(&mut self, language: Language, opened_documents: Vec<CanonicalizedPath>) {
         let Some(language_id) = language.id() else {
             return;
         };
@@ -129,7 +125,7 @@ impl LspManager {
             });
     }
 
-    pub(crate) fn shutdown(&mut self) {
+    pub fn shutdown(&mut self) {
         for (_, channel) in self.lsp_server_process_channels.drain() {
             channel
                 .shutdown()
@@ -138,14 +134,12 @@ impl LspManager {
     }
 
     #[cfg(test)]
-    pub(crate) fn lsp_request_sent(&self, from_editor: &FromEditor) -> bool {
+    pub fn lsp_request_sent(&self, from_editor: &FromEditor) -> bool {
         self.history.get(from_editor.variant()) == Some(from_editor)
     }
 
     #[cfg(test)]
-    pub(crate) fn lsp_server_initialized_args(
-        &self,
-    ) -> Option<(LanguageId, Vec<CanonicalizedPath>)> {
+    pub fn lsp_server_initialized_args(&self) -> Option<(LanguageId, Vec<CanonicalizedPath>)> {
         self.lsp_server_initialized_args_history.last().cloned()
     }
 }

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -1,13 +1,13 @@
-pub(crate) mod code_action;
-pub(crate) mod completion;
-pub(crate) mod diagnostic;
-pub(crate) mod documentation;
+pub mod code_action;
+pub mod completion;
+pub mod diagnostic;
+pub mod documentation;
 
-pub(crate) mod goto_definition_response;
-pub(crate) mod hover;
-pub(crate) mod manager;
-pub(crate) mod prepare_rename_response;
-pub(crate) mod process;
-pub(crate) mod signature_help;
-pub(crate) mod symbols;
-pub(crate) mod workspace_edit;
+pub mod goto_definition_response;
+pub mod hover;
+pub mod manager;
+pub mod prepare_rename_response;
+pub mod process;
+pub mod signature_help;
+pub mod symbols;
+pub mod workspace_edit;

--- a/src/lsp/prepare_rename_response.rs
+++ b/src/lsp/prepare_rename_response.rs
@@ -3,9 +3,9 @@ use std::ops::Range;
 use crate::position::Position;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct PrepareRenameResponse {
-    pub(crate) range: Option<Range<Position>>,
-    pub(crate) placeholder: Option<String>,
+pub struct PrepareRenameResponse {
+    pub range: Option<Range<Position>>,
+    pub placeholder: Option<String>,
 }
 
 impl From<lsp_types::PrepareRenameResponse> for PrepareRenameResponse {

--- a/src/lsp/process.rs
+++ b/src/lsp/process.rs
@@ -59,7 +59,7 @@ struct PendingResponseRequest {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) enum LspNotification {
+pub enum LspNotification {
     Initialized(Box<Language>),
     PublishDiagnostics(PublishDiagnosticsParams),
     Completion(ResponseContext, Completion),
@@ -77,12 +77,12 @@ pub(crate) enum LspNotification {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub(crate) struct ResponseContext {
-    pub(crate) scope: Option<Scope>,
-    pub(crate) description: Option<String>,
+pub struct ResponseContext {
+    pub scope: Option<Scope>,
+    pub description: Option<String>,
 }
 impl ResponseContext {
-    pub(crate) fn set_description(self, descrption: &str) -> Self {
+    pub fn set_description(self, descrption: &str) -> Self {
         Self {
             description: Some(descrption.to_owned()),
             ..self
@@ -101,7 +101,7 @@ enum LspServerProcessMessage {
 }
 
 #[derive(Debug, NamedVariant, Clone, PartialEq)]
-pub(crate) enum FromEditor {
+pub enum FromEditor {
     TextDocumentHover(RequestParams),
     TextDocumentCompletion(RequestParams),
     TextDocumentDefinition(RequestParams),
@@ -159,19 +159,19 @@ pub(crate) enum FromEditor {
 }
 
 impl FromEditor {
-    pub(crate) fn variant(&self) -> &'static str {
+    pub fn variant(&self) -> &'static str {
         self.variant_name()
     }
 }
 
-pub(crate) struct LspServerProcessChannel {
+pub struct LspServerProcessChannel {
     language: Language,
     sender: Sender<LspServerProcessMessage>,
     is_initialized: bool,
 }
 
 impl LspServerProcessChannel {
-    pub(crate) fn new(
+    pub fn new(
         language: Language,
         screen_message_sender: Sender<AppMessage>,
         current_working_directory: CanonicalizedPath,
@@ -179,7 +179,7 @@ impl LspServerProcessChannel {
         LspServerProcess::start(language, screen_message_sender, current_working_directory)
     }
 
-    pub(crate) fn shutdown(self) -> anyhow::Result<()> {
+    pub fn shutdown(self) -> anyhow::Result<()> {
         self.send(LspServerProcessMessage::Shutdown)
     }
 
@@ -192,7 +192,7 @@ impl LspServerProcessChannel {
             .map_err(|err| anyhow::anyhow!("Unable to send request: {}", err))
     }
 
-    pub(crate) fn documents_did_open(
+    pub fn documents_did_open(
         &mut self,
         paths: Vec<CanonicalizedPath>,
     ) -> Result<(), anyhow::Error> {
@@ -205,7 +205,7 @@ impl LspServerProcessChannel {
         )
     }
 
-    pub(crate) fn document_did_open(&self, path: CanonicalizedPath) -> Result<(), anyhow::Error> {
+    pub fn document_did_open(&self, path: CanonicalizedPath) -> Result<(), anyhow::Error> {
         let content = path.read()?;
         let Some(language_id) = self.language.id() else {
             return Ok(());
@@ -220,15 +220,15 @@ impl LspServerProcessChannel {
         ))
     }
 
-    pub(crate) fn is_initialized(&self) -> bool {
+    pub fn is_initialized(&self) -> bool {
         self.is_initialized
     }
 
-    pub(crate) fn initialized(&mut self) {
+    pub fn initialized(&mut self) {
         self.is_initialized = true
     }
 
-    pub(crate) fn send_from_editor(&self, from_editor: FromEditor) -> Result<(), anyhow::Error> {
+    pub fn send_from_editor(&self, from_editor: FromEditor) -> Result<(), anyhow::Error> {
         self.send(LspServerProcessMessage::FromEditor(from_editor))
     }
 }
@@ -418,7 +418,7 @@ impl LspServerProcess {
     /// 2. Processes incoming messages from both the stdout reader and editor
     ///
     /// Returns the stdout reader thread handle for cleanup
-    pub(crate) fn listen(
+    pub fn listen(
         mut self,
         receiver: Receiver<LspServerProcessMessage>,
         app_message_sender: Sender<AppMessage>,
@@ -998,7 +998,7 @@ impl LspServerProcess {
             .unwrap_or_default()
     }
 
-    pub(crate) fn shutdown(&mut self) -> anyhow::Result<()> {
+    pub fn shutdown(&mut self) -> anyhow::Result<()> {
         self.send_request::<lsp_request!("shutdown")>(ResponseContext::default(), None, ())?;
         Ok(())
     }
@@ -1407,7 +1407,7 @@ impl LspServerProcess {
         )
     }
 
-    pub(crate) fn text_document_signature_help(
+    pub fn text_document_signature_help(
         &mut self,
         params: RequestParams,
     ) -> Result<(), anyhow::Error> {

--- a/src/lsp/signature_help.rs
+++ b/src/lsp/signature_help.rs
@@ -9,15 +9,15 @@ use crate::{
 use super::documentation::Documentation;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct SignatureHelp {
-    pub(crate) signatures: Vec<SignatureInformation>,
+pub struct SignatureHelp {
+    pub signatures: Vec<SignatureInformation>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct SignatureInformation {
-    pub(crate) label: String,
-    pub(crate) documentation: Option<Documentation>,
-    pub(crate) active_parameter_byte_range: Option<SelectionRange>,
+pub struct SignatureInformation {
+    pub label: String,
+    pub documentation: Option<Documentation>,
+    pub active_parameter_byte_range: Option<SelectionRange>,
 }
 
 impl From<lsp_types::SignatureHelp> for SignatureHelp {
@@ -33,7 +33,7 @@ impl From<lsp_types::SignatureHelp> for SignatureHelp {
 }
 
 impl SignatureHelp {
-    pub(crate) fn into_info(self) -> Option<Info> {
+    pub fn into_info(self) -> Option<Info> {
         self.signatures
             .into_iter()
             .map(|signature| {

--- a/src/lsp/symbols.rs
+++ b/src/lsp/symbols.rs
@@ -8,8 +8,8 @@ use lsp_types::{DocumentSymbolResponse, SymbolKind};
 use shared::{canonicalized_path::CanonicalizedPath, icons::get_icon_config};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct Symbols {
-    pub(crate) symbols: Vec<Symbol>,
+pub struct Symbols {
+    pub symbols: Vec<Symbol>,
 }
 
 /// This limit is defined so that we don't send too much symbols to the main event loop,
@@ -49,7 +49,7 @@ impl Symbols {
         Ok(symbols)
     }
 
-    pub(crate) fn try_from_document_symbol_response(
+    pub fn try_from_document_symbol_response(
         value: DocumentSymbolResponse,
         path: CanonicalizedPath,
     ) -> anyhow::Result<Self> {
@@ -70,7 +70,7 @@ impl Symbols {
         Ok(Self { symbols })
     }
 
-    pub(crate) fn try_from_workspace_symbol_response(
+    pub fn try_from_workspace_symbol_response(
         workspace_symbol_response: lsp_types::WorkspaceSymbolResponse,
         working_directory: &CanonicalizedPath,
     ) -> anyhow::Result<Self> {
@@ -164,14 +164,14 @@ impl Symbol {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct Symbol {
-    pub(crate) name: String,
-    pub(crate) kind: SymbolKind,
-    pub(crate) location: Location,
-    pub(crate) container_name: Option<String>,
+pub struct Symbol {
+    pub name: String,
+    pub kind: SymbolKind,
+    pub location: Location,
+    pub container_name: Option<String>,
 }
 impl Symbol {
-    pub(crate) fn display(&self) -> String {
+    pub fn display(&self) -> String {
         let icon = get_icon_config()
             .completion
             .get(&format!("{:?}", self.kind))

--- a/src/lsp/workspace_edit.rs
+++ b/src/lsp/workspace_edit.rs
@@ -6,12 +6,12 @@ use shared::canonicalized_path::CanonicalizedPath;
 use super::completion::PositionalEdit;
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub(crate) struct WorkspaceEdit {
-    pub(crate) edits: Vec<TextDocumentEdit>,
-    pub(crate) resource_operations: Vec<ResourceOperation>,
+pub struct WorkspaceEdit {
+    pub edits: Vec<TextDocumentEdit>,
+    pub resource_operations: Vec<ResourceOperation>,
 }
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum ResourceOperation {
+pub enum ResourceOperation {
     Create(String),
     Rename {
         old: CanonicalizedPath,
@@ -130,7 +130,7 @@ impl TryFrom<lsp_types::TextDocumentEdit> for TextDocumentEdit {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct TextDocumentEdit {
-    pub(crate) path: CanonicalizedPath,
-    pub(crate) edits: Vec<PositionalEdit>,
+pub struct TextDocumentEdit {
+    pub path: CanonicalizedPath,
+    pub edits: Vec<PositionalEdit>,
 }

--- a/src/persistence/_00001.rs
+++ b/src/persistence/_00001.rs
@@ -4,7 +4,7 @@
 use crate::persistence::Migration;
 
 #[derive(serde::Deserialize, serde::Serialize, Default, Debug)]
-pub(crate) struct Root {
+pub struct Root {
     version: String,
 }
 

--- a/src/persistence/_00002.rs
+++ b/src/persistence/_00002.rs
@@ -3,18 +3,18 @@ use std::{collections::HashMap, path::PathBuf};
 use crate::persistence::Migration;
 
 #[derive(serde::Deserialize, serde::Serialize, Debug)]
-pub(crate) struct Root {
-    pub(crate) version: String,
-    pub(crate) workspace_sessions: HashMap<PathBuf, WorkspaceSession>,
+pub struct Root {
+    pub version: String,
+    pub workspace_sessions: HashMap<PathBuf, WorkspaceSession>,
 }
 
 #[derive(Default, serde::Serialize, serde::Deserialize, Debug)]
-pub(crate) struct WorkspaceSession {
+pub struct WorkspaceSession {
     /// We use PathBuf instead of CanonicalizedPath because
     /// the stored path might be deleted after Root is serialized and stored,
     /// and we don't want the deserialization of Root to fail because some
     /// path inside marked_files no longer exists.
-    pub(crate) marked_files: Vec<PathBuf>,
+    pub marked_files: Vec<PathBuf>,
 }
 
 impl Default for Root {

--- a/src/persistence/_00003.rs
+++ b/src/persistence/_00003.rs
@@ -3,19 +3,19 @@ use std::{collections::HashMap, path::PathBuf};
 use crate::{char_index_range::CharIndexRange, persistence::Migration};
 
 #[derive(serde::Deserialize, serde::Serialize, Debug)]
-pub(crate) struct Root {
-    pub(crate) version: String,
-    pub(crate) workspace_sessions: HashMap<PathBuf, WorkspaceSession>,
+pub struct Root {
+    pub version: String,
+    pub workspace_sessions: HashMap<PathBuf, WorkspaceSession>,
 }
 
 #[derive(Default, serde::Serialize, serde::Deserialize, Debug)]
-pub(crate) struct WorkspaceSession {
+pub struct WorkspaceSession {
     /// We use PathBuf instead of CanonicalizedPath because
     /// the stored path might be deleted after Root is serialized and stored,
     /// and we don't want the deserialization of Root to fail because some
     /// path inside marked_files no longer exists.
-    pub(crate) marked_files: Vec<PathBuf>,
-    pub(crate) marks: HashMap<PathBuf, Vec<CharIndexRange>>,
+    pub marked_files: Vec<PathBuf>,
+    pub marks: HashMap<PathBuf, Vec<CharIndexRange>>,
 }
 
 impl Default for Root {

--- a/src/persistence/_00004.rs
+++ b/src/persistence/_00004.rs
@@ -7,20 +7,20 @@ use crate::{
 };
 
 #[derive(serde::Deserialize, serde::Serialize, Debug)]
-pub(crate) struct Root {
-    pub(crate) version: String,
-    pub(crate) workspace_sessions: HashMap<PathBuf, WorkspaceSession>,
+pub struct Root {
+    pub version: String,
+    pub workspace_sessions: HashMap<PathBuf, WorkspaceSession>,
 }
 
 #[derive(Default, serde::Serialize, serde::Deserialize, Debug)]
-pub(crate) struct WorkspaceSession {
+pub struct WorkspaceSession {
     /// We use PathBuf instead of CanonicalizedPath because
     /// the stored path might be deleted after Root is serialized and stored,
     /// and we don't want the deserialization of Root to fail because some
     /// path inside marked_files no longer exists.
-    pub(crate) marked_files: Vec<PathBuf>,
-    pub(crate) marks: HashMap<PathBuf, Vec<CharIndexRange>>,
-    pub(crate) prompt_histories: HashMap<PromptHistoryKey, IndexSet<String>>,
+    pub marked_files: Vec<PathBuf>,
+    pub marks: HashMap<PathBuf, Vec<CharIndexRange>>,
+    pub prompt_histories: HashMap<PromptHistoryKey, IndexSet<String>>,
 }
 
 impl Default for Root {

--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -16,18 +16,18 @@ use std::{
 
 use crate::char_index_range::CharIndexRange;
 
-pub(crate) mod _00001;
-pub(crate) mod _00002;
-pub(crate) mod _00003;
-pub(crate) mod _00004;
+pub mod _00001;
+pub mod _00002;
+pub mod _00003;
+pub mod _00004;
 
 #[derive(serde::Serialize, serde::Deserialize)]
-pub(crate) struct Version(pub(crate) u8);
+pub struct Version(pub u8);
 
-pub(crate) type Root = _00004::Root;
-pub(crate) type WorkspaceSession = _00004::WorkspaceSession;
+pub type Root = _00004::Root;
+pub type WorkspaceSession = _00004::WorkspaceSession;
 
-pub(crate) struct Persistence {
+pub struct Persistence {
     path: PathBuf,
     root: Root,
 }
@@ -62,7 +62,7 @@ impl Persistence {
         (parser.parse)(content)
     }
 
-    pub(crate) fn load_or_default(path: PathBuf) -> Self {
+    pub fn load_or_default(path: PathBuf) -> Self {
         Persistence::load(path.clone())
             .map_err(|err| {
                 #[cfg(test)]
@@ -76,29 +76,25 @@ impl Persistence {
             })
     }
 
-    pub(crate) fn write(&self) -> anyhow::Result<()> {
+    pub fn write(&self) -> anyhow::Result<()> {
         std::fs::write(self.path.clone(), serde_json::to_string_pretty(&self.root)?)?;
         Ok(())
     }
 
-    pub(crate) fn set_workspace_session(
-        &mut self,
-        working_directory: &Path,
-        session: WorkspaceSession,
-    ) {
+    pub fn set_workspace_session(&mut self, working_directory: &Path, session: WorkspaceSession) {
         self.root
             .workspace_sessions
             .insert(working_directory.to_path_buf(), session);
     }
 
-    pub(crate) fn get_marked_files(&self, workding_directory: &PathBuf) -> Option<Vec<PathBuf>> {
+    pub fn get_marked_files(&self, workding_directory: &PathBuf) -> Option<Vec<PathBuf>> {
         self.root
             .workspace_sessions
             .get(workding_directory)
             .map(|session| session.marked_files.clone())
     }
 
-    pub(crate) fn get_marks(
+    pub fn get_marks(
         &self,
         working_directory: &PathBuf,
     ) -> Option<HashMap<PathBuf, Vec<CharIndexRange>>> {
@@ -108,7 +104,7 @@ impl Persistence {
             .map(|session| session.marks.clone())
     }
 
-    pub(crate) fn get_prompt_histories(
+    pub fn get_prompt_histories(
         &self,
         working_directory: &Path,
     ) -> Option<HashMap<crate::components::prompt::PromptHistoryKey, indexmap::IndexSet<String>>>
@@ -120,7 +116,7 @@ impl Persistence {
     }
 }
 
-pub(crate) trait Migration:
+pub trait Migration:
     Default + serde::de::DeserializeOwned + serde::Serialize + std::fmt::Debug
 {
     type PreviousVersion: Migration;

--- a/src/position.rs
+++ b/src/position.rs
@@ -4,36 +4,36 @@ use serde::Serialize;
 use crate::{buffer::Buffer, selection::CharIndex};
 
 #[derive(PartialEq, Eq, Hash, Clone, Copy, Debug, Default, Serialize, JsonSchema)]
-pub(crate) struct Position {
+pub struct Position {
     /// 0-based
-    pub(crate) line: usize,
+    pub line: usize,
     /// 0-based
-    pub(crate) column: usize,
+    pub column: usize,
 }
 
 impl Position {
-    pub(crate) fn new(line: usize, column: usize) -> Self {
+    pub fn new(line: usize, column: usize) -> Self {
         Self { line, column }
     }
-    pub(crate) fn to_char_index(self, buffer: &Buffer) -> anyhow::Result<CharIndex> {
+    pub fn to_char_index(self, buffer: &Buffer) -> anyhow::Result<CharIndex> {
         buffer.position_to_char(self)
     }
 
-    pub(crate) fn sub_column(&self, column: usize) -> Self {
+    pub fn sub_column(&self, column: usize) -> Self {
         Self {
             line: self.line,
             column: self.column.saturating_sub(column),
         }
     }
 
-    pub(crate) fn move_right(&self, by: usize) -> Position {
+    pub fn move_right(&self, by: usize) -> Position {
         Position {
             line: self.line,
             column: self.column + by,
         }
     }
 
-    pub(crate) fn move_up(&self, by: usize) -> Option<Position> {
+    pub fn move_up(&self, by: usize) -> Option<Position> {
         if self.line < by {
             None
         } else {
@@ -44,39 +44,39 @@ impl Position {
         }
     }
 
-    pub(crate) fn move_left(&self, by: usize) -> Position {
+    pub fn move_left(&self, by: usize) -> Position {
         Position {
             line: self.line,
             column: self.column.saturating_sub(by),
         }
     }
 
-    pub(crate) fn set_line(self, line: usize) -> Position {
+    pub fn set_line(self, line: usize) -> Position {
         Position { line, ..self }
     }
 
-    pub(crate) fn move_down(&self, line: usize) -> Position {
+    pub fn move_down(&self, line: usize) -> Position {
         Position {
             line: self.line + line,
             column: self.column,
         }
     }
 
-    pub(crate) fn translate(&self, Position { line, column }: Position) -> Position {
+    pub fn translate(&self, Position { line, column }: Position) -> Position {
         Position {
             line: self.line + line,
             column: self.column + column,
         }
     }
 
-    pub(crate) fn set_column(self, new_column: usize) -> Position {
+    pub fn set_column(self, new_column: usize) -> Position {
         Position {
             column: new_column,
             ..self
         }
     }
 
-    pub(crate) fn to_host_position(self) -> ki_protocol_types::Position {
+    pub fn to_host_position(self) -> ki_protocol_types::Position {
         ki_protocol_types::Position {
             character: self.column as u32,
             line: self.line as u32,

--- a/src/quickfix_list.rs
+++ b/src/quickfix_list.rs
@@ -79,7 +79,7 @@ impl QuickfixListItem {
         .set_highlight_column_range(highlight_column_range)
     }
 
-    pub(crate) fn apply_edit(self, edit: &crate::edit::Edit) -> Option<Self> {
+    pub fn apply_edit(self, edit: &crate::edit::Edit) -> Option<Self> {
         Some(Self {
             location: self.location.apply_edit(edit)?,
             ..self
@@ -87,14 +87,14 @@ impl QuickfixListItem {
     }
 }
 
-pub(crate) struct QuickfixList {
+pub struct QuickfixList {
     dropdown: Dropdown,
     #[cfg(test)]
     items: Vec<QuickfixListItem>,
 }
 
 impl QuickfixList {
-    pub(crate) fn new(
+    pub fn new(
         title: String,
         items: Vec<QuickfixListItem>,
         buffers: Vec<Rc<RefCell<Buffer>>>,
@@ -137,16 +137,16 @@ impl QuickfixList {
     }
 
     #[cfg(test)]
-    pub(crate) fn items(&self) -> Vec<QuickfixListItem> {
+    pub fn items(&self) -> Vec<QuickfixListItem> {
         self.items.clone()
     }
 
-    pub(crate) fn render(&self) -> crate::components::dropdown::DropdownRender {
+    pub fn render(&self) -> crate::components::dropdown::DropdownRender {
         self.dropdown.render()
     }
 
     /// Returns the current item index after `movement` is applied
-    pub(crate) fn get_item(&mut self, movement: Movement) -> Option<(usize, Dispatches)> {
+    pub fn get_item(&mut self, movement: Movement) -> Option<(usize, Dispatches)> {
         self.dropdown.apply_movement(movement);
         Some((
             self.dropdown.current_item_index(),
@@ -154,14 +154,14 @@ impl QuickfixList {
         ))
     }
 
-    pub(crate) fn set_current_item_index(mut self, item_index: usize) -> Self {
+    pub fn set_current_item_index(mut self, item_index: usize) -> Self {
         self.dropdown.set_current_item_index(item_index);
         self
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct QuickfixListItem {
+pub struct QuickfixListItem {
     /// This field is for performance optimization,
     /// if it exists, then we do not need to query the filesystem
     /// for the contain of this line (specified by `self.location.range.start.line`).
@@ -197,11 +197,7 @@ impl From<Location> for QuickfixListItem {
 }
 
 impl QuickfixListItem {
-    pub(crate) fn new(
-        location: Location,
-        info: Option<Info>,
-        line: Option<String>,
-    ) -> QuickfixListItem {
+    pub fn new(location: Location, info: Option<Info>, line: Option<String>) -> QuickfixListItem {
         QuickfixListItem {
             location,
             info,
@@ -209,24 +205,24 @@ impl QuickfixListItem {
         }
     }
 
-    pub(crate) fn location(&self) -> &Location {
+    pub fn location(&self) -> &Location {
         &self.location
     }
 
-    pub(crate) fn info(&self) -> &Option<Info> {
+    pub fn info(&self) -> &Option<Info> {
         &self.info
     }
 
     #[cfg(test)]
-    pub(crate) fn set_info(self, info: Option<Info>) -> Self {
+    pub fn set_info(self, info: Option<Info>) -> Self {
         Self { info, ..self }
     }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub(crate) struct Location {
-    pub(crate) path: CanonicalizedPath,
-    pub(crate) range: CharIndexRange,
+pub struct Location {
+    pub path: CanonicalizedPath,
+    pub range: CharIndexRange,
 }
 
 impl Location {
@@ -293,14 +289,14 @@ impl Ord for Location {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum QuickfixListType {
+pub enum QuickfixListType {
     Diagnostic(DiagnosticSeverityRange),
     Items(Vec<QuickfixListItem>),
     Mark,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Copy)]
-pub(crate) enum DiagnosticSeverityRange {
+pub enum DiagnosticSeverityRange {
     All,
     Error,
     Warning,
@@ -308,7 +304,7 @@ pub(crate) enum DiagnosticSeverityRange {
     Hint,
 }
 impl DiagnosticSeverityRange {
-    pub(crate) fn contains(&self, severity: Option<DiagnosticSeverity>) -> bool {
+    pub fn contains(&self, severity: Option<DiagnosticSeverity>) -> bool {
         matches!(
             (self, severity),
             (DiagnosticSeverityRange::All, _)

--- a/src/recipes.rs
+++ b/src/recipes.rs
@@ -7,7 +7,7 @@ use crate::{
     test_app::*,
 };
 
-pub(crate) fn recipe_groups() -> Vec<RecipeGroup> {
+pub fn recipe_groups() -> Vec<RecipeGroup> {
     [
         swap_cursors(),
         swap_current_selection_using_a_different_selection_mode(),
@@ -1710,7 +1710,7 @@ pub(crate) fn run(path: Option<CanonicalizedPath>) -> anyhow::Result<()> {
                     file_extension: "rs",
                     prepare_events: &[],
                     events: keys!("n d p r i n t enter r r d v l r f"),
-                    expectations: Box::new([CurrentComponentContent(r#"pub(crate) fn run(path: Option<CanonicalizedPath>) -> anyhow::Result<()> {
+                     expectations: Box::new([CurrentComponentContent(r#"pub(crate) fn run(path: Option<CanonicalizedPath>) -> anyhow::Result<()> {
     let (sender, receiver) = std::sync::mpsc::channel();
     let syntax_highlighter_sender = syntax_highlight::start_thread(sender.clone());
     let mut app = App::from_channel(

--- a/src/rectangle.rs
+++ b/src/rectangle.rs
@@ -10,18 +10,18 @@ use crate::{
 
 #[derive(Debug, PartialEq, Eq, Default, Clone)]
 /// A struct to represent a rectangle with origin, width and height
-pub(crate) struct Rectangle {
-    pub(crate) origin: Position,
-    pub(crate) width: usize,
-    pub(crate) height: usize,
+pub struct Rectangle {
+    pub origin: Position,
+    pub width: usize,
+    pub height: usize,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 /// A struct to represent a border with direction, start and length
-pub(crate) struct Border {
-    pub(crate) direction: BorderDirection,
-    pub(crate) start: Position,
-    pub(crate) length: usize,
+pub struct Border {
+    pub direction: BorderDirection,
+    pub start: Position,
+    pub length: usize,
 }
 
 impl Border {
@@ -50,7 +50,7 @@ impl Border {
         }
     }
 
-    pub(crate) fn to_positioned_cells(&self, border_style: Style) -> Vec<PositionedCell> {
+    pub fn to_positioned_cells(&self, border_style: Style) -> Vec<PositionedCell> {
         self.positions()
             .into_iter()
             .map(|position| PositionedCell {
@@ -95,7 +95,7 @@ impl Border {
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 // An enum to represent the direction of a border (horizontal or vertical)
-pub(crate) enum BorderDirection {
+pub enum BorderDirection {
     Horizontal,
     Vertical,
 }
@@ -105,7 +105,7 @@ enum Element {
     Border(Border),
 }
 
-pub(crate) fn spread(length: usize, count: usize) -> Vec<usize> {
+pub fn spread(length: usize, count: usize) -> Vec<usize> {
     if count == 0 {
         return vec![];
     }
@@ -332,7 +332,7 @@ impl Rectangle {
 
     // A method to generate a vector of rectangles and a vector of borders based on bspwm tiling algorithm
     #[cfg(test)]
-    pub(crate) fn generate_binary_partition(
+    pub fn generate_binary_partition(
         count: usize,
         dimension: Dimension,
     ) -> (Vec<Rectangle>, Vec<Border>) {
@@ -376,7 +376,7 @@ impl Rectangle {
         (rectangles, borders)
     }
 
-    pub(crate) fn dimension(&self) -> Dimension {
+    pub fn dimension(&self) -> Dimension {
         Dimension {
             width: self.width,
             height: self.height,
@@ -384,7 +384,7 @@ impl Rectangle {
     }
 
     /// Split the rectangle horizontally at the given line.
-    pub(crate) fn split_horizontally_at(&self, line: usize) -> (Rectangle, Rectangle) {
+    pub fn split_horizontally_at(&self, line: usize) -> (Rectangle, Rectangle) {
         let up = Rectangle {
             origin: self.origin,
             width: self.width,
@@ -398,7 +398,7 @@ impl Rectangle {
         (up, bottom)
     }
 
-    pub(crate) fn split_vertically_at(&self, column: usize) -> (Rectangle, Rectangle) {
+    pub fn split_vertically_at(&self, column: usize) -> (Rectangle, Rectangle) {
         let left = Rectangle {
             origin: self.origin,
             width: column,
@@ -446,7 +446,7 @@ impl Rectangle {
         }
     }
 
-    pub(crate) fn generate(
+    pub fn generate(
         kind: LayoutKind,
         count: usize,
         ratio: f32,
@@ -460,7 +460,7 @@ impl Rectangle {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum LayoutKind {
+pub enum LayoutKind {
     #[allow(unused)]
     Tall,
     Wide,

--- a/src/render_flex_layout.rs
+++ b/src/render_flex_layout.rs
@@ -3,7 +3,7 @@ use unicode_width::UnicodeWidthStr;
 
 use crate::utils::distribute_items;
 
-pub(crate) enum FlexLayoutComponent {
+pub enum FlexLayoutComponent {
     Text(String),
     Spacer,
 }
@@ -15,7 +15,7 @@ pub(crate) enum FlexLayoutComponent {
 /// - `width`: Target width of the rendered output in character cells
 ///
 /// Returns a String formatted according to the layout rules.
-pub(crate) fn render_flex_layout(
+pub fn render_flex_layout(
     width: usize,
     separator: &str,
     components: &[FlexLayoutComponent],

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 #[derive(Default, Clone)]
-pub(crate) struct Screen {
+pub struct Screen {
     windows: Vec<Window>,
     borders: Vec<Border>,
     cursor: Option<crate::components::component::Cursor>,
@@ -17,7 +17,7 @@ pub(crate) struct Screen {
 }
 
 impl Screen {
-    pub(crate) fn new(
+    pub fn new(
         windows: Vec<Window>,
         borders: Vec<Border>,
         cursor: Option<crate::components::component::Cursor>,
@@ -34,7 +34,7 @@ impl Screen {
     /// This takes a `&mut self` instead of a `&self` because memoization.
     /// Memoization is necessary because there are other functions that depends on the result of this function,
     /// for example `Screen::dimension`.
-    pub(crate) fn get_positioned_cells(&mut self) -> Vec<PositionedCell> {
+    pub fn get_positioned_cells(&mut self) -> Vec<PositionedCell> {
         if let Some(positioned_cells) = self.memoized_positioned_cells.clone() {
             positioned_cells
         } else {
@@ -56,12 +56,12 @@ impl Screen {
         }
     }
 
-    pub(crate) fn cursor(&self) -> Option<crate::components::component::Cursor> {
+    pub fn cursor(&self) -> Option<crate::components::component::Cursor> {
         self.cursor.clone()
     }
 
     /// The `new_screen` need not be the same size as the old screen (`self`).
-    pub(crate) fn diff(&mut self, old_screen: &mut Screen) -> Vec<PositionedCell> {
+    pub fn diff(&mut self, old_screen: &mut Screen) -> Vec<PositionedCell> {
         // We use `IndexSet` instead of `HashSet` because the latter does not preserve ordering,
         // which can cause re-render to flicker like old TV (at least on Kitty term)
 
@@ -74,7 +74,7 @@ impl Screen {
     }
 
     #[cfg(test)]
-    pub(crate) fn stringify(&mut self) -> String {
+    pub fn stringify(&mut self) -> String {
         self.get_positioned_cells()
             .into_iter()
             .chunk_by(|cell| cell.position.line)
@@ -98,7 +98,7 @@ impl Screen {
             .join("\n")
     }
 
-    pub(crate) fn dimension(&mut self) -> Dimension {
+    pub fn dimension(&mut self) -> Dimension {
         let cells = self.get_positioned_cells();
         let max_column = cells
             .iter()
@@ -116,20 +116,20 @@ impl Screen {
         }
     }
 
-    pub(crate) fn add_window(mut self, window: Window) -> Screen {
+    pub fn add_window(mut self, window: Window) -> Screen {
         self.windows.push(window);
         self
     }
 }
 
 #[derive(Clone)]
-pub(crate) struct Window {
+pub struct Window {
     grid: Grid,
     rectangle: Rectangle,
 }
 
 impl Window {
-    pub(crate) fn to_positioned_cells(&self) -> Vec<PositionedCell> {
+    pub fn to_positioned_cells(&self) -> Vec<PositionedCell> {
         self.grid
             .to_positioned_cells()
             .into_iter()
@@ -140,7 +140,7 @@ impl Window {
             .collect()
     }
 
-    pub(crate) fn new(grid: Grid, rectangle: Rectangle) -> Self {
+    pub fn new(grid: Grid, rectangle: Rectangle) -> Self {
         Self { grid, rectangle }
     }
 }

--- a/src/scripting.rs
+++ b/src/scripting.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use shared::canonicalized_path::CanonicalizedPath;
 use std::{io::Write, ops::Range, process::Stdio};
 
-pub(crate) const LEADER_KEYMAP_LAYOUT: KeyboardMeaningLayout = [
+pub const LEADER_KEYMAP_LAYOUT: KeyboardMeaningLayout = [
     [
         __Q__, __W__, __E__, __R__, __T__, /****/ __Y__, __U__, __I__, __O__, __P__,
     ],
@@ -23,14 +23,14 @@ pub(crate) const LEADER_KEYMAP_LAYOUT: KeyboardMeaningLayout = [
     ],
 ];
 
-pub(crate) fn leader_meanings() -> Vec<Meaning> {
+pub fn leader_meanings() -> Vec<Meaning> {
     LEADER_KEYMAP_LAYOUT
         .iter()
         .flat_map(|row| row.iter().cloned())
         .collect_vec()
 }
 
-pub(crate) fn custom_keymap() -> Vec<CustomActionKeymap> {
+pub fn custom_keymap() -> Vec<CustomActionKeymap> {
     AppConfig::singleton()
         .leader_keymap()
         .keybindings()
@@ -46,33 +46,33 @@ pub(crate) fn custom_keymap() -> Vec<CustomActionKeymap> {
 }
 
 #[derive(Clone, Deserialize, Serialize, JsonSchema)]
-pub(crate) struct Keybinding {
-    pub(crate) name: String,
-    pub(crate) script: Script,
+pub struct Keybinding {
+    pub name: String,
+    pub script: Script,
 }
 
-pub(crate) type CustomActionKeymap = (Meaning, String, Script);
+pub type CustomActionKeymap = (Meaning, String, Script);
 
 #[derive(Serialize, Clone, JsonSchema)]
-pub(crate) struct ScriptInput {
-    pub(crate) current_file_path: Option<String>,
+pub struct ScriptInput {
+    pub current_file_path: Option<String>,
     /// 0-based index
-    pub(crate) selections: Vec<Selection>,
+    pub selections: Vec<Selection>,
 }
 
 #[derive(Serialize, Clone, JsonSchema)]
-pub(crate) struct Selection {
-    pub(crate) content: String,
-    pub(crate) range: Range<Position>,
+pub struct Selection {
+    pub content: String,
+    pub range: Range<Position>,
 }
 
 #[derive(Deserialize, JsonSchema)]
-pub(crate) struct ScriptOutput {
-    pub(crate) dispatches: Vec<ScriptDispatch>,
+pub struct ScriptOutput {
+    pub dispatches: Vec<ScriptDispatch>,
 }
 
 #[derive(Serialize, Deserialize, JsonSchema, Debug, PartialEq, Clone)]
-pub(crate) enum ScriptDispatch {
+pub enum ScriptDispatch {
     ShowInfo { title: String, content: String },
     ReplaceSelections(Vec<String>),
 }
@@ -83,16 +83,13 @@ struct ScriptName(String);
 
 #[derive(Clone, Deserialize, Serialize, JsonSchema, Debug)]
 #[serde(try_from = "ScriptName", into = "ScriptName")]
-pub(crate) struct Script {
-    pub(crate) path: CanonicalizedPath,
-    pub(crate) name: String,
+pub struct Script {
+    pub path: CanonicalizedPath,
+    pub name: String,
 }
 
 impl Script {
-    pub(crate) fn execute(
-        &self,
-        context: crate::scripting::ScriptInput,
-    ) -> anyhow::Result<ScriptOutput> {
+    pub fn execute(&self, context: crate::scripting::ScriptInput) -> anyhow::Result<ScriptOutput> {
         let json = serde_json::to_string(&context)?;
 
         let mut child = std::process::Command::new(self.path.display_absolute())
@@ -136,7 +133,7 @@ impl From<Script> for ScriptName {
 }
 
 impl ScriptDispatch {
-    pub(crate) fn into_app_dispatch(self) -> Dispatch {
+    pub fn into_app_dispatch(self) -> Dispatch {
         match self {
             ScriptDispatch::ShowInfo { title, content } => {
                 Dispatch::ShowGlobalInfo(Info::new(title, content))

--- a/src/search.rs
+++ b/src/search.rs
@@ -7,7 +7,7 @@ use crate::{
     list::grep::RegexConfig,
 };
 
-pub(crate) fn parse_search_config(input: &str) -> anyhow::Result<GlobalSearchConfig> {
+pub fn parse_search_config(input: &str) -> anyhow::Result<GlobalSearchConfig> {
     let default = || {
         Ok(GlobalSearchConfig {
             include_glob: None,

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -19,11 +19,11 @@ use crate::{
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct SelectionSet {
+pub struct SelectionSet {
     /// 0 means the cursor is at the first selection
-    pub(crate) cursor_index: usize,
-    pub(crate) selections: NonEmpty<Selection>,
-    pub(crate) mode: Alternator<SelectionMode>,
+    pub cursor_index: usize,
+    pub selections: NonEmpty<Selection>,
+    pub mode: Alternator<SelectionMode>,
     /// This will be set when a vertical movement is executed.
     /// Once set, its value will not changed.
     /// A non-vertical movement will reset its value to None.
@@ -42,14 +42,14 @@ impl Default for SelectionSet {
 }
 
 impl SelectionSet {
-    pub(crate) fn map<F, A>(&self, f: F) -> NonEmpty<A>
+    pub fn map<F, A>(&self, f: F) -> NonEmpty<A>
     where
         F: Fn(&Selection) -> A,
     {
         self.selections.clone().map(|selection| f(&selection))
     }
 
-    pub(crate) fn map_with_index<F, A>(&self, f: F) -> NonEmpty<A>
+    pub fn map_with_index<F, A>(&self, f: F) -> NonEmpty<A>
     where
         F: Fn(usize, &Selection) -> A,
     {
@@ -61,17 +61,13 @@ impl SelectionSet {
         })
     }
 
-    pub(crate) fn only(&mut self) {
+    pub fn only(&mut self) {
         self.selections.head = self.primary_selection().clone().set_initial_range(None);
         self.selections.tail.clear();
         self.cursor_index = 0;
     }
 
-    pub(crate) fn apply<F>(
-        &self,
-        mode: Alternator<SelectionMode>,
-        f: F,
-    ) -> anyhow::Result<SelectionSet>
+    pub fn apply<F>(&self, mode: Alternator<SelectionMode>, f: F) -> anyhow::Result<SelectionSet>
     where
         F: Fn(&Selection) -> anyhow::Result<Selection>,
     {
@@ -87,14 +83,14 @@ impl SelectionSet {
         })
     }
 
-    pub(crate) fn move_left(&mut self, cursor_direction: &Direction) {
+    pub fn move_left(&mut self, cursor_direction: &Direction) {
         self.apply_mut(|selection| {
             let cursor_char_index = selection.to_char_index(cursor_direction);
             selection.range = (cursor_char_index - 1..cursor_char_index - 1).into()
         });
     }
 
-    pub(crate) fn move_right(&mut self, cursor_direction: &Direction, len_chars: usize) {
+    pub fn move_right(&mut self, cursor_direction: &Direction, len_chars: usize) {
         self.apply_mut(|selection| {
             let cursor_char_index = selection.to_char_index(cursor_direction);
             let next = (cursor_char_index + 1).min(CharIndex(len_chars));
@@ -102,7 +98,7 @@ impl SelectionSet {
         });
     }
 
-    pub(crate) fn apply_mut<F, A>(&mut self, f: F) -> NonEmpty<A>
+    pub fn apply_mut<F, A>(&mut self, f: F) -> NonEmpty<A>
     where
         F: Fn(&mut Selection) -> A,
     {
@@ -112,7 +108,7 @@ impl SelectionSet {
         NonEmpty { head, tail }
     }
 
-    pub(crate) fn generate(
+    pub fn generate(
         &self,
         buffer: &Buffer,
         mode: &SelectionMode,
@@ -147,7 +143,7 @@ impl SelectionSet {
     }
 
     /// Returns `false` if no new selection is added
-    pub(crate) fn add_selection(
+    pub fn add_selection(
         &mut self,
         buffer: &Buffer,
         movement: &MovementApplicandum,
@@ -195,11 +191,11 @@ impl SelectionSet {
         Ok(self.selections.len() > initial_selections_length)
     }
 
-    pub(crate) fn mode(&self) -> &SelectionMode {
+    pub fn mode(&self) -> &SelectionMode {
         self.mode.primary()
     }
 
-    pub(crate) fn all_selections(
+    pub fn all_selections(
         &self,
         buffer: &Buffer,
         cursor_direction: &Direction,
@@ -250,7 +246,7 @@ impl SelectionSet {
             Ok(None)
         }
     }
-    pub(crate) fn add_all(
+    pub fn add_all(
         &mut self,
         buffer: &Buffer,
         cursor_direction: &Direction,
@@ -263,43 +259,43 @@ impl SelectionSet {
         Ok(())
     }
     #[cfg(test)]
-    pub(crate) fn escape_highlight_mode(&mut self) {
+    pub fn escape_highlight_mode(&mut self) {
         self.apply_mut(|selection| selection.disable_extension());
     }
 
-    pub(crate) fn enable_selection_extension(&mut self) {
+    pub fn enable_selection_extension(&mut self) {
         self.mode.copy_primary_to_secondary();
 
         self.apply_mut(|selection| selection.enable_selection_extension());
     }
 
-    pub(crate) fn swap_anchor(&mut self) {
+    pub fn swap_anchor(&mut self) {
         self.mode.cycle();
         self.apply_mut(|selection| selection.swap_initial_range_direction());
     }
 
-    pub(crate) fn clamp(&self, max_char_index: CharIndex) -> anyhow::Result<SelectionSet> {
+    pub fn clamp(&self, max_char_index: CharIndex) -> anyhow::Result<SelectionSet> {
         self.apply(self.mode.clone(), |selection| {
             Ok(selection.clamp(max_char_index))
         })
     }
 
-    pub(crate) fn len(&self) -> usize {
+    pub fn len(&self) -> usize {
         self.selections.len()
     }
 
-    pub(crate) fn unset_initial_range(&mut self) {
+    pub fn unset_initial_range(&mut self) {
         self.apply_mut(|selection| selection.initial_range = None);
     }
 
-    pub(crate) fn new(selections: NonEmpty<Selection>) -> Self {
+    pub fn new(selections: NonEmpty<Selection>) -> Self {
         Self {
             selections,
             ..Default::default()
         }
     }
 
-    pub(crate) fn primary_selection(&self) -> &Selection {
+    pub fn primary_selection(&self) -> &Selection {
         if let Some(selection) = self.selections.get(self.cursor_index) {
             selection
         } else {
@@ -315,7 +311,7 @@ impl SelectionSet {
         }
     }
 
-    pub(crate) fn set_selections(self, selections: NonEmpty<Selection>) -> SelectionSet {
+    pub fn set_selections(self, selections: NonEmpty<Selection>) -> SelectionSet {
         Self {
             cursor_index: self.cursor_index.min(selections.len() - 1),
             selections,
@@ -323,14 +319,14 @@ impl SelectionSet {
         }
     }
 
-    pub(crate) fn set_mode(self, mode: SelectionMode) -> SelectionSet {
+    pub fn set_mode(self, mode: SelectionMode) -> SelectionSet {
         Self {
             mode: self.mode.replace_primary(mode),
             ..self
         }
     }
 
-    pub(crate) fn secondary_selections(&self) -> Vec<&Selection> {
+    pub fn secondary_selections(&self) -> Vec<&Selection> {
         self.selections
             .iter()
             .enumerate()
@@ -339,7 +335,7 @@ impl SelectionSet {
             .collect_vec()
     }
 
-    pub(crate) fn apply_edit(self, edit: &crate::edit::Edit, max_char_index: CharIndex) -> Self {
+    pub fn apply_edit(self, edit: &crate::edit::Edit, max_char_index: CharIndex) -> Self {
         let NonEmpty { head, tail } = self.selections;
         let head = head
             .clone()
@@ -362,7 +358,7 @@ impl SelectionSet {
         Self { selections, ..self }
     }
 
-    pub(crate) fn cycle_primary_selection(&mut self, direction: Direction) {
+    pub fn cycle_primary_selection(&mut self, direction: Direction) {
         let sorted_ranges = self
             .selections
             .iter()
@@ -402,15 +398,15 @@ impl SelectionSet {
         }
     }
 
-    pub(crate) fn is_extended(&self) -> bool {
+    pub fn is_extended(&self) -> bool {
         self.primary_selection().initial_range.is_some()
     }
 
-    pub(crate) fn selections(&self) -> &NonEmpty<Selection> {
+    pub fn selections(&self) -> &NonEmpty<Selection> {
         &self.selections
     }
 
-    pub(crate) fn delete_current_selection(&mut self, direction: Direction) {
+    pub fn delete_current_selection(&mut self, direction: Direction) {
         let index = self.cursor_index;
         match self
             .selections
@@ -435,13 +431,13 @@ impl SelectionSet {
         }
     }
 
-    pub(crate) fn sticky_column_index(&self) -> &Option<usize> {
+    pub fn sticky_column_index(&self) -> &Option<usize> {
         &self.sticky_column_index
     }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub(crate) enum SelectionMode {
+pub enum SelectionMode {
     // Regex
     Subword,
     Word,
@@ -468,12 +464,12 @@ pub(crate) enum SelectionMode {
     BigWord,
 }
 impl SelectionMode {
-    pub(crate) fn is_node(&self) -> bool {
+    pub fn is_node(&self) -> bool {
         use SelectionMode::*;
         matches!(self, SyntaxNode | SyntaxNodeFine)
     }
 
-    pub(crate) fn display(&self) -> String {
+    pub fn display(&self) -> String {
         match self {
             SelectionMode::Line => "LINE".to_string(),
             SelectionMode::LineFull => "LINE*".to_string(),
@@ -499,7 +495,7 @@ impl SelectionMode {
         }
     }
 
-    pub(crate) fn to_selection_mode_trait_object(
+    pub fn to_selection_mode_trait_object(
         &self,
         buffer: &Buffer,
         current_selection: &Selection,
@@ -514,11 +510,11 @@ impl SelectionMode {
             cursor_direction,
         };
         Ok(match self {
-            SelectionMode::Subword => Box::new(PositionBased(selection_mode::Subword::new())),
+            SelectionMode::Subword => Box::new(PositionBased(selection_mode::Subword)),
             SelectionMode::Word => Box::new(PositionBased(selection_mode::Word)),
             SelectionMode::BigWord => Box::new(PositionBased(selection_mode::BigWord)),
             SelectionMode::Line => Box::new(PositionBased(selection_mode::LineTrimmed)),
-            SelectionMode::LineFull => Box::new(PositionBased(selection_mode::LineFull::new())),
+            SelectionMode::LineFull => Box::new(PositionBased(selection_mode::LineFull)),
             SelectionMode::Character => Box::new(PositionBased(selection_mode::Character)),
             SelectionMode::Custom => Box::new(IterBased(selection_mode::Custom::new(
                 current_selection.clone(),
@@ -557,7 +553,7 @@ impl SelectionMode {
         })
     }
 
-    pub(crate) fn is_contiguous(&self) -> bool {
+    pub fn is_contiguous(&self) -> bool {
         matches!(
             self,
             SelectionMode::Subword
@@ -579,7 +575,7 @@ impl From<Selection> for ApplyMovementResult {
 }
 
 #[derive(PartialEq, Clone, Debug, Eq, Hash, Default)]
-pub(crate) struct Selection {
+pub struct Selection {
     pub range: CharIndexRange,
 
     /// Used for extended selection.
@@ -592,32 +588,32 @@ pub(crate) struct Selection {
 }
 
 impl Selection {
-    pub(crate) fn to_char_index(&self, cursor_direction: &Direction) -> CharIndex {
+    pub fn to_char_index(&self, cursor_direction: &Direction) -> CharIndex {
         match cursor_direction {
             Direction::Start => self.range.start,
             Direction::End => (self.range.end - 1).max(self.range.start),
         }
     }
 
-    pub(crate) fn new(range: CharIndexRange) -> Self {
+    pub fn new(range: CharIndexRange) -> Self {
         Selection {
             range,
             ..Selection::default()
         }
     }
 
-    pub(crate) fn set_initial_range(self, initial_range: Option<CharIndexRange>) -> Self {
+    pub fn set_initial_range(self, initial_range: Option<CharIndexRange>) -> Self {
         Selection {
             initial_range,
             ..self
         }
     }
 
-    pub(crate) fn set_info(self, info: Option<Info>) -> Self {
+    pub fn set_info(self, info: Option<Info>) -> Self {
         Selection { info, ..self }
     }
 
-    pub(crate) fn extended_range(&self) -> CharIndexRange {
+    pub fn extended_range(&self) -> CharIndexRange {
         match &self.initial_range {
             None => self.range,
             Some(extended_selection_anchor) => {
@@ -629,7 +625,7 @@ impl Selection {
     }
 
     #[cfg(test)]
-    pub(crate) fn default() -> Selection {
+    pub fn default() -> Selection {
         Selection {
             range: (CharIndex(0)..CharIndex(0)).into(),
             initial_range: None,
@@ -637,7 +633,7 @@ impl Selection {
         }
     }
 
-    pub(crate) fn get_selection_(
+    pub fn get_selection_(
         buffer: &Buffer,
         current_selection: &Selection,
         mode: &SelectionMode,
@@ -663,18 +659,18 @@ impl Selection {
         selection_mode.apply_movement(&params, *movement)
     }
     #[cfg(test)]
-    pub(crate) fn disable_extension(&mut self) {
+    pub fn disable_extension(&mut self) {
         log::info!("escape highlight mode");
         self.initial_range = None
     }
 
-    pub(crate) fn enable_selection_extension(&mut self) {
+    pub fn enable_selection_extension(&mut self) {
         if self.initial_range.is_none() {
             self.enable_extension();
         }
     }
 
-    pub(crate) fn swap_initial_range_direction(&mut self) {
+    pub fn swap_initial_range_direction(&mut self) {
         if let Some(initial_range) = self.initial_range.take() {
             self.initial_range = Some(std::mem::replace(&mut self.range, initial_range));
         }
@@ -690,21 +686,21 @@ impl Selection {
         }
     }
 
-    pub(crate) fn info(&self) -> Option<Info> {
+    pub fn info(&self) -> Option<Info> {
         self.info.clone()
     }
 
-    pub(crate) fn set_range(self, range: CharIndexRange) -> Selection {
+    pub fn set_range(self, range: CharIndexRange) -> Selection {
         Selection { range, ..self }
     }
 
     /// WARNING: You should always use `extended_range` unless you know what you are doing
     /// This always represent the non-extended range
-    pub(crate) fn range(&self) -> CharIndexRange {
+    pub fn range(&self) -> CharIndexRange {
         self.range
     }
 
-    pub(crate) fn anchors(&self) -> Vec<CharIndexRange> {
+    pub fn anchors(&self) -> Vec<CharIndexRange> {
         Vec::new()
             .into_iter()
             .chain([self.range])
@@ -712,7 +708,7 @@ impl Selection {
             .collect_vec()
     }
 
-    pub(crate) fn get_anchor(&self, cursor_direction: &Direction) -> CharIndex {
+    pub fn get_anchor(&self, cursor_direction: &Direction) -> CharIndex {
         match cursor_direction {
             Direction::Start => self.extended_range().start,
             Direction::End => self.extended_range().end,
@@ -737,7 +733,7 @@ impl Selection {
         })
     }
 
-    pub(crate) fn collapsed_to_anchor_range(self, direction: &Direction) -> Self {
+    pub fn collapsed_to_anchor_range(self, direction: &Direction) -> Self {
         let range = if let Some(initial_range) = self.initial_range {
             let (start, end) = if initial_range.start < self.range.start {
                 (initial_range, self.range)
@@ -754,7 +750,7 @@ impl Selection {
         self.set_range(range).set_initial_range(None)
     }
 
-    pub(crate) fn update_with_byte_range(
+    pub fn update_with_byte_range(
         self,
         buffer: &Buffer,
         byte_range: selection_mode::ByteRange,
@@ -764,7 +760,7 @@ impl Selection {
             .set_range(buffer.byte_range_to_char_index_range(byte_range.range())?))
     }
 
-    pub(crate) fn apply_offset(self, offset: isize) -> Selection {
+    pub fn apply_offset(self, offset: isize) -> Selection {
         let new_range = self.range.apply_offset(offset);
         let new_initial_range = self.initial_range.map(|range| range.apply_offset(offset));
         self.set_range(new_range)
@@ -825,10 +821,10 @@ impl Sub<usize> for CharIndex {
     serde::Serialize,
     serde::Deserialize,
 )]
-pub(crate) struct CharIndex(pub usize);
+pub struct CharIndex(pub usize);
 
 impl CharIndex {
-    pub(crate) fn to_position(self, buffer: &Buffer) -> Position {
+    pub fn to_position(self, buffer: &Buffer) -> Position {
         let line = self.to_line(buffer).unwrap_or(0);
         Position {
             line,
@@ -840,11 +836,11 @@ impl CharIndex {
         }
     }
 
-    pub(crate) fn to_line(self, buffer: &Buffer) -> anyhow::Result<usize> {
+    pub fn to_line(self, buffer: &Buffer) -> anyhow::Result<usize> {
         Ok(buffer.rope().try_char_to_line(self.0)?)
     }
 
-    pub(crate) fn apply_offset(&self, change: isize) -> CharIndex {
+    pub fn apply_offset(&self, change: isize) -> CharIndex {
         if change.is_positive() {
             *self + (change as usize)
         } else {

--- a/src/selection_mode/ast_grep.rs
+++ b/src/selection_mode/ast_grep.rs
@@ -2,13 +2,13 @@ use ast_grep_core::{language::TSLanguage, NodeMatch, StrDoc};
 
 use super::{ByteRange, IterBasedSelectionMode};
 
-pub(crate) struct AstGrep {
+pub struct AstGrep {
     pattern: ast_grep_core::matcher::Pattern<TSLanguage>,
     grep: ast_grep_core::AstGrep<StrDoc<TSLanguage>>,
 }
 
 impl AstGrep {
-    pub(crate) fn new(buffer: &crate::buffer::Buffer, pattern: &str) -> anyhow::Result<Self> {
+    pub fn new(buffer: &crate::buffer::Buffer, pattern: &str) -> anyhow::Result<Self> {
         let Some(language) = buffer.treesitter_language() else {
             return Err(anyhow::anyhow!(
                 "Unable to launch AST Grep because no Tree-sitter language is found."
@@ -20,7 +20,7 @@ impl AstGrep {
         Ok(Self { pattern, grep })
     }
 
-    pub(crate) fn replace(
+    pub fn replace(
         language: tree_sitter::Language,
         source_code: &str,
         pattern: &str,
@@ -33,7 +33,7 @@ impl AstGrep {
         Ok(grep.root().replace_all(pattern.clone(), replacement))
     }
 
-    pub(crate) fn find_all(&self) -> impl Iterator<Item = NodeMatch<'_, StrDoc<TSLanguage>>> {
+    pub fn find_all(&self) -> impl Iterator<Item = NodeMatch<'_, StrDoc<TSLanguage>>> {
         self.grep.root().find_all(self.pattern.clone())
     }
 }

--- a/src/selection_mode/big_word.rs
+++ b/src/selection_mode/big_word.rs
@@ -84,7 +84,7 @@ impl PositionBasedSelectionMode for BigWord {
     }
 }
 
-pub(crate) fn process_paste_gap(prev_gap: Option<String>, next_gap: Option<String>) -> String {
+pub fn process_paste_gap(prev_gap: Option<String>, next_gap: Option<String>) -> String {
     match (prev_gap, next_gap) {
         (None, None) => Default::default(),
         (None, Some(gap)) | (Some(gap), None) => gap,

--- a/src/selection_mode/character.rs
+++ b/src/selection_mode/character.rs
@@ -5,7 +5,7 @@ use super::{
     SelectionModeTrait, Subword,
 };
 
-pub(crate) struct Character;
+pub struct Character;
 
 impl PositionBasedSelectionMode for Character {
     fn first(
@@ -44,7 +44,7 @@ fn get_char(
     params: &super::SelectionModeParams,
     position: SelectionPosition,
 ) -> anyhow::Result<Option<crate::selection::Selection>> {
-    if let Some(current_word) = PositionBased(Subword::new()).current(
+    if let Some(current_word) = PositionBased(Subword).current(
         params,
         crate::components::editor::IfCurrentNotFound::LookForward,
     )? {

--- a/src/selection_mode/custom.rs
+++ b/src/selection_mode/custom.rs
@@ -2,12 +2,12 @@ use crate::selection::Selection;
 
 use super::IterBasedSelectionMode;
 
-pub(crate) struct Custom {
+pub struct Custom {
     current_selection: Selection,
 }
 
 impl Custom {
-    pub(crate) fn new(current_selection: Selection) -> Custom {
+    pub fn new(current_selection: Selection) -> Custom {
         Custom { current_selection }
     }
 }

--- a/src/selection_mode/diagnostic.rs
+++ b/src/selection_mode/diagnostic.rs
@@ -3,13 +3,13 @@ use crate::{components::suggestive_editor::Info, quickfix_list::DiagnosticSeveri
 use super::IterBasedSelectionMode;
 
 // TODO: change this to custom selections, so it can also hold references, definitions etc
-pub(crate) struct Diagnostic {
+pub struct Diagnostic {
     severity_range: DiagnosticSeverityRange,
     diagnostics: Vec<crate::lsp::diagnostic::Diagnostic>,
 }
 
 impl Diagnostic {
-    pub(crate) fn new(
+    pub fn new(
         severity_range: DiagnosticSeverityRange,
         params: super::SelectionModeParams<'_>,
     ) -> Self {

--- a/src/selection_mode/git_hunk.rs
+++ b/src/selection_mode/git_hunk.rs
@@ -3,12 +3,12 @@ use itertools::Itertools;
 
 use super::{ByteRange, IterBasedSelectionMode};
 
-pub(crate) struct GitHunk {
+pub struct GitHunk {
     ranges: Vec<super::ByteRange>,
 }
 
 impl GitHunk {
-    pub(crate) fn new(
+    pub fn new(
         diff_mode: &crate::git::DiffMode,
         buffer: &Buffer,
         working_directory: &shared::canonicalized_path::CanonicalizedPath,

--- a/src/selection_mode/line_full.rs
+++ b/src/selection_mode/line_full.rs
@@ -4,13 +4,7 @@ use crate::selection_mode::ApplyMovementResult;
 
 use super::{ByteRange, PositionBasedSelectionMode};
 
-pub(crate) struct LineFull;
-
-impl LineFull {
-    pub(crate) fn new() -> Self {
-        Self
-    }
-}
+pub struct LineFull;
 
 impl PositionBasedSelectionMode for LineFull {
     fn up(

--- a/src/selection_mode/line_trimmed.rs
+++ b/src/selection_mode/line_trimmed.rs
@@ -11,7 +11,7 @@ use crate::{
 use super::{ByteRange, PositionBasedSelectionMode, SelectionModeParams};
 
 #[derive(Clone)]
-pub(crate) struct LineTrimmed;
+pub struct LineTrimmed;
 
 impl PositionBasedSelectionMode for LineTrimmed {
     fn get_current_selection_by_cursor(
@@ -621,7 +621,7 @@ fn get_line(
     Ok(Some(ByteRange::new(trimmed_range)))
 }
 
-pub(crate) fn process_paste_gap(
+pub fn process_paste_gap(
     params: &SelectionModeParams,
     prev_gap: Option<String>,
     next_gap: Option<String>,

--- a/src/selection_mode/local_quickfix.rs
+++ b/src/selection_mode/local_quickfix.rs
@@ -3,12 +3,12 @@ use crate::quickfix_list::QuickfixListItem;
 use super::{ByteRange, IterBasedSelectionMode};
 
 // TODO: change this to custom selections, so it can also hold references, definitions etc
-pub(crate) struct LocalQuickfix {
+pub struct LocalQuickfix {
     ranges: Vec<ByteRange>,
 }
 
 impl LocalQuickfix {
-    pub(crate) fn new(
+    pub fn new(
         params: super::SelectionModeParams<'_>,
         quickfix_list_items: Vec<&QuickfixListItem>,
     ) -> Self {

--- a/src/selection_mode/mark.rs
+++ b/src/selection_mode/mark.rs
@@ -2,8 +2,8 @@ use crate::char_index_range::CharIndexRange;
 
 use super::IterBasedSelectionMode;
 
-pub(crate) struct Mark {
-    pub(crate) marks: Vec<CharIndexRange>,
+pub struct Mark {
+    pub marks: Vec<CharIndexRange>,
 }
 
 impl IterBasedSelectionMode for Mark {

--- a/src/selection_mode/mod.rs
+++ b/src/selection_mode/mod.rs
@@ -1,41 +1,41 @@
-pub(crate) mod ast_grep;
-pub(crate) mod character;
-pub(crate) mod custom;
-pub(crate) mod diagnostic;
-pub(crate) mod git_hunk;
-pub(crate) mod mark;
-pub(crate) mod naming_convention_agnostic;
-pub(crate) mod syntax_token;
+pub mod ast_grep;
+pub mod character;
+pub mod custom;
+pub mod diagnostic;
+pub mod git_hunk;
+pub mod mark;
+pub mod naming_convention_agnostic;
+pub mod syntax_token;
 
-pub(crate) mod top_node;
+pub mod top_node;
 
-pub(crate) mod big_word;
-pub(crate) mod line_full;
-pub(crate) mod line_trimmed;
-pub(crate) mod local_quickfix;
-pub(crate) mod regex;
-pub(crate) mod subword;
-pub(crate) mod syntax_node;
-pub(crate) mod word;
-pub(crate) use self::regex::Regex;
-pub(crate) use ast_grep::AstGrep;
-pub(crate) use big_word::BigWord;
-pub(crate) use character::Character;
-pub(crate) use custom::Custom;
-pub(crate) use diagnostic::Diagnostic;
-pub(crate) use git_hunk::GitHunk;
+pub mod big_word;
+pub mod line_full;
+pub mod line_trimmed;
+pub mod local_quickfix;
+pub mod regex;
+pub mod subword;
+pub mod syntax_node;
+pub mod word;
+pub use self::regex::Regex;
+pub use ast_grep::AstGrep;
+pub use big_word::BigWord;
+pub use character::Character;
+pub use custom::Custom;
+pub use diagnostic::Diagnostic;
+pub use git_hunk::GitHunk;
 use itertools::Itertools;
-pub(crate) use line_full::LineFull;
-pub(crate) use line_trimmed::LineTrimmed;
-pub(crate) use local_quickfix::LocalQuickfix;
-pub(crate) use mark::Mark;
-pub(crate) use naming_convention_agnostic::NamingConventionAgnostic;
+pub use line_full::LineFull;
+pub use line_trimmed::LineTrimmed;
+pub use local_quickfix::LocalQuickfix;
+pub use mark::Mark;
+pub use naming_convention_agnostic::NamingConventionAgnostic;
 use position_pair::ParsedChar;
 use std::ops::Range;
-pub(crate) use subword::Subword;
-pub(crate) use syntax_node::SyntaxNode;
-pub(crate) use top_node::TopNode;
-pub(crate) use word::Word;
+pub use subword::Subword;
+pub use syntax_node::SyntaxNode;
+pub use top_node::TopNode;
+pub use word::Word;
 
 use crate::{
     buffer::Buffer,
@@ -50,26 +50,26 @@ use crate::{
 };
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
-pub(crate) struct ByteRange {
+pub struct ByteRange {
     range: Range<usize>,
     info: Option<Info>,
 }
 impl ByteRange {
-    pub(crate) fn new(range: Range<usize>) -> Self {
+    pub fn new(range: Range<usize>) -> Self {
         Self { range, info: None }
     }
 
-    pub(crate) fn with_info(range: Range<usize>, info: Info) -> Self {
+    pub fn with_info(range: Range<usize>, info: Info) -> Self {
         Self {
             range,
             info: Some(info),
         }
     }
-    pub(crate) fn to_char_index_range(&self, buffer: &Buffer) -> anyhow::Result<CharIndexRange> {
+    pub fn to_char_index_range(&self, buffer: &Buffer) -> anyhow::Result<CharIndexRange> {
         Ok((buffer.byte_to_char(self.range.start)?..buffer.byte_to_char(self.range.end)?).into())
     }
 
-    pub(crate) fn to_selection(
+    pub fn to_selection(
         &self,
         buffer: &Buffer,
         selection: &Selection,
@@ -84,11 +84,11 @@ impl ByteRange {
         ByteRange { info, ..self }
     }
 
-    pub(crate) fn range(&self) -> &Range<usize> {
+    pub fn range(&self) -> &Range<usize> {
         &self.range
     }
 
-    pub(crate) fn info(&self) -> Option<Info> {
+    pub fn info(&self) -> Option<Info> {
         self.info.clone()
     }
 }
@@ -108,10 +108,10 @@ impl Ord for ByteRange {
     }
 }
 
-pub(crate) struct SelectionModeParams<'a> {
-    pub(crate) buffer: &'a Buffer,
-    pub(crate) current_selection: &'a Selection,
-    pub(crate) cursor_direction: &'a Direction,
+pub struct SelectionModeParams<'a> {
+    pub buffer: &'a Buffer,
+    pub current_selection: &'a Selection,
+    pub cursor_direction: &'a Direction,
 }
 impl SelectionModeParams<'_> {
     fn cursor_char_index(&self) -> CharIndex {
@@ -265,13 +265,13 @@ impl SelectionModeParams<'_> {
     }
 }
 #[derive(Debug, Clone)]
-pub(crate) struct ApplyMovementResult {
-    pub(crate) selection: Selection,
-    pub(crate) sticky_column_index: Option<usize>,
+pub struct ApplyMovementResult {
+    pub selection: Selection,
+    pub sticky_column_index: Option<usize>,
 }
 
 impl ApplyMovementResult {
-    pub(crate) fn from_selection(selection: Selection) -> Self {
+    pub fn from_selection(selection: Selection) -> Self {
         Self {
             selection,
             sticky_column_index: None,
@@ -1116,8 +1116,8 @@ pub trait PositionBasedSelectionMode {
         Default::default()
     }
 }
-pub(crate) struct PositionBased<T: PositionBasedSelectionMode>(pub(crate) T);
-pub(crate) struct IterBased<T: IterBasedSelectionMode>(pub(crate) T);
+pub struct PositionBased<T: PositionBasedSelectionMode>(pub T);
+pub struct IterBased<T: IterBasedSelectionMode>(pub T);
 
 impl<T: IterBasedSelectionMode> SelectionModeTrait for IterBased<T> {
     fn all_selections<'a>(
@@ -1228,7 +1228,7 @@ impl<T: IterBasedSelectionMode> SelectionModeTrait for IterBased<T> {
     }
 }
 
-pub(crate) trait IterBasedSelectionMode {
+pub trait IterBasedSelectionMode {
     /// NOTE: this method should not be used directly,
     /// Use `iter_filtered` instead.
     /// I wish to have private trait methods :(
@@ -1924,33 +1924,27 @@ mod position_pair {
     use crate::surround::EnclosureKind;
 
     #[derive(Debug, PartialEq)]
-    pub(crate) enum Position {
+    pub enum Position {
         Open,
         Close,
         Escaped,
     }
 
     #[derive(Debug, PartialEq)]
-    pub(crate) enum ParsedChar {
+    pub enum ParsedChar {
         Enclosure(Position, EnclosureKind),
         Other(char),
     }
 
     impl ParsedChar {
-        pub(crate) fn is_closing_of(
-            &self,
-            enclosure_kind: &crate::surround::EnclosureKind,
-        ) -> bool {
+        pub fn is_closing_of(&self, enclosure_kind: &crate::surround::EnclosureKind) -> bool {
             match self {
                 ParsedChar::Enclosure(Position::Close, kind) => kind == enclosure_kind,
                 _ => false,
             }
         }
 
-        pub(crate) fn is_opening_of(
-            &self,
-            enclosure_kind: &crate::surround::EnclosureKind,
-        ) -> bool {
+        pub fn is_opening_of(&self, enclosure_kind: &crate::surround::EnclosureKind) -> bool {
             match self {
                 ParsedChar::Enclosure(Position::Open, kind) => kind == enclosure_kind,
                 _ => false,
@@ -1958,7 +1952,7 @@ mod position_pair {
         }
     }
 
-    pub(crate) fn create_position_pairs(chars: &[char]) -> Vec<ParsedChar> {
+    pub fn create_position_pairs(chars: &[char]) -> Vec<ParsedChar> {
         use EnclosureKind::*;
         use Position::*;
         let mut parsed_chars = Vec::new();

--- a/src/selection_mode/naming_convention_agnostic.rs
+++ b/src/selection_mode/naming_convention_agnostic.rs
@@ -2,12 +2,12 @@ use itertools::Itertools;
 
 use super::{ByteRange, IterBasedSelectionMode};
 
-pub(crate) struct NamingConventionAgnostic {
+pub struct NamingConventionAgnostic {
     pattern: String,
 }
 
 impl NamingConventionAgnostic {
-    pub(crate) fn replace(input: &str, _: &str, replace_pattern: &str) -> anyhow::Result<String> {
+    pub fn replace(input: &str, _: &str, replace_pattern: &str) -> anyhow::Result<String> {
         let case = Self::cases()
             .into_iter()
             .find(|case| convert_case::Casing::is_case(&input, *case))
@@ -18,7 +18,7 @@ impl NamingConventionAgnostic {
 
         Ok(convert_case::Casing::to_case(&replace_pattern, case))
     }
-    pub(crate) fn new(pattern: String) -> Self {
+    pub fn new(pattern: String) -> Self {
         Self { pattern }
     }
     fn cases() -> Vec<convert_case::Case> {
@@ -35,7 +35,7 @@ impl NamingConventionAgnostic {
             .collect()
     }
 
-    pub(crate) fn find_all(&self, haystack: &str) -> Vec<(ByteRange, String)> {
+    pub fn find_all(&self, haystack: &str) -> Vec<(ByteRange, String)> {
         self.possible_patterns()
             .into_iter()
             .flat_map(move |pattern| {
@@ -52,7 +52,7 @@ impl NamingConventionAgnostic {
             .collect()
     }
 
-    pub(crate) fn replace_all(&self, haystack: &str, replace_pattern: String) -> String {
+    pub fn replace_all(&self, haystack: &str, replace_pattern: String) -> String {
         self.find_all(haystack)
             .into_iter()
             .filter_map(move |(_, str)| {

--- a/src/selection_mode/regex.rs
+++ b/src/selection_mode/regex.rs
@@ -2,13 +2,13 @@ use crate::{buffer::Buffer, list::grep::RegexConfig};
 
 use super::{ByteRange, IterBasedSelectionMode};
 
-pub(crate) struct Regex {
+pub struct Regex {
     regex: fancy_regex::Regex,
     content: String,
 }
 
 /// BOTTLENECK 3
-pub(crate) fn get_regex(pattern: &str, config: RegexConfig) -> anyhow::Result<fancy_regex::Regex> {
+pub fn get_regex(pattern: &str, config: RegexConfig) -> anyhow::Result<fancy_regex::Regex> {
     let pattern = if config.escaped {
         regex::escape(pattern)
     } else {
@@ -29,7 +29,7 @@ pub(crate) fn get_regex(pattern: &str, config: RegexConfig) -> anyhow::Result<fa
 }
 
 impl Regex {
-    pub(crate) fn from_config(
+    pub fn from_config(
         buffer: &Buffer,
         pattern: &str,
         config: RegexConfig,

--- a/src/selection_mode/subword.rs
+++ b/src/selection_mode/subword.rs
@@ -7,10 +7,6 @@ const SUBWORD_REGEX: &str =
     r"[A-Z]{2,}(?=[A-Z][a-z])|[A-Z]{2,}|[A-Z][a-z]+|[A-Z]|[a-z]+|[^\w\s]|_|[0-9]+";
 
 impl Subword {
-    pub(crate) fn new() -> Self {
-        Self
-    }
-
     fn get_current_selection(
         &self,
         buffer: &Buffer,
@@ -220,7 +216,7 @@ mod test_subword {
     #[test]
     fn simple_case() {
         let buffer = Buffer::new(None, "snake Case camel");
-        PositionBased(super::Subword::new()).assert_all_selections(
+        PositionBased(super::Subword).assert_all_selections(
             &buffer,
             Selection::default(),
             &[(0..5, "snake"), (6..10, "Case"), (11..16, "camel")],
@@ -233,7 +229,7 @@ mod test_subword {
             None,
             "snake_case camelCase PascalCase UPPER_SNAKE ->() 123 <_> HTTPNetwork X",
         );
-        PositionBased(super::Subword::new()).assert_all_selections(
+        PositionBased(super::Subword).assert_all_selections(
             &buffer,
             Selection::default(),
             &[
@@ -280,7 +276,7 @@ mod test_subword {
     #[test]
     fn consecutive_uppercase_letters() {
         let buffer = Buffer::new(None, "XMLParser JSONObject HTMLElement");
-        PositionBased(super::Subword::new()).assert_all_selections(
+        PositionBased(super::Subword).assert_all_selections(
             &buffer,
             Selection::default(),
             &[
@@ -370,7 +366,7 @@ mod test_subword {
 }
 
 #[derive(Clone, Copy)]
-pub(crate) enum SelectionPosition {
+pub enum SelectionPosition {
     First,
     Last,
 }

--- a/src/selection_mode/syntax_node.rs
+++ b/src/selection_mode/syntax_node.rs
@@ -7,8 +7,8 @@ use crate::{
 
 use super::{ByteRange, IterBasedSelectionMode, TopNode};
 
-pub(crate) struct SyntaxNode {
-    pub(crate) coarse: bool,
+pub struct SyntaxNode {
+    pub coarse: bool,
 }
 
 impl IterBasedSelectionMode for SyntaxNode {
@@ -208,7 +208,7 @@ impl SyntaxNode {
                 .ok()
         }))
     }
-    pub(crate) fn select_vertical(
+    pub fn select_vertical(
         &self,
         params: &super::SelectionModeParams,
         go_up: bool,
@@ -234,11 +234,7 @@ impl SyntaxNode {
     }
 }
 
-pub(crate) fn get_node(
-    node: tree_sitter::Node,
-    go_up: bool,
-    coarse: bool,
-) -> Option<tree_sitter::Node> {
+pub fn get_node(node: tree_sitter::Node, go_up: bool, coarse: bool) -> Option<tree_sitter::Node> {
     match (go_up, coarse) {
         (true, _) => node.parent(),
         (false, true) => node.named_child(0),

--- a/src/selection_mode/syntax_token.rs
+++ b/src/selection_mode/syntax_token.rs
@@ -1,4 +1,4 @@
-pub(crate) struct SyntaxToken;
+pub struct SyntaxToken;
 
 use crate::components::editor::IfCurrentNotFound;
 

--- a/src/selection_mode/top_node.rs
+++ b/src/selection_mode/top_node.rs
@@ -1,7 +1,7 @@
 use super::{ByteRange, IterBasedSelectionMode};
 use itertools::Itertools;
 
-pub(crate) struct TopNode;
+pub struct TopNode;
 
 impl IterBasedSelectionMode for TopNode {
     fn iter<'a>(

--- a/src/selection_mode/word.rs
+++ b/src/selection_mode/word.rs
@@ -65,7 +65,7 @@ impl PositionBasedSelectionMode for Word {
     }
 }
 
-pub(crate) fn process_paste_gap(prev_gap: Option<String>, next_gap: Option<String>) -> String {
+pub fn process_paste_gap(prev_gap: Option<String>, next_gap: Option<String>) -> String {
     match (prev_gap, next_gap) {
         (None, None) => Default::default(),
         (None, Some(gap)) | (Some(gap), None) => gap,

--- a/src/selection_range.rs
+++ b/src/selection_range.rs
@@ -6,12 +6,12 @@ use std::ops::Range;
 use crate::{char_index_range::CharIndexRange, position::Position};
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub(crate) enum SelectionRange {
+pub enum SelectionRange {
     Byte(Range<usize>),
     Position(Range<Position>),
 }
 impl SelectionRange {
-    pub(crate) fn to_char_index_range(
+    pub fn to_char_index_range(
         &self,
         buffer: &crate::buffer::Buffer,
     ) -> anyhow::Result<CharIndexRange> {
@@ -23,7 +23,7 @@ impl SelectionRange {
         }
     }
 
-    pub(crate) fn move_left(&self, count: usize) -> SelectionRange {
+    pub fn move_left(&self, count: usize) -> SelectionRange {
         match self {
             SelectionRange::Byte(_) => todo!(),
             SelectionRange::Position(range) => {

--- a/src/soft_wrap.rs
+++ b/src/soft_wrap.rs
@@ -8,14 +8,14 @@ use crate::{
 };
 
 #[derive(Debug, Clone, Default)]
-pub(crate) struct WrappedLines {
+pub struct WrappedLines {
     width: usize,
     lines: Vec<WrappedLine>,
     ending_with_newline_character: bool,
 }
 
 #[derive(Debug, PartialEq)]
-pub(crate) enum CalibrationError {
+pub enum CalibrationError {
     LineOutOfRange,
     ColumnOutOfRange,
 }
@@ -33,14 +33,14 @@ impl Display for WrappedLines {
     }
 }
 
-pub(crate) struct Positions(Box<dyn Iterator<Item = Position>>);
+pub struct Positions(Box<dyn Iterator<Item = Position>>);
 
 impl Positions {
-    pub(crate) fn into_iter(self) -> Box<dyn Iterator<Item = Position>> {
+    pub fn into_inner(self) -> Box<dyn Iterator<Item = Position>> {
         self.0
     }
 
-    pub(crate) fn first(&mut self) -> Option<Position> {
+    pub fn first(&mut self) -> Option<Position> {
         self.0.next()
     }
 
@@ -50,13 +50,13 @@ impl Positions {
 
     #[cfg(test)]
     fn into_vec(self) -> Vec<Position> {
-        self.into_iter().collect_vec()
+        self.into_inner().collect_vec()
     }
 }
 impl WrappedLines {
     /// The returned value is not one position but potentially multiple positions
     /// because some characters take multiple cells in terminal
-    pub(crate) fn calibrate(&self, position: Position) -> Result<Positions, CalibrationError> {
+    pub fn calibrate(&self, position: Position) -> Result<Positions, CalibrationError> {
         if self.lines.is_empty() && position.line == 0 && position.column == 0 {
             return Ok(Positions::single(Position::new(0, 0)));
         }
@@ -84,7 +84,7 @@ impl WrappedLines {
 
         let width = self.width;
 
-        Ok(Positions(Box::new(new_positions.into_iter().map(
+        Ok(Positions(Box::new(new_positions.into_inner().map(
             move |new_position| {
                 debug_assert!(new_position.column <= width);
                 Position {
@@ -95,17 +95,17 @@ impl WrappedLines {
         ))))
     }
 
-    pub(crate) fn lines(&self) -> &Vec<WrappedLine> {
+    pub fn lines(&self) -> &Vec<WrappedLine> {
         &self.lines
     }
 
-    pub(crate) fn wrapped_lines_count(&self) -> usize {
+    pub fn wrapped_lines_count(&self) -> usize {
         self.lines.iter().map(|line| line.count()).sum()
     }
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct WrappedLine {
+pub struct WrappedLine {
     /// 0-based
     line_number: usize,
     primary: String,
@@ -120,14 +120,14 @@ impl Display for WrappedLine {
     }
 }
 impl WrappedLine {
-    pub(crate) fn lines(&self) -> Vec<String> {
+    pub fn lines(&self) -> Vec<String> {
         [self.primary.clone()]
             .into_iter()
             .chain(self.wrapped.iter().cloned())
             .collect()
     }
 
-    pub(crate) fn line_number(&self) -> usize {
+    pub fn line_number(&self) -> usize {
         self.line_number
     }
 
@@ -168,7 +168,7 @@ impl WrappedLine {
     }
 }
 
-pub(crate) fn soft_wrap(text: &str, width: usize) -> WrappedLines {
+pub fn soft_wrap(text: &str, width: usize) -> WrappedLines {
     let re = lazy_regex::lazy_regex!(r"\b");
 
     // LABEL: NEED_TO_REDUCE_WIDTH_BY_1
@@ -211,7 +211,7 @@ pub(crate) fn soft_wrap(text: &str, width: usize) -> WrappedLines {
     result
 }
 
-pub(crate) fn wrap_items(items: Vec<String>, wrap_width: usize) -> Vec<String> {
+pub fn wrap_items(items: Vec<String>, wrap_width: usize) -> Vec<String> {
     if wrap_width == 0 {
         return Vec::new();
     }

--- a/src/style.rs
+++ b/src/style.rs
@@ -4,11 +4,11 @@ use crate::{
 };
 
 #[derive(Debug, Default, PartialEq, Eq, Clone, Copy, Hash, PartialOrd, Ord)]
-pub(crate) struct Style {
-    pub(crate) foreground_color: Option<Color>,
-    pub(crate) background_color: Option<Color>,
-    pub(crate) line: Option<CellLine>,
-    pub(crate) is_bold: bool,
+pub struct Style {
+    pub foreground_color: Option<Color>,
+    pub background_color: Option<Color>,
+    pub line: Option<CellLine>,
+    pub is_bold: bool,
 }
 
 pub const fn fg(color: Color) -> Style {
@@ -48,32 +48,32 @@ impl Style {
         }
     }
 
-    pub(crate) fn set_some_background_color(self, background_color: Option<Color>) -> Style {
+    pub fn set_some_background_color(self, background_color: Option<Color>) -> Style {
         Style {
             background_color,
             ..self
         }
     }
 
-    pub(crate) fn set_some_foreground_color(self, foreground_color: Option<Color>) -> Style {
+    pub fn set_some_foreground_color(self, foreground_color: Option<Color>) -> Style {
         Style {
             foreground_color,
             ..self
         }
     }
 
-    pub(crate) const fn line(self, line: Option<CellLine>) -> Style {
+    pub const fn line(self, line: Option<CellLine>) -> Style {
         Style { line, ..self }
     }
 
-    pub(crate) const fn underline(self, color: Color) -> Style {
+    pub const fn underline(self, color: Color) -> Style {
         self.line(Some(CellLine {
             color,
             style: CellLineStyle::Underline,
         }))
     }
 
-    pub(crate) const fn undercurl(&self, color: Color) -> Style {
+    pub const fn undercurl(&self, color: Color) -> Style {
         self.line(Some(CellLine {
             color,
             style: CellLineStyle::Undercurl,

--- a/src/surround.rs
+++ b/src/surround.rs
@@ -3,7 +3,7 @@ use itertools::Itertools;
 use crate::selection::CharIndex;
 
 #[derive(Clone, Debug, PartialEq, Eq, Copy)]
-pub(crate) enum EnclosureKind {
+pub enum EnclosureKind {
     Parentheses,
     CurlyBraces,
     AngularBrackets,
@@ -28,7 +28,7 @@ impl std::fmt::Display for EnclosureKind {
 }
 
 /// Return the open index and close index of the given `kind`.
-pub(crate) fn get_surrounding_indices(
+pub fn get_surrounding_indices(
     content: &str,
     kind: EnclosureKind,
     cursor_char_index: CharIndex,
@@ -87,7 +87,7 @@ pub(crate) fn get_surrounding_indices(
 }
 
 impl EnclosureKind {
-    pub(crate) const fn open_close_symbols(&self) -> (char, char) {
+    pub const fn open_close_symbols(&self) -> (char, char) {
         match self {
             EnclosureKind::Parentheses => ('(', ')'),
             EnclosureKind::CurlyBraces => ('{', '}'),
@@ -99,7 +99,7 @@ impl EnclosureKind {
         }
     }
 
-    pub(crate) const fn open_close_symbols_str(&self) -> (&'static str, &'static str) {
+    pub const fn open_close_symbols_str(&self) -> (&'static str, &'static str) {
         match self {
             EnclosureKind::Parentheses => ("(", ")"),
             EnclosureKind::CurlyBraces => ("{", "}"),
@@ -111,7 +111,7 @@ impl EnclosureKind {
         }
     }
 
-    pub(crate) fn to_str(self) -> &'static str {
+    pub fn to_str(self) -> &'static str {
         match self {
             EnclosureKind::Parentheses => "Parentheses",
             EnclosureKind::CurlyBraces => "Curly Braces",

--- a/src/syntax_highlight/mod.rs
+++ b/src/syntax_highlight/mod.rs
@@ -18,9 +18,9 @@ use crate::{
 use shared::language::Language;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct HighlightedSpan {
-    pub(crate) byte_range: Range<usize>,
-    pub(crate) style_key: StyleKey,
+pub struct HighlightedSpan {
+    pub byte_range: Range<usize>,
+    pub style_key: StyleKey,
 }
 
 pub trait GetHighlightConfig {
@@ -108,7 +108,7 @@ impl Highlight for HighlightConfiguration {
 }
 
 #[derive(Clone, Default, Debug)]
-pub(crate) struct HighlightedSpans(pub Vec<HighlightedSpan>);
+pub struct HighlightedSpans(pub Vec<HighlightedSpan>);
 impl HighlightedSpans {
     /// This method only updates the highlight spans within the affected range.
     /// The affected range starts from the smallest point of edit to the last visible range.
@@ -117,7 +117,7 @@ impl HighlightedSpans {
     /// 1. That is expensive due to the huge number of highlight spans
     /// 2. The highlight spans will be recomputed quickly, so there's no point
     ///    in updating the out-of-bound ones.
-    pub(crate) fn apply_edit_mut(&mut self, affected_range: &Range<usize>, change: isize) {
+    pub fn apply_edit_mut(&mut self, affected_range: &Range<usize>, change: isize) {
         if self.0.is_empty() {
             return;
         }
@@ -143,23 +143,23 @@ impl HighlightedSpans {
 }
 
 #[derive(Clone, Default, Debug, PartialEq, Eq)]
-pub(crate) struct SyntaxHighlightRequestBatchId(u8);
+pub struct SyntaxHighlightRequestBatchId(u8);
 
 impl SyntaxHighlightRequestBatchId {
-    pub(crate) fn increment(&mut self) {
+    pub fn increment(&mut self) {
         self.0 = self.0.wrapping_add(1)
     }
 }
 
 #[derive(Debug)]
-pub(crate) struct SyntaxHighlightRequest {
-    pub(crate) component_id: ComponentId,
-    pub(crate) batch_id: SyntaxHighlightRequestBatchId,
-    pub(crate) language: Language,
-    pub(crate) source_code: String,
+pub struct SyntaxHighlightRequest {
+    pub component_id: ComponentId,
+    pub batch_id: SyntaxHighlightRequestBatchId,
+    pub language: Language,
+    pub source_code: String,
 }
 
-pub(crate) fn start_thread(callback: Sender<AppMessage>) -> Sender<SyntaxHighlightRequest> {
+pub fn start_thread(callback: Sender<AppMessage>) -> Sender<SyntaxHighlightRequest> {
     let (sender, receiver) = std::sync::mpsc::channel::<SyntaxHighlightRequest>();
     use debounce::EventDebouncer;
     struct Event(SyntaxHighlightRequest);
@@ -221,16 +221,17 @@ pub(crate) fn start_thread(callback: Sender<AppMessage>) -> Sender<SyntaxHighlig
 }
 type TreeSitterGrammarId = String;
 /// We have to cache the highlight configurations because they load slowly.
-pub(crate) struct HighlightConfigs(
+#[derive(Default)]
+pub struct HighlightConfigs(
     HashMap<TreeSitterGrammarId, tree_sitter_highlight::HighlightConfiguration>,
 );
 
 impl HighlightConfigs {
-    pub(crate) fn new() -> HighlightConfigs {
-        HighlightConfigs(Default::default())
+    pub fn new() -> Self {
+        Self::default()
     }
 
-    pub(crate) fn highlight(
+    pub fn highlight(
         &mut self,
         language: Language,
         source_code: &str,

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -4,7 +4,7 @@ use std::io::{Read, Write};
 #[allow(dead_code)]
 /// This piece of function is left in the codebase as a reference,
 /// in case we want to implement integrated terminal.
-pub(crate) fn run_integrated_terminal(rows: u16, cols: u16) -> Result<(), anyhow::Error> {
+pub fn run_integrated_terminal(rows: u16, cols: u16) -> Result<(), anyhow::Error> {
     crossterm::terminal::enable_raw_mode()?;
     use portable_pty::CommandBuilder;
 

--- a/src/test_app.rs
+++ b/src/test_app.rs
@@ -23,11 +23,11 @@ use std::{
     sync::{Arc, Mutex},
     time::Duration,
 };
-pub(crate) use Dispatch::*;
-pub(crate) use DispatchEditor::*;
+pub use Dispatch::*;
+pub use DispatchEditor::*;
 
-pub(crate) use Movement::*;
-pub(crate) use SelectionMode::*;
+pub use Movement::*;
+pub use SelectionMode::*;
 
 use crate::{
     app::StatusLine,
@@ -84,7 +84,7 @@ use crate::{
 use crate::{lsp::process::LspNotification, themes::Color};
 
 #[allow(clippy::large_enum_variant)]
-pub(crate) enum Step {
+pub enum Step {
     App(Dispatch),
     Shell(&'static str, Vec<String>),
     AppLater(Box<dyn Fn() -> Dispatch>),
@@ -119,7 +119,7 @@ impl Step {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) enum ExpectKind {
+pub enum ExpectKind {
     // This is just a placeholder for ending a test case without actual assertions.
     // Such test cases are those that just expect the series of actions to not result in failure.
     NoError,
@@ -666,10 +666,10 @@ fn run_range_style_key_check(
     )
 }
 
-pub(crate) use ExpectKind::*;
-pub(crate) use Step::*;
+pub use ExpectKind::*;
+pub use Step::*;
 #[derive(Clone)]
-pub(crate) struct State {
+pub struct State {
     temp_dir: CanonicalizedPath,
     main_rs: CanonicalizedPath,
     foo_rs: CanonicalizedPath,
@@ -677,32 +677,32 @@ pub(crate) struct State {
     git_ignore: CanonicalizedPath,
 }
 impl State {
-    pub(crate) fn main_rs(&self) -> CanonicalizedPath {
+    pub fn main_rs(&self) -> CanonicalizedPath {
         self.main_rs.clone()
     }
 
-    pub(crate) fn foo_rs(&self) -> CanonicalizedPath {
+    pub fn foo_rs(&self) -> CanonicalizedPath {
         self.foo_rs.clone()
     }
 
-    pub(crate) fn hello_ts(&self) -> CanonicalizedPath {
+    pub fn hello_ts(&self) -> CanonicalizedPath {
         self.hello_ts.clone()
     }
 
-    pub(crate) fn new_path(&self, path: &str) -> PathBuf {
+    pub fn new_path(&self, path: &str) -> PathBuf {
         self.temp_dir.to_path_buf().join(path)
     }
 
-    pub(crate) fn gitignore(&self) -> CanonicalizedPath {
+    pub fn gitignore(&self) -> CanonicalizedPath {
         self.git_ignore.clone()
     }
 
-    pub(crate) fn temp_dir(&self) -> CanonicalizedPath {
+    pub fn temp_dir(&self) -> CanonicalizedPath {
         self.temp_dir.clone()
     }
 }
 
-pub(crate) fn execute_test(callback: impl Fn(State) -> Box<[Step]>) -> anyhow::Result<()> {
+pub fn execute_test(callback: impl Fn(State) -> Box<[Step]>) -> anyhow::Result<()> {
     execute_test_helper(
         || Box::new(NullWriter),
         false,
@@ -721,7 +721,7 @@ pub(crate) fn execute_test(callback: impl Fn(State) -> Box<[Step]>) -> anyhow::R
     Ok(())
 }
 
-pub(crate) fn execute_test_custom(
+pub fn execute_test_custom(
     options: RunTestOptions,
     callback: impl Fn(State) -> Box<[Step]>,
 ) -> anyhow::Result<()> {
@@ -739,7 +739,7 @@ pub(crate) fn execute_test_custom(
     Ok(())
 }
 
-pub(crate) fn execute_recipe(
+pub fn execute_recipe(
     callback: impl Fn(State) -> Box<[Step]>,
     assert_last_step_is_expect: bool,
 ) -> anyhow::Result<TestOutput> {
@@ -856,10 +856,10 @@ fn execute_test_helper(
 }
 
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct RunTestOptions {
-    pub(crate) enable_lsp: bool,
-    pub(crate) enable_syntax_highlighting: bool,
-    pub(crate) enable_file_watcher: bool,
+pub struct RunTestOptions {
+    pub enable_lsp: bool,
+    pub enable_syntax_highlighting: bool,
+    pub enable_file_watcher: bool,
 }
 
 fn run_test(
@@ -1220,7 +1220,7 @@ fn signature_help() -> anyhow::Result<()> {
 }
 
 #[test]
-pub(crate) fn repo_git_hunks() -> Result<(), anyhow::Error> {
+pub fn repo_git_hunks() -> Result<(), anyhow::Error> {
     execute_test(|s| {
         let path_new_file = s.new_path("new_file.md");
         fn strs_to_strings(strs: &[&str]) -> Option<Info> {
@@ -1292,7 +1292,7 @@ pub(crate) fn repo_git_hunks() -> Result<(), anyhow::Error> {
 }
 
 #[test]
-pub(crate) fn revert_modified_hunk() -> Result<(), anyhow::Error> {
+pub fn revert_modified_hunk() -> Result<(), anyhow::Error> {
     let original_content = "pub(crate) struct Foo {
     a: (),
     b: (),
@@ -1371,7 +1371,7 @@ fn main() {
 }
 
 #[test]
-pub(crate) fn non_git_ignored_files() -> Result<(), anyhow::Error> {
+pub fn non_git_ignored_files() -> Result<(), anyhow::Error> {
     execute_test(|s| {
         let temp_dir = s.temp_dir();
         Box::new([

--- a/src/themes/from_zed_theme.rs
+++ b/src/themes/from_zed_theme.rs
@@ -171,6 +171,6 @@ pub(super) fn from_theme_content(theme: ThemeContent) -> Theme {
         } else {
             super::HunkStyles::dark()
         },
-        git_gutter: GitGutterStyles::new(),
+        git_gutter: GitGutterStyles::default(),
     }
 }

--- a/src/themes/mod.rs
+++ b/src/themes/mod.rs
@@ -1,29 +1,29 @@
 pub mod from_zed_theme;
-pub(crate) mod theme_descriptor;
-pub(crate) mod vscode_dark;
-pub(crate) mod vscode_light;
+pub mod theme_descriptor;
+pub mod vscode_dark;
+pub mod vscode_light;
 use std::collections::HashMap;
 
 use itertools::Itertools;
 use my_proc_macros::hex;
 use once_cell::sync::OnceCell;
 use strum::IntoEnumIterator as _;
-pub(crate) use vscode_dark::vscode_dark;
-pub(crate) use vscode_light::vscode_light;
+pub use vscode_dark::vscode_dark;
+pub use vscode_light::vscode_light;
 
 use crate::{env::parse_env, grid::StyleKey, style::Style};
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub(crate) struct Theme {
-    pub(crate) name: String,
-    pub(crate) syntax: SyntaxStyles,
-    pub(crate) ui: UiStyles,
-    pub(crate) diagnostic: DiagnosticStyles,
-    pub(crate) hunk: HunkStyles,
-    pub(crate) git_gutter: GitGutterStyles,
+pub struct Theme {
+    pub name: String,
+    pub syntax: SyntaxStyles,
+    pub ui: UiStyles,
+    pub diagnostic: DiagnosticStyles,
+    pub hunk: HunkStyles,
+    pub git_gutter: GitGutterStyles,
 }
 
-pub(crate) fn from_name(name: &str) -> Result<Theme, String> {
+pub fn from_name(name: &str) -> Result<Theme, String> {
     let descriptors = crate::themes::theme_descriptor::all();
     descriptors
         .iter()
@@ -36,11 +36,11 @@ pub(crate) fn from_name(name: &str) -> Result<Theme, String> {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub(crate) struct HunkStyles {
-    pub(crate) old_background: Color,
-    pub(crate) new_background: Color,
-    pub(crate) old_emphasized_background: Color,
-    pub(crate) new_emphasized_background: Color,
+pub struct HunkStyles {
+    pub old_background: Color,
+    pub new_background: Color,
+    pub old_emphasized_background: Color,
+    pub new_emphasized_background: Color,
 }
 
 impl HunkStyles {
@@ -64,14 +64,14 @@ impl HunkStyles {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub(crate) struct GitGutterStyles {
-    pub(crate) insertion: Color,
-    pub(crate) deletion: Color,
-    pub(crate) replacement: Color,
+pub struct GitGutterStyles {
+    pub insertion: Color,
+    pub deletion: Color,
+    pub replacement: Color,
 }
 
-impl GitGutterStyles {
-    pub(crate) fn new() -> Self {
+impl Default for GitGutterStyles {
+    fn default() -> Self {
         Self {
             insertion: hex!("#BAF0C0"),
             deletion: hex!("#F9D8D6"),
@@ -81,7 +81,7 @@ impl GitGutterStyles {
 }
 
 impl Theme {
-    pub(crate) fn get_style(&self, source: &StyleKey) -> Style {
+    pub fn get_style(&self, source: &StyleKey) -> Style {
         match source {
             StyleKey::UiMark => self.ui.mark,
             StyleKey::UiPrimarySelection => {
@@ -157,12 +157,12 @@ impl Default for Theme {
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
-pub(crate) struct DiagnosticStyles {
-    pub(crate) error: Style,
-    pub(crate) warning: Style,
-    pub(crate) info: Style,
-    pub(crate) hint: Style,
-    pub(crate) default: Style,
+pub struct DiagnosticStyles {
+    pub error: Style,
+    pub warning: Style,
+    pub info: Style,
+    pub hint: Style,
+    pub default: Style,
 }
 
 impl DiagnosticStyles {
@@ -178,33 +178,33 @@ impl DiagnosticStyles {
 }
 
 #[derive(Default, Clone, PartialEq, Eq, Debug)]
-pub(crate) struct UiStyles {
-    pub(crate) fuzzy_matched_char: Style,
-    pub(crate) global_title: Style,
-    pub(crate) window_title_focused: Style,
-    pub(crate) window_title_unfocused: Style,
-    pub(crate) parent_lines_background: Color,
-    pub(crate) section_divider_background: Color,
-    pub(crate) jump_mark_odd: Style,
-    pub(crate) jump_mark_even: Style,
-    pub(crate) text_foreground: Color,
-    pub(crate) background_color: Color,
-    pub(crate) primary_selection_background: Color,
-    pub(crate) primary_selection_anchor_background: Color,
-    pub(crate) primary_selection_secondary_cursor: Style,
-    pub(crate) secondary_selection_background: Color,
-    pub(crate) secondary_selection_anchor_background: Color,
-    pub(crate) possible_selection_background: Color,
-    pub(crate) incremental_search_match_background: Color,
-    pub(crate) secondary_selection_primary_cursor: Style,
-    pub(crate) secondary_selection_secondary_cursor: Style,
-    pub(crate) line_number: Style,
-    pub(crate) border: Style,
-    pub(crate) mark: Style,
+pub struct UiStyles {
+    pub fuzzy_matched_char: Style,
+    pub global_title: Style,
+    pub window_title_focused: Style,
+    pub window_title_unfocused: Style,
+    pub parent_lines_background: Color,
+    pub section_divider_background: Color,
+    pub jump_mark_odd: Style,
+    pub jump_mark_even: Style,
+    pub text_foreground: Color,
+    pub background_color: Color,
+    pub primary_selection_background: Color,
+    pub primary_selection_anchor_background: Color,
+    pub primary_selection_secondary_cursor: Style,
+    pub secondary_selection_background: Color,
+    pub secondary_selection_anchor_background: Color,
+    pub possible_selection_background: Color,
+    pub incremental_search_match_background: Color,
+    pub secondary_selection_primary_cursor: Style,
+    pub secondary_selection_secondary_cursor: Style,
+    pub line_number: Style,
+    pub border: Style,
+    pub mark: Style,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
-pub(crate) struct SyntaxStyles {
+pub struct SyntaxStyles {
     map: once_cell::sync::OnceCell<HashMap<HighlightName, Style>>,
     groups: Vec<(HighlightName, Style)>,
 }
@@ -652,7 +652,7 @@ pub fn highlight_names() -> &'static Vec<&'static str> {
 
 /// This should be constructed using the `hex!` macro.
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Deserialize, PartialOrd, Ord)]
-pub(crate) struct Color {
+pub struct Color {
     r: u8,
     g: u8,
     b: u8,
@@ -688,7 +688,7 @@ impl Color {
         }
     }
 
-    pub(crate) fn from_hex(hex: &str) -> anyhow::Result<Color> {
+    pub fn from_hex(hex: &str) -> anyhow::Result<Color> {
         let regex = lazy_regex::regex!(r"^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3}|[A-Fa-f0-9]{8})$");
         if !regex.is_match(hex) {
             return Err(anyhow::anyhow!("Invalid hex color: {}", hex));
@@ -710,7 +710,7 @@ impl Color {
 
     /// Refer https://docs.rs/colorsys/latest/src/colorsys/rgb/transform.rs.html#61
     /// Refer https://sl.bing.net/b69EKNHqrLw
-    pub(crate) fn get_contrasting_color(&self) -> Color {
+    pub fn get_contrasting_color(&self) -> Color {
         let Color { r, g, b, a } = self;
         // Calculate the luminance of the color
         let luminance = (0.299 * (*r as f64) + 0.587 * (*g as f64) + 0.114 * (*b as f64)) / 255.0;

--- a/src/themes/theme_descriptor.rs
+++ b/src/themes/theme_descriptor.rs
@@ -4,14 +4,14 @@ use super::{from_zed_theme, vscode_dark, vscode_light, Theme};
 use zed_theme::get_zed_themes;
 
 #[derive(Clone, Debug, PartialEq)]
-pub(crate) struct ThemeDescriptor(String);
+pub struct ThemeDescriptor(String);
 
 impl ThemeDescriptor {
-    pub(crate) fn name(&self) -> &str {
+    pub fn name(&self) -> &str {
         &self.0
     }
 
-    pub(crate) fn to_theme(&self) -> Theme {
+    pub fn to_theme(&self) -> Theme {
         let theme_map = &*THEMES;
         theme_map
             .get(&self.0)
@@ -41,7 +41,7 @@ static THEMES: LazyLock<HashMap<String, Theme>> = LazyLock::new(|| {
     themes
 });
 
-pub(crate) fn all() -> Vec<ThemeDescriptor> {
+pub fn all() -> Vec<ThemeDescriptor> {
     THEMES.keys().cloned().map(ThemeDescriptor).collect()
 }
 

--- a/src/themes/vscode_dark.rs
+++ b/src/themes/vscode_dark.rs
@@ -67,6 +67,6 @@ pub fn vscode_dark() -> Theme {
         },
         diagnostic: DiagnosticStyles::default(),
         hunk: super::HunkStyles::dark(),
-        git_gutter: GitGutterStyles::new(),
+        git_gutter: GitGutterStyles::default(),
     }
 }

--- a/src/themes/vscode_light.rs
+++ b/src/themes/vscode_light.rs
@@ -67,6 +67,6 @@ pub fn vscode_light() -> Theme {
         },
         diagnostic: DiagnosticStyles::default(),
         hunk: super::HunkStyles::light(),
-        git_gutter: GitGutterStyles::new(),
+        git_gutter: GitGutterStyles::default(),
     }
 }

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 #[derive(Clone)]
-pub(crate) struct Callback<T>(Arc<dyn Fn(T) + Send + Sync>);
+pub struct Callback<T>(Arc<dyn Fn(T) + Send + Sync>);
 
 impl<T> PartialEq for Callback<T> {
     fn eq(&self, other: &Self) -> bool {
@@ -12,16 +12,16 @@ impl<T> PartialEq for Callback<T> {
 }
 
 impl<T> Callback<T> {
-    pub(crate) fn new(callback: Arc<dyn Fn(T) + Send + Sync>) -> Self {
+    pub fn new(callback: Arc<dyn Fn(T) + Send + Sync>) -> Self {
         Self(callback)
     }
 
-    pub(crate) fn call(&self, event: T) {
+    pub fn call(&self, event: T) {
         self.0(event)
     }
 }
 
-pub(crate) fn debounce<T: PartialEq + Eq + Send + Sync + 'static>(
+pub fn debounce<T: PartialEq + Eq + Send + Sync + 'static>(
     callback: Callback<T>,
     duration: Duration,
 ) -> Callback<T> {
@@ -41,12 +41,12 @@ pub(crate) fn debounce<T: PartialEq + Eq + Send + Sync + 'static>(
     }))
 }
 
-pub(crate) enum SendResult {
+pub enum SendResult {
     Succeeed,
     ReceiverDisconnected,
 }
 impl SendResult {
-    pub(crate) fn is_receiver_disconnected(&self) -> bool {
+    pub fn is_receiver_disconnected(&self) -> bool {
         matches!(self, SendResult::ReceiverDisconnected)
     }
 }
@@ -60,7 +60,7 @@ impl<T> From<Result<(), SendError<T>>> for SendResult {
     }
 }
 
-pub(crate) fn batch<T: Send + Sync + 'static>(
+pub fn batch<T: Send + Sync + 'static>(
     callback: Arc<dyn Fn(Vec<T>) -> SendResult + Send + Sync>,
     interval: Duration,
 ) -> Arc<dyn Fn(T) -> SendResult + Send + Sync> {

--- a/src/transformation.rs
+++ b/src/transformation.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) enum Transformation {
+pub enum Transformation {
     Case(convert_case::Case),
     Unwrap,
     Wrap,
@@ -58,7 +58,7 @@ impl std::fmt::Display for Transformation {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct MyRegex(pub(crate) fancy_regex::Regex);
+pub struct MyRegex(pub fancy_regex::Regex);
 
 impl PartialEq for MyRegex {
     fn eq(&self, other: &Self) -> bool {
@@ -69,7 +69,7 @@ impl PartialEq for MyRegex {
 impl Eq for MyRegex {}
 
 impl Transformation {
-    pub(crate) fn apply(&self, selection_index: usize, string: String) -> anyhow::Result<String> {
+    pub fn apply(&self, selection_index: usize, string: String) -> anyhow::Result<String> {
         match self {
             Transformation::Case(case) => Ok(string.to_case(*case)),
             Transformation::Unwrap => Ok(regex::Regex::new(r"\s*\n+\s*")

--- a/src/ui_tree.rs
+++ b/src/ui_tree.rs
@@ -5,7 +5,7 @@ use nary_tree::{NodeId, NodeMut, NodeRef, RemoveBehavior};
 
 use crate::components::{component::Component, editor::Editor};
 
-pub(crate) struct UiTree {
+pub struct UiTree {
     tree: nary_tree::Tree<KindedComponent>,
     focused_component_id: NodeId,
 }
@@ -14,7 +14,7 @@ pub(crate) struct UiTree {
 /// the root of this `Tree` is always defined,
 /// which makes its usage more pleasing.
 impl UiTree {
-    pub(crate) fn new() -> UiTree {
+    pub fn new() -> UiTree {
         let mut tree = nary_tree::Tree::new();
         let mut editor = Editor::from_text(Some(tree_sitter_md::LANGUAGE.into()), "");
         editor.set_title("[ROOT] (Cannot be saved)".to_string());
@@ -28,20 +28,16 @@ impl UiTree {
         }
     }
 
-    pub(crate) fn root(&self) -> NodeRef<'_, KindedComponent> {
+    pub fn root(&self) -> NodeRef<'_, KindedComponent> {
         self.tree.root().unwrap()
     }
 
-    pub(crate) fn get(&self, id: NodeId) -> Option<NodeRef<'_, KindedComponent>> {
+    pub fn get(&self, id: NodeId) -> Option<NodeRef<'_, KindedComponent>> {
         self.tree.get(id)
     }
 
     /// The root will never be removed to ensure that this tree always contain one component
-    pub(crate) fn remove(
-        &mut self,
-        node_id: NodeId,
-        change_focus: bool,
-    ) -> Option<KindedComponent> {
+    pub fn remove(&mut self, node_id: NodeId, change_focus: bool) -> Option<KindedComponent> {
         if node_id == self.root_id() {
             return None;
         }
@@ -64,7 +60,7 @@ impl UiTree {
         self.tree.get_mut(id)
     }
 
-    pub(crate) fn remain_only_current_component(&mut self) {
+    pub fn remain_only_current_component(&mut self) {
         if !self
             .root()
             .children()
@@ -87,7 +83,7 @@ impl UiTree {
     }
 
     /// Append `component` to the Node of given `node_id`
-    pub(crate) fn append_component(
+    pub fn append_component(
         &mut self,
         node_id: NodeId,
         component: KindedComponent,
@@ -104,7 +100,7 @@ impl UiTree {
         id
     }
 
-    pub(crate) fn append_component_to_current(&mut self, component: KindedComponent, focus: bool) {
+    pub fn append_component_to_current(&mut self, component: KindedComponent, focus: bool) {
         self.append_component(self.focused_component_id, component, focus);
     }
 
@@ -114,7 +110,7 @@ impl UiTree {
 
     /// This return everything except the root, but if only root exists, then the root will be returned.
     /// This behaviour ensures that the tree always contain a component.
-    pub(crate) fn components(&self) -> Vec<KindedComponent> {
+    pub fn components(&self) -> Vec<KindedComponent> {
         if self.root().children().count() == 0 {
             Some(self.root().data().clone()).into_iter().collect_vec()
         } else {
@@ -128,15 +124,15 @@ impl UiTree {
         }
     }
 
-    pub(crate) fn root_id(&self) -> NodeId {
+    pub fn root_id(&self) -> NodeId {
         self.root().node_id()
     }
 
-    pub(crate) fn remove_current_child(&mut self, kind: ComponentKind) -> Option<KindedComponent> {
+    pub fn remove_current_child(&mut self, kind: ComponentKind) -> Option<KindedComponent> {
         self.remove_node_child(self.focused_component_id, kind)
     }
 
-    pub(crate) fn remove_node_child(
+    pub fn remove_node_child(
         &mut self,
         node_id: NodeId,
         kind: ComponentKind,
@@ -153,20 +149,20 @@ impl UiTree {
         }
     }
 
-    pub(crate) fn get_current_node_child_id(&self, kind: ComponentKind) -> Option<NodeId> {
+    pub fn get_current_node_child_id(&self, kind: ComponentKind) -> Option<NodeId> {
         let node_id = self.focused_component_id;
         self.get_node_child_id(node_id, kind)
     }
 
     #[cfg(test)]
-    pub(crate) fn count_by_kind(&self, kind: ComponentKind) -> usize {
+    pub fn count_by_kind(&self, kind: ComponentKind) -> usize {
         self.root()
             .traverse_pre_order()
             .filter(|node| node.data().kind == kind)
             .count()
     }
 
-    pub(crate) fn set_focus_component_id(&mut self, id: NodeId) {
+    pub fn set_focus_component_id(&mut self, id: NodeId) {
         // This check is necessary.
         // In case of any logical error that causes `id` to be pointing to node that is removed from the tree,
         // it should always fallback to use root ID
@@ -181,11 +177,11 @@ impl UiTree {
         };
     }
 
-    pub(crate) fn focused_component_id(&self) -> NodeId {
+    pub fn focused_component_id(&self) -> NodeId {
         self.focused_component_id
     }
 
-    pub(crate) fn cycle_component(&mut self) {
+    pub fn cycle_component(&mut self) {
         self.set_focus_component_id(
             self.root()
                 .traverse_pre_order()
@@ -200,12 +196,12 @@ impl UiTree {
         );
     }
 
-    pub(crate) fn get_current_node(&self) -> NodeRef<'_, KindedComponent> {
+    pub fn get_current_node(&self) -> NodeRef<'_, KindedComponent> {
         self.get(self.focused_component_id)
             .unwrap_or_else(|| self.root())
     }
 
-    pub(crate) fn replace_node_child(
+    pub fn replace_node_child(
         &mut self,
         id: NodeId,
         kind: ComponentKind,
@@ -216,7 +212,7 @@ impl UiTree {
         self.append_component(id, KindedComponent::new(kind, component), focus)
     }
 
-    pub(crate) fn replace_current_node_child(
+    pub fn replace_current_node_child(
         &mut self,
         kind: ComponentKind,
         component: Rc<RefCell<dyn Component>>,
@@ -227,7 +223,7 @@ impl UiTree {
         self.append_component(id, KindedComponent::new(kind, component), focus)
     }
 
-    pub(crate) fn close_current_and_focus_parent(&mut self) {
+    pub fn close_current_and_focus_parent(&mut self) {
         if let Some(node) = self.tree.get(self.focused_component_id) {
             let parent_id = node.parent().map(|parent| parent.node_id());
             self.tree
@@ -236,11 +232,11 @@ impl UiTree {
         }
     }
 
-    pub(crate) fn current_component(&self) -> Rc<RefCell<(dyn Component)>> {
+    pub fn current_component(&self) -> Rc<RefCell<(dyn Component)>> {
         self.get_current_node().data().component()
     }
 
-    pub(crate) fn replace_root_node_child(
+    pub fn replace_root_node_child(
         &mut self,
         kind: ComponentKind,
         component: Rc<RefCell<dyn Component>>,
@@ -249,7 +245,7 @@ impl UiTree {
         self.replace_node_child(self.root_id(), kind, component, focus)
     }
 
-    pub(crate) fn remove_all_root_children(&mut self) {
+    pub fn remove_all_root_children(&mut self) {
         let children_ids = self
             .root()
             .children()
@@ -261,10 +257,7 @@ impl UiTree {
         debug_assert_eq!(self.root().children().count(), 0);
     }
 
-    pub(crate) fn get_component_by_kind(
-        &self,
-        kind: ComponentKind,
-    ) -> Option<Rc<RefCell<dyn Component>>> {
+    pub fn get_component_by_kind(&self, kind: ComponentKind) -> Option<Rc<RefCell<dyn Component>>> {
         Some(
             self.root()
                 .traverse_pre_order()
@@ -284,7 +277,7 @@ impl UiTree {
         )
     }
 
-    pub(crate) fn get_component_by_id(
+    pub fn get_component_by_id(
         &self,
         component_id: crate::components::component::ComponentId,
     ) -> Option<Rc<RefCell<dyn Component>>> {
@@ -305,24 +298,21 @@ impl Default for UiTree {
 }
 
 #[derive(Clone)]
-pub(crate) struct KindedComponent {
+pub struct KindedComponent {
     component: Rc<RefCell<dyn Component>>,
     kind: ComponentKind,
 }
 
 impl KindedComponent {
-    pub(crate) fn new(
-        kind: ComponentKind,
-        component: Rc<RefCell<dyn Component>>,
-    ) -> KindedComponent {
+    pub fn new(kind: ComponentKind, component: Rc<RefCell<dyn Component>>) -> KindedComponent {
         Self { kind, component }
     }
 
-    pub(crate) fn component(&self) -> Rc<RefCell<dyn Component>> {
+    pub fn component(&self) -> Rc<RefCell<dyn Component>> {
         self.component.clone()
     }
 
-    pub(crate) fn kind(&self) -> ComponentKind {
+    pub fn kind(&self) -> ComponentKind {
         self.kind
     }
 }
@@ -336,7 +326,7 @@ impl std::fmt::Debug for KindedComponent {
 #[derive(PartialEq, Eq, Clone, Copy, Debug, PartialOrd, Ord)]
 /// The order of variants in this enum is significant
 /// Higher-rank variant will be rendered before lower-rank variant
-pub(crate) enum ComponentKind {
+pub enum ComponentKind {
     SuggestiveEditor,
     FileExplorer,
     QuickfixList,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,4 @@
-pub(crate) fn find_previous<T>(
+pub fn find_previous<T>(
     iter: impl Iterator<Item = T>,
     set_last_match_predicate: impl Fn(&T, &Option<T>) -> bool,
     break_predicate: impl Fn(&T) -> bool,
@@ -16,7 +16,7 @@ pub(crate) fn find_previous<T>(
     last_match
 }
 
-pub(crate) fn consolidate_errors<T, E: std::fmt::Debug>(
+pub fn consolidate_errors<T, E: std::fmt::Debug>(
     message: &str,
     results: Vec<Result<T, E>>,
 ) -> anyhow::Result<()> {
@@ -40,7 +40,7 @@ pub(crate) fn consolidate_errors<T, E: std::fmt::Debug>(
 /// assert_eq!(distribute_items(5, 2), vec![3, 2]);
 /// assert_eq!(distribute_items(6, 3), vec![2, 2, 2]);
 /// ```
-pub(crate) fn distribute_items(total: usize, n_parts: usize) -> Vec<usize> {
+pub fn distribute_items(total: usize, n_parts: usize) -> Vec<usize> {
     if n_parts == 0 {
         return vec![];
     }
@@ -60,7 +60,7 @@ pub(crate) fn distribute_items(total: usize, n_parts: usize) -> Vec<usize> {
     result
 }
 
-pub(crate) fn distribute_items_by_2(total: usize) -> (usize, usize) {
+pub fn distribute_items_by_2(total: usize) -> (usize, usize) {
     distribute_items(total, 2)
         .into_iter()
         .collect_tuple()
@@ -161,7 +161,7 @@ pub struct TrimResult<T> {
 /// * When equal trimming isn't possible, trims from the side with more available elements
 /// * Never removes elements from the protected range
 /// * If requested trim count exceeds available elements, trims what it can and returns the remainder
-pub(crate) fn trim_array<T: Clone + std::fmt::Debug>(
+pub fn trim_array<T: Clone + std::fmt::Debug>(
     arr: &[T],
     protected_range: Range<usize>,
     trim_count: usize,


### PR DESCRIPTION
pub(crate) is equivalent to pub in a binary crate, but the latter is much more useful for crate splitting and integration tests.

There are some minor changes here made to appease clippy: the rest are just a global find + replace.