### PR TITLE
feat: Scrolling (eg alt i/k) always centers the screen

### DIFF
--- a/src/components/editor.rs
+++ b/src/components/editor.rs
@@ -2622,7 +2622,10 @@ impl Editor {
                 .set_range((start..start).into()),
         ))
         .set_mode(selection_mode);
-        self.handle_movement(context, Movement::Current(IfCurrentNotFound::LookForward))
+        let dispatches =
+            self.handle_movement(context, Movement::Current(IfCurrentNotFound::LookForward))?;
+        self.align_selection_to_center(context);
+        Ok(dispatches)
     }
 
     /// This returns a vector of selections


### PR DESCRIPTION
Right now the half-page scroll action moves the cursor by a half page, which triggers a screen-recenter semi-randomly depending on whether the cursor lands on the last visible line or one past the viewport. This feels choppy. This fix explicitly re-centers the screen on scroll.