### PR TITLE
fix(ci): rerun on master to publish doc build

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,6 +2,8 @@ name: Rust
 
 on:
   merge_group:
+  push:
+    branches: ["master"]
   pull_request:
     branches: ["master"]
 


### PR DESCRIPTION
The docs only publish if the pipeline runs against master.