### PR TITLE
fix(app): closing Ki leaves terminal in a weird state

### DIFF
--- a/src/frontend/crossterm.rs
+++ b/src/frontend/crossterm.rs
@@ -25,6 +25,8 @@ impl Crossterm {
     }
 }
 
+#[cfg(not(windows))]
+use crossterm::event::PopKeyboardEnhancementFlags;
 use crossterm::{
     cursor::{Hide, MoveTo, SetCursorStyle, Show},
     event::{
@@ -100,6 +102,12 @@ impl Frontend for Crossterm {
     }
 
     fn leave_alternate_screen(&mut self) -> anyhow::Result<()> {
+        // Need to disable keyboard enhancement when closing Ki
+        // so that we don't leave the terminal in a weird state
+        // (because most terminal apps cannot react to KKP events properly)
+        #[cfg(not(windows))]
+        self.stdout.execute(PopKeyboardEnhancementFlags)?;
+
         self.stdout.execute(LeaveAlternateScreen)?;
         self.stdout.execute(DisableBracketedPaste)?;
         Ok(())


### PR DESCRIPTION
This is fixed by removing the keyboard enhancement commands that were fired to enable Kitty's Keyboard Protocol during the launch of Ki.

This fix is verified by running Ki and closing it immediately, then running Vim.

Before this fix, one press of the colon key (:) in Vim would result in 2 characters being inserted, namely colon and semicolon.