### PR TITLE
fix(prompt): cannot enter normal mode

### DIFF
--- a/src/frontend/crossterm.rs
+++ b/src/frontend/crossterm.rs
@@ -80,7 +80,9 @@ impl Frontend for Crossterm {
         // so that we can detect Key Release events
         // which is crucial for implementing momentary layers
         self.stdout.execute(PushKeyboardEnhancementFlags(
-            KeyboardEnhancementFlags::REPORT_EVENT_TYPES,
+            KeyboardEnhancementFlags::REPORT_EVENT_TYPES
+                | KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES,
+            // DISAMBIGUATE_ESCAPE_CODES is necessary for preventing an Esc tap to be captured as a double esc presses
         ))?;
         Ok(())
     }


### PR DESCRIPTION
This is because when the esc key is tapped, two esc key presses will be captured, thus closing the prompt.

This is fixed by allowing esc releases to be detected.