### PR TITLE
tidy(ci): remove linux glibc builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,8 +25,6 @@ jobs:
           gh release create nightly --prerelease --title 'Nightly Release' \
             ki-linux-x64/ki-linux-x64 \
             ki-linux-arm64/ki-linux-arm64 \
-            ki-linux-x64-musl/ki-linux-x64-musl \
-            ki-linux-arm64-musl/ki-linux-arm64-musl \
             ki-windows-x64/ki-windows-x64.exe \
             ki-windows-arm64/ki-windows-arm64.exe \
             ki-macos-x64/ki-macos-x64 \

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -7,22 +7,12 @@ jobs:
     strategy:
       matrix:
         runner:
-          - ubuntu-latest
-          - ubuntu-24.04-arm # No -latest tag available
           - windows-latest
           - windows-11-arm # No -latest tag available
           - macos-latest
           - macos-15-intel # No -latest tag available
 
         include:
-          - runner: ubuntu-latest
-            code: linux-x64
-            extension:
-            mv: mv
-          - runner: ubuntu-24.04-arm
-            code: linux-arm64
-            extension:
-            mv: mv
           - runner: windows-latest
             code: windows-x64
             extension: .exe
@@ -66,10 +56,10 @@ jobs:
 
         include:
           - runner: ubuntu-latest
-            code: linux-x64-musl
+            code: linux-x64
             rustup_target: x86_64-unknown-linux-musl
           - runner: ubuntu-24.04-arm
-            code: linux-arm64-musl
+            code: linux-arm64
             rustup_target: aarch64-unknown-linux-musl
 
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,6 @@ jobs:
           gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} \
             ki-linux-x64/ki-linux-x64 \
             ki-linux-arm64/ki-linux-arm64 \
-            ki-linux-x64-musl/ki-linux-x64-musl \
-            ki-linux-arm64-musl/ki-linux-arm64-musl \
             ki-windows-x64/ki-windows-x64.exe \
             ki-windows-arm64/ki-windows-arm64.exe \
             ki-macos-x64/ki-macos-x64 \


### PR DESCRIPTION
musl builds are statically linked, and so work on all linux platforms. Shipping only a musl build is also the approach taken by jujutsu.