### PR TITLE
keymap: move Replace with Copied Text into the Paste MoL

### DIFF
--- a/docs/docs/momentary-layers/paste-mol.mdx
+++ b/docs/docs/momentary-layers/paste-mol.mdx
@@ -38,3 +38,11 @@ hello(x, y, z);
 If this layer is deactivated immediately without pressing any movement key, the current selection is replaced with the clipboard content.
 
 <TutorialFallback filename="replace"/>
+
+### Replace with copied text
+
+Replace current selection with previous/next copied text in the clipboard history.
+
+This is similar to [Yanking Earlier Kills](https://www.gnu.org/software/emacs/manual/html_node/emacs/Earlier-Kills.html) in Emacs.
+
+This is useful when you want to retrieve earlier copies.

--- a/docs/docs/normal-mode/actions.md
+++ b/docs/docs/normal-mode/actions.md
@@ -48,14 +48,6 @@ This replaces the parent node of the current node, with the current node.
 
 Note: Raise should never cause any syntax errors, if it does that's a bug.
 
-### `← Replace`/`Replace →`
-
-Replace current selection with previous/next copied text in the clipboard history.
-
-This is similar to [Yanking Earlier Kills](https://www.gnu.org/software/emacs/manual/html_node/emacs/Earlier-Kills.html) in Emacs.
-
-This is useful when you want to retrieve earlier copies.
-
 ### `Open`
 
 Open next to current selection.

--- a/src/components/editor_keymap.rs
+++ b/src/components/editor_keymap.rs
@@ -216,6 +216,18 @@ pub const KEYMAP_YES_NO: KeyboardMeaningLayout = [
     ],
 ];
 
+pub const KEYMAP_PASTE: KeyboardMeaningLayout = [
+    [
+        _____, _____, _____, _____, _____, /****/ _____, PBWoG, _____, PAWoG, _____,
+    ],
+    [
+        _____, _____, _____, _____, _____, /****/ RplcP, PBWiG, PRplc, PAWiG, RplcN,
+    ],
+    [
+        _____, _____, _____, _____, _____, /****/ _____, _____, _____, _____, _____,
+    ],
+];
+
 pub type KeyboardLayout = [[&'static str; 10]; 3];
 
 pub const QWERTY: KeyboardLayout = [
@@ -301,6 +313,7 @@ struct KeySet {
     transform: HashMap<Meaning, &'static str>,
     yes_no: HashMap<Meaning, &'static str>,
     leader: HashMap<Meaning, &'static str>,
+    paste: HashMap<Meaning, &'static str>,
 }
 
 impl KeySet {
@@ -416,6 +429,12 @@ impl KeySet {
             ),
             leader: HashMap::from_iter(
                 LEADER_KEYMAP_LAYOUT
+                    .into_iter()
+                    .flatten()
+                    .zip(layout.into_iter().flatten()),
+            ),
+            paste: HashMap::from_iter(
+                KEYMAP_PASTE
                     .into_iter()
                     .flatten()
                     .zip(layout.into_iter().flatten()),
@@ -586,6 +605,15 @@ impl KeyboardLayoutKind {
         let keyset = self.get_keyset();
         keyset
             .yes_no
+            .get(meaning)
+            .cloned()
+            .unwrap_or_else(|| panic!("Unable to find key binding of {meaning:#?}"))
+    }
+
+    pub fn get_paste_keymap(&self, meaning: &Meaning) -> &'static str {
+        let keyset = self.get_keyset();
+        keyset
+            .paste
             .get(meaning)
             .cloned()
             .unwrap_or_else(|| panic!("Unable to find key binding of {meaning:#?}"))
@@ -966,6 +994,16 @@ pub enum Meaning {
     AgSlR,
     /// Change working directory
     CWDir,
+    /// Replace with pattern
+    PRplc,
+    /// Paste after with gaps
+    PAWiG,
+    /// Paste before with gaps
+    PBWiG,
+    /// Paste after without gaps
+    PAWoG,
+    /// Paste before without gaps
+    PBWoG,
 }
 pub fn shifted(c: &'static str) -> &'static str {
     match c {

--- a/src/components/editor_keymap_legend.rs
+++ b/src/components/editor_keymap_legend.rs
@@ -346,18 +346,6 @@ impl Editor {
                 Dispatch::ToEditor(Redo),
             ),
             Keymap::new_extended(
-                context.keyboard_layout_kind().get_key(&Meaning::RplcP),
-                Direction::Start.format_action("Replace"),
-                "Replace (with previous copied text)".to_string(),
-                Dispatch::ToEditor(ReplaceWithPreviousCopiedText),
-            ),
-            Keymap::new_extended(
-                context.keyboard_layout_kind().get_key(&Meaning::RplcN),
-                Direction::End.format_action("Replace"),
-                "Replace (with next copied text)".to_string(),
-                Dispatch::ToEditor(ReplaceWithNextCopiedText),
-            ),
-            Keymap::new_extended(
                 "enter",
                 "save".to_string(),
                 "Save".to_string(),
@@ -1668,29 +1656,53 @@ pub fn paste_keymaps(context: &Context) -> Keymaps {
     Keymaps::new(
         [
             Keymap::new(
-                context.keyboard_layout_kind().get_key(&Meaning::Left_),
+                context
+                    .keyboard_layout_kind()
+                    .get_paste_keymap(&Meaning::PBWiG),
                 Direction::Start.format_action("Paste with gaps"),
                 Dispatch::ToEditor(PasteWithMovement(Movement::Left)),
             ),
             Keymap::new(
-                context.keyboard_layout_kind().get_key(&Meaning::Right),
+                context
+                    .keyboard_layout_kind()
+                    .get_paste_keymap(&Meaning::PAWiG),
                 Direction::End.format_action("Paste with gaps"),
                 Dispatch::ToEditor(PasteWithMovement(Right)),
             ),
             Keymap::new(
-                context.keyboard_layout_kind().get_key(&Meaning::Next_),
+                context
+                    .keyboard_layout_kind()
+                    .get_paste_keymap(&Meaning::PAWoG),
                 Direction::End.format_action("Paste"),
                 Dispatch::ToEditor(PasteWithMovement(Movement::Next)),
             ),
             Keymap::new(
-                context.keyboard_layout_kind().get_key(&Meaning::Prev_),
+                context
+                    .keyboard_layout_kind()
+                    .get_paste_keymap(&Meaning::PBWoG),
                 Direction::Start.format_action("Paste"),
                 Dispatch::ToEditor(PasteWithMovement(Movement::Previous)),
             ),
             Keymap::new(
-                context.keyboard_layout_kind().get_key(&Meaning::Down_),
+                context
+                    .keyboard_layout_kind()
+                    .get_paste_keymap(&Meaning::PRplc),
                 "Replace with pattern".to_string(),
                 Dispatch::ToEditor(ReplaceWithPattern),
+            ),
+            Keymap::new(
+                context
+                    .keyboard_layout_kind()
+                    .get_paste_keymap(&Meaning::RplcP),
+                Direction::Start.format_action("Replace with copied text"),
+                Dispatch::ToEditor(ReplaceWithPreviousCopiedText),
+            ),
+            Keymap::new(
+                context
+                    .keyboard_layout_kind()
+                    .get_paste_keymap(&Meaning::RplcN),
+                Direction::End.format_action("Replace with copied text"),
+                Dispatch::ToEditor(ReplaceWithNextCopiedText),
             ),
         ]
         .as_ref(),


### PR DESCRIPTION
Because it's more natural to have them there, than on the Shift MoL.