### PR TITLE
keymap: remove `shift+V` = Delete Cut

### DIFF
--- a/src/components/editor_keymap.rs
+++ b/src/components/editor_keymap.rs
@@ -36,7 +36,7 @@ pub const KEYMAP_NORMAL_SHIFTED: [[Meaning; 10]; 3] = [
         LineF, BWord, FStyx, ChngX, Trsfm, /****/ CrsrP, DeDnt, Break, Indnt, CrsrN,
     ],
     [
-        Redo_, _____, _____, DeltX, Pst0G, /****/ GSrch, ToIdx, _____, _____, SSEnd,
+        Redo_, _____, _____, _____, Pst0G, /****/ GSrch, ToIdx, _____, _____, SSEnd,
     ],
     // Why is Raise placed at the same Position as Swap?
     // Because Raise is a special-case of Swap where the movement is Up
@@ -638,8 +638,6 @@ pub enum Meaning {
     DeDnt,
     /// Delete
     Delte,
-    /// Delete Cut
-    DeltX,
     /// Down
     Down_,
     /// Swap

--- a/src/components/editor_keymap_legend.rs
+++ b/src/components/editor_keymap_legend.rs
@@ -105,13 +105,6 @@ impl Editor {
         .to_vec()
     }
 
-    fn cut_keymap_legend_config(&self, context: &Context) -> KeymapLegendConfig {
-        KeymapLegendConfig {
-            title: "Cut".to_string(),
-            keymaps: cut_keymaps(context),
-        }
-    }
-
     pub fn keymap_other_movements(&self, context: &Context) -> Vec<Keymap> {
         [
             Keymap::new_extended(
@@ -406,11 +399,6 @@ impl Editor {
                 "*",
                 "Keyboard".to_string(),
                 Dispatch::OpenKeyboardLayoutPrompt,
-            ),
-            Keymap::new(
-                context.keyboard_layout_kind().get_key(&Meaning::DeltX),
-                "Delete X".to_string(),
-                Dispatch::ShowKeymapLegend(self.cut_keymap_legend_config(context)),
             ),
         ]
         .into_iter()


### PR DESCRIPTION
This should have been removed in the last commit.