### PR TITLE
feat(ci): turn off merge queues

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,7 +1,6 @@
 name: Rust
 
 on:
-  merge_group:
   push:
     branches: ["master"]
   pull_request:


### PR DESCRIPTION
The inability to edit the commit message is unfortunately a dealbreaker.