### PR TITLE
refactor(Delete MOL): use new momentary layer API

### DIFF
--- a/docs/docs/momentary-layers/delete-mol.mdx
+++ b/docs/docs/momentary-layers/delete-mol.mdx
@@ -1,13 +1,25 @@
 import {TutorialFallback} from '@site/src/components/TutorialFallback';
+import {KeymapFallback} from '@site/src/components/KeymapFallback';
 
 # Delete MOL
 
-When this layer is activated, movement keys are overridden with the following behavior:
+## Keymap
 
-> Deletes both the current selection and the whitespace/gap leading to the `<movement>` selection, then moves to select the `<movement>` selection.
+<KeymapFallback filename="delete"/>
+
+### Directional Deletes
+
+Directional Deletes deletes the current selection, along with the gap between the current selection and the `<movement>` selection,
+then selects the `<movement>` selection, where `<movement>` can be any of the following movements:
+
+1. Left/Right
+2. Previous/Next
 
 <TutorialFallback filename="delete"/>
+
 <TutorialFallback filename="delete-finer-movement"/>
+
+### Delete One
 
 If the layer is deactivated immediately without pressing any movement key, the current selection is deleted and collapses to a single-character selection at the cursor position.
 

--- a/event/src/event.rs
+++ b/event/src/event.rs
@@ -41,12 +41,6 @@ impl fmt::Debug for KeyEvent {
     }
 }
 impl KeyEvent {
-    /// Returns `true` if this key event has the same key code and modifiers as `other`,
-    /// ignoring the event kind (press/release/repeat).
-    pub fn same_key(&self, other: &KeyEvent) -> bool {
-        self.code == other.code && self.modifiers == other.modifiers
-    }
-
     pub const fn pressed(key: crossterm::event::KeyCode, modifiers: KeyModifiers) -> KeyEvent {
         KeyEvent {
             code: key,

--- a/ki-jetbrains/src/kotlin/protocol/Types.kt
+++ b/ki-jetbrains/src/kotlin/protocol/Types.kt
@@ -167,10 +167,6 @@ enum class EditorMode(val string: String) {
 	Swap("swap"),
 	@SerialName("replace")
 	Replace("replace"),
-	@SerialName("delete")
-	Delete("delete"),
-	@SerialName("paste")
-	Paste("paste"),
 }
 
 @Serializable

--- a/ki-protocol-types/src/lib.rs
+++ b/ki-protocol-types/src/lib.rs
@@ -57,8 +57,6 @@ pub enum EditorMode {
     FindOneChar,
     Swap,
     Replace,
-    Delete,
-    Paste,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/ki-vscode/src/protocol/types.ts
+++ b/ki-vscode/src/protocol/types.ts
@@ -115,8 +115,6 @@ export enum EditorMode {
 	FindOneChar = "findOneChar",
 	Swap = "swap",
 	Replace = "replace",
-	Delete = "delete",
-	Paste = "paste",
 }
 
 export interface ModeParams {

--- a/src/components/editor.rs
+++ b/src/components/editor.rs
@@ -35,8 +35,8 @@ use crate::{
     transformation::{MyRegex, Transformation},
 };
 use crate::{grid::LINE_NUMBER_VERTICAL_BORDER, selection_mode::PositionBasedSelectionMode};
-use crossterm::event::{KeyCode, KeyEventKind, MouseButton, MouseEventKind};
-use event::{parse_key_event, KeyEvent};
+use crossterm::event::{KeyCode, MouseButton, MouseEventKind};
+use event::KeyEvent;
 use itertools::{Either, Itertools};
 use my_proc_macros::key;
 use nonempty::NonEmpty;
@@ -58,7 +58,6 @@ pub enum Mode {
     FindOneChar(IfCurrentNotFound),
     Swap,
     Replace,
-    Delete { other_key_pressed: bool },
 }
 
 #[derive(Clone, Copy, PartialEq, Debug, Eq)]
@@ -399,11 +398,6 @@ impl Component for Editor {
             }
             DeleteCutWithMovement(movement) => {
                 return self.delete_with_movement(context, movement, true)
-            }
-            EnterDeleteMode => {
-                self.mode = Mode::Delete {
-                    other_key_pressed: false,
-                }
             }
             AlignSelections(direction) => return self.align_selections(direction, context),
             JoinSelection => return self.join_selection(context),
@@ -1586,53 +1580,29 @@ impl Editor {
         context: &Context,
         key_event: KeyEvent,
     ) -> anyhow::Result<Dispatches> {
-        if key_event.kind == KeyEventKind::Release {
-            if let (Mode::Delete { other_key_pressed }, true) = (
-                &self.mode,
-                parse_key_event(
-                    context
-                        .keyboard_layout_kind()
-                        .get_key(&super::editor_keymap::Meaning::Delte),
-                )
-                .unwrap()
-                .same_key(&key_event),
-            ) {
-                return Ok(
-                    Dispatches::one(Dispatch::ToEditor(DispatchEditor::EnterNormalMode))
-                        .append_some(if !other_key_pressed {
-                            Some(Dispatch::ToEditor(DispatchEditor::DeleteOne))
-                        } else {
-                            None
-                        }),
-                );
-            }
+        match self.handle_universal_key(key_event, context)? {
+            HandleEventResult::Ignored(key_event) => {
+                if let Some(jumps) = self.jumps.take() {
+                    self.handle_jump_mode(context, key_event, jumps)
+                } else if let Mode::Insert = self.mode {
+                    self.handle_insert_mode(context, key_event)
+                } else if let Mode::FindOneChar(_) = self.mode {
+                    self.handle_find_one_char_mode(
+                        IfCurrentNotFound::LookForward,
+                        key_event,
+                        context,
+                    )
+                } else {
+                    let keymap_legend_config = self.get_current_keymap_legend_config(context);
 
-            Ok(Default::default())
-        } else {
-            match self.handle_universal_key(key_event, context)? {
-                HandleEventResult::Ignored(key_event) => {
-                    if let Some(jumps) = self.jumps.take() {
-                        self.handle_jump_mode(context, key_event, jumps)
-                    } else if let Mode::Insert = self.mode {
-                        self.handle_insert_mode(context, key_event)
-                    } else if let Mode::FindOneChar(_) = self.mode {
-                        self.handle_find_one_char_mode(
-                            IfCurrentNotFound::LookForward,
-                            key_event,
-                            context,
-                        )
-                    } else {
-                        let keymap_legend_config = self.get_current_keymap_legend_config(context);
-
-                        if let Some(keymap) = keymap_legend_config.keymaps().get(&key_event) {
-                            return Ok(keymap.get_dispatches());
-                        }
-                        log::info!("unhandled event: {key_event:?}");
-                        Ok(vec![].into())
+                    if let Some(keymap) = keymap_legend_config.keymaps().get(&key_event) {
+                        return Ok(keymap.get_dispatches());
                     }
+                    log::info!("unhandled event: {key_event:?}");
+                    Ok(vec![].into())
                 }
-                HandleEventResult::Handled(dispatches) => Ok(dispatches),
             }
+            HandleEventResult::Handled(dispatches) => Ok(dispatches),
         }
     }
 
@@ -1923,12 +1893,6 @@ impl Editor {
                 )
                 .map(|_| Default::default()),
             Mode::FindOneChar(_) | Mode::Insert => Ok(Default::default()),
-            Mode::Delete { .. } => {
-                self.mode = Mode::Delete {
-                    other_key_pressed: true,
-                };
-                self.delete_with_movement(context, movement, false)
-            }
         }
     }
 
@@ -2889,7 +2853,6 @@ impl Editor {
                 Mode::FindOneChar(_) => "ONE".to_string(),
                 Mode::Swap => "SWAP".to_string(),
                 Mode::Replace => "RPLCE".to_string(),
-                Mode::Delete { .. } => "DELTE".to_string(),
             }
         }
     }
@@ -4633,7 +4596,6 @@ pub enum DispatchEditor {
     PasteWithMovement(Movement),
     DeleteWithMovement(Movement),
     DeleteCutWithMovement(Movement),
-    EnterDeleteMode,
     AlignSelections(Direction),
     JoinSelection,
     ReplaceSelections(Vec<String>),

--- a/src/components/editor_keymap_printer.rs
+++ b/src/components/editor_keymap_printer.rs
@@ -13,7 +13,7 @@ use crate::{
     components::{
         editor::{Direction, Editor},
         editor_keymap::{shifted, KeyboardLayout},
-        editor_keymap_legend::paste_keymaps,
+        editor_keymap_legend::{delete_keymaps, paste_keymaps},
     },
     context::Context,
 };
@@ -373,6 +373,11 @@ impl KeymapPrintSections {
                 layout,
             ),
             KeymapPrintSection::from_keymaps("Paste".to_string(), &paste_keymaps(&context), layout),
+            KeymapPrintSection::from_keymaps(
+                "Delete".to_string(),
+                &delete_keymaps(&context),
+                layout,
+            ),
         ]
         .to_vec();
 

--- a/src/embed/app.rs
+++ b/src/embed/app.rs
@@ -470,7 +470,6 @@ impl EmbeddedApp {
             Mode::FindOneChar(_) => ki_protocol_types::EditorMode::FindOneChar,
             Mode::Swap => ki_protocol_types::EditorMode::Swap,
             Mode::Replace => ki_protocol_types::EditorMode::Replace,
-            Mode::Delete { .. } => ki_protocol_types::EditorMode::Delete,
         };
 
         self.send_notification(OutputMessageWrapper {

--- a/src/recipes.rs
+++ b/src/recipes.rs
@@ -339,7 +339,7 @@ Why?
                     .trim(),
                     file_extension: "md",
                     prepare_events: &[],
-                    events: keys!("s v o"),
+                    events: keys!("s v o release-v"),
                     expectations: Box::new([CurrentSelectedTexts(&["world"])]),
                     terminal_height: None,
                     similar_vim_combos: &[],


### PR DESCRIPTION
This removes the hacky code that was added to make Delete MOL works.