### PR TITLE
hack(momentary_layers): fix windows

### DIFF
--- a/src/frontend/crossterm.rs
+++ b/src/frontend/crossterm.rs
@@ -79,6 +79,8 @@ impl Frontend for Crossterm {
         // Enable [Kitty's Keyboard Protocol](https://sw.kovidgoyal.net/kitty/keyboard-protocol/)
         // so that we can detect Key Release events
         // which is crucial for implementing momentary layers
+        // HACK: crossterm on windows unconditionally errors when we attempt KKP initializaiton. See #1212
+        #[cfg(not(windows))]
         self.stdout.execute(PushKeyboardEnhancementFlags(
             KeyboardEnhancementFlags::REPORT_EVENT_TYPES
                 | KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES,


### PR DESCRIPTION
Hack around crossterm's windows behaviour by disabling KKP unconditionally on windows. A proper solution will follow later.

Hotfixes #1212.