### PR TITLE
perf(quickfix): cache buffers

### DIFF
--- a/src/quickfix_list.rs
+++ b/src/quickfix_list.rs
@@ -136,19 +136,7 @@ impl QuickfixList {
         items: Vec<QuickfixListItem>,
         current_working_directory: &CanonicalizedPath,
     ) {
-        // Extend the buffers cache with new paths
-        for path in items
-            .iter()
-            .map(|item| &item.location().path)
-            .unique_by(|path| path.try_display_relative_to(current_working_directory))
-        {
-            self.buffers.entry(path.clone()).or_insert_with(|| {
-                Buffer::from_path(path, false)
-                    .ok()
-                    .map(|buffer| Rc::new(RefCell::new(buffer)))
-                    .unwrap_or_else(|| Rc::new(RefCell::new(Buffer::new(None, ""))))
-            });
-        }
+        self.extend_buffers(&items, current_working_directory);
 
         let items = {
             self.items.extend(items);
@@ -166,6 +154,8 @@ impl QuickfixList {
     ) {
         // Clear buffers cache
         self.buffers.clear();
+        self.extend_buffers(&items, current_working_directory);
+
         let (items, dropdown_items) = self.convert_items(items, current_working_directory);
         self.dropdown.set_items(dropdown_items);
         self.items = items;
@@ -276,6 +266,26 @@ impl QuickfixList {
 
     pub(crate) fn set_title(&mut self, title: &str) {
         self.title = title.to_string()
+    }
+
+    fn extend_buffers(
+        &mut self,
+        items: &[QuickfixListItem],
+        current_working_directory: &CanonicalizedPath,
+    ) {
+        // Extend the buffers cache with new paths
+        for path in items
+            .iter()
+            .map(|item| &item.location().path)
+            .unique_by(|path| path.try_display_relative_to(current_working_directory))
+        {
+            self.buffers.entry(path.clone()).or_insert_with(|| {
+                Buffer::from_path(path, false)
+                    .ok()
+                    .map(|buffer| Rc::new(RefCell::new(buffer)))
+                    .unwrap_or_else(|| Rc::new(RefCell::new(Buffer::new(None, ""))))
+            });
+        }
     }
 }
 


### PR DESCRIPTION
## Description

Previously, buffers are constantly reconstructed across different calls of `extend_items` of the same global search session, which caused some files to be repeatedly read from the file system unnecessarily.

This PR avoids the rereading by caching the buffers.

## Proof of improvements
The following flamegraph are obtained by:
1. Run `just profile`
2. Run `space d g i enter` (global search for `gi`)
3. Quit Ki

### Before (37%)

The block of `std::fs::read_...` is visible in the flamegraph.

<img width="600" alt="image" src="https://github.com/user-attachments/assets/a440cccc-63a0-4648-90b0-6bbdef7d3c91" />



### After (27%)

The block of `std::fs::read_...` is no longer visible using the same zoom level.

<img width="600" alt="image" src="https://github.com/user-attachments/assets/53d8c130-ee00-416a-b73e-0ca738f5d410" />