### PR TITLE
fix(language/odin,c#): syntax node selection not working

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2443,6 +2443,7 @@ dependencies = [
  "tree-sitter",
  "tree-sitter-bash",
  "tree-sitter-c",
+ "tree-sitter-c-sharp",
  "tree-sitter-cpp",
  "tree-sitter-css",
  "tree-sitter-diff",
@@ -2823,6 +2824,16 @@ name = "tree-sitter-c"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a3aad8f0129083a59fe8596157552d2bb7148c492d44c21558d68ca1c722707"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-c-sharp"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67f06accca7b45351758663b8215089e643d53bd9a660ce0349314263737fcb0"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/docs/static/app_config_json_schema.json
+++ b/docs/static/app_config_json_schema.json
@@ -72,7 +72,9 @@
         "Toml",
         "KiQuickfix",
         "Haskell",
-        "Hcl"
+        "Hcl",
+        "Odin",
+        "CSharp"
       ]
     },
     "Command": {
@@ -434,6 +436,11 @@
           "description": "A spacer pushes its preceding group of components to the left,\nand the following to the right.\n\nIf a status line contains more than one spacers,\neach spacer will be given the similar width.",
           "type": "string",
           "const": "Spacer"
+        },
+        {
+          "description": "The detected language for the current file",
+          "type": "string",
+          "const": "Language"
         }
       ]
     }

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -57,6 +57,7 @@ tree-sitter-julia = "0.23.1"
 nvim-treesitter-highlight-queries = { version = "0.1.0", path = "../nvim-treesitter-highlight-queries" }
 tree-sitter-hcl = "1.1.0"
 tree-sitter-odin = "1.3.0"
+tree-sitter-c-sharp = "0.23.1"
 
 
 [dev-dependencies]

--- a/shared/src/language.rs
+++ b/shared/src/language.rs
@@ -100,6 +100,7 @@ pub enum CargoLinkedTreesitterLanguage {
     Haskell,
     Hcl,
     Odin,
+    CSharp,
 }
 
 impl CargoLinkedTreesitterLanguage {
@@ -146,6 +147,7 @@ impl CargoLinkedTreesitterLanguage {
             CargoLinkedTreesitterLanguage::KiQuickfix => tree_sitter_quickfix::language(),
             CargoLinkedTreesitterLanguage::Hcl => tree_sitter_hcl::LANGUAGE.into(),
             CargoLinkedTreesitterLanguage::Odin => tree_sitter_odin::LANGUAGE.into(),
+            CargoLinkedTreesitterLanguage::CSharp => tree_sitter_c_sharp::LANGUAGE.into(),
         }
     }
 
@@ -194,6 +196,7 @@ impl CargoLinkedTreesitterLanguage {
             CargoLinkedTreesitterLanguage::KiQuickfix => Some(r#" (header) @keyword"#),
             CargoLinkedTreesitterLanguage::Hcl => None,
             CargoLinkedTreesitterLanguage::Odin => Some(tree_sitter_odin::HIGHLIGHTS_QUERY),
+            CargoLinkedTreesitterLanguage::CSharp => None,
         }
     }
 }

--- a/shared/src/languages.rs
+++ b/shared/src/languages.rs
@@ -231,11 +231,7 @@ fn c_sharp() -> Language {
         lsp_language_id: Some(LanguageId::new("c_sharp")),
         tree_sitter_grammar_config: Some(GrammarConfig {
             id: "c_sharp".to_string(),
-            kind: GrammarConfigKind::FromSource {
-                url: "https://github.com/tree-sitter/tree-sitter-c-sharp".to_string(),
-                subpath: None,
-                commit: "master".to_string(),
-            },
+            kind: GrammarConfigKind::CargoLinked(CargoLinkedTreesitterLanguage::CSharp),
         }),
         line_comment_prefix: Some("//".to_string()),
         block_comment_affixes: Some(("/*".to_string(), "*/".to_string())),

--- a/src/app.rs
+++ b/src/app.rs
@@ -155,6 +155,8 @@ pub enum StatusLineComponent {
     Spacer,
     CurrentFileParentFolder,
     LspProgress,
+    /// The detected language for the current file
+    Language,
 }
 
 impl<T: Frontend> App<T> {
@@ -610,6 +612,12 @@ impl<T: Frontend> App<T> {
                         StatusLineComponent::LspProgress => {
                             Some(FlexLayoutComponent::Text(self.context.lsp_progress()))
                         }
+                        StatusLineComponent::Language => self
+                            .current_component()
+                            .borrow()
+                            .editor()
+                            .language()
+                            .map(FlexLayoutComponent::Text),
                     })
                     .collect_vec(),
             )

--- a/src/components/editor.rs
+++ b/src/components/editor.rs
@@ -4533,6 +4533,12 @@ impl Editor {
             .flatten()
             .collect_vec())
     }
+
+    pub(crate) fn language(&self) -> Option<String> {
+        self.buffer()
+            .language()
+            .and_then(|language| language.tree_sitter_grammar_id())
+    }
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug)]

--- a/src/config_default.json
+++ b/src/config_default.json
@@ -7,6 +7,7 @@
                 "KiCharacter",
                 "Mode",
                 "SelectionMode",
+                "Language",
                 "Reveal",
                 "LastSearchString",
                 "Spacer",


### PR DESCRIPTION
This is fixed by using the cargo-linked tree-sitter-odin.