### PR TITLE
feat(ci): merge queue support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,8 +1,7 @@
 name: Rust
 
 on:
-  push:
-    branches: ["master"]
+  merge_group:
   pull_request:
     branches: ["master"]
 


### PR DESCRIPTION
With a merge queue, running CI on master doesn't make sense, so that has been removed.