### PR TITLE
fix(file_explorer): fix Windows

### DIFF
--- a/shared/src/canonicalized_path.rs
+++ b/shared/src/canonicalized_path.rs
@@ -157,6 +157,14 @@ impl CanonicalizedPath {
             .collect::<Vec<_>>()
     }
 
+    pub fn ancestors(&self) -> anyhow::Result<Vec<CanonicalizedPath>> {
+        self.0
+            .ancestors()
+            .skip(1)
+            .map(|path| path.try_into())
+            .collect()
+    }
+
     pub fn parent(&self) -> anyhow::Result<Option<CanonicalizedPath>> {
         self.0.parent().map(|path| path.try_into()).transpose()
     }

--- a/src/components/file_explorer.rs
+++ b/src/components/file_explorer.rs
@@ -380,17 +380,12 @@ impl Tree {
     }
 
     fn reveal(self, path: &CanonicalizedPath) -> anyhow::Result<Self> {
-        let components = path.components();
+        let paths = path.ancestors()?;
 
-        let paths = (1..=components.len())
-            .map(|i| components[..i].to_vec())
-            .map(|components| -> Result<CanonicalizedPath, _> {
-                components.join(std::path::MAIN_SEPARATOR_STR).try_into()
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-
+        // Reverse because ancestors returns the parent first, not the topmost directory
         Ok(paths
             .into_iter()
+            .rev()
             .fold(self, |tree, path| tree.toggle(&path, |_| true)))
     }
 


### PR DESCRIPTION
Fixes #1231

Due to a combination of generous std::mem::take usage, and hand-written ancestors logic, windows path handling is completely broken, and the error silently clears the internal tree datastructure.