### PR TITLE
refactor(Buffer::get_line_by_line_index): return Result instead of Option

### DIFF
--- a/src/components/editor.rs
+++ b/src/components/editor.rs
@@ -1477,10 +1477,7 @@ impl Editor {
                     let line = self
                         .buffer()
                         .get_line_by_line_index(line_index)
-                        .map(|line| line.to_string())
-                        .ok_or_else(|| {
-                            anyhow::anyhow!("Unable to obtain line at line index {line_index}")
-                        })?;
+                        .map(|line| line.to_string())?;
 
                     let line_char_index = self.buffer().line_to_char(line_index)?;
 
@@ -4095,10 +4092,7 @@ impl Editor {
             let line_char_index = self.buffer().line_to_char(current_line_index)?;
             let line_length = self
                 .buffer()
-                .get_line_by_line_index(current_line_index)
-                .ok_or_else(|| {
-                    anyhow::anyhow!("Unable to get line at line index {current_line_index:?}")
-                })?
+                .get_line_by_line_index(current_line_index)?
                 .len_chars();
 
             [ActionGroup::new(

--- a/src/selection_mode/line_full.rs
+++ b/src/selection_mode/line_full.rs
@@ -42,7 +42,7 @@ impl PositionBasedSelectionMode for LineFull {
             }
         };
         let mut line_index = buffer.char_to_line(start_char_index)?;
-        while let Some(slice) = buffer.get_line_by_line_index(line_index) {
+        while let Ok(slice) = buffer.get_line_by_line_index(line_index) {
             if slice.chars().all(|char| char.is_whitespace()) {
                 return Ok(self
                     .get_current_selection_by_cursor(
@@ -101,7 +101,7 @@ impl PositionBasedSelectionMode for LineFull {
         let mut line_index = buffer.char_to_line(start_char_index)?;
 
         while line_index < buffer.len_lines() {
-            if let Some(slice) = buffer.get_line_by_line_index(line_index) {
+            if let Ok(slice) = buffer.get_line_by_line_index(line_index) {
                 if slice.chars().all(|char| char.is_whitespace()) {
                     return Ok(self
                         .to_index(params, line_index)?
@@ -124,7 +124,7 @@ impl PositionBasedSelectionMode for LineFull {
     ) -> anyhow::Result<Option<super::ByteRange>> {
         let line_index = buffer.char_to_line(cursor_char_index)?;
         let line_start_char_index = buffer.line_to_char(line_index)?;
-        let Some(line) = buffer.get_line_by_line_index(line_index) else {
+        let Ok(line) = buffer.get_line_by_line_index(line_index) else {
             return Ok(None);
         };
         let range = buffer.char_index_range_to_byte_range(

--- a/src/selection_mode/line_trimmed.rs
+++ b/src/selection_mode/line_trimmed.rs
@@ -433,7 +433,7 @@ impl PositionBasedSelectionMode for LineTrimmed {
         let mut line_index = buffer.char_to_line(start_char_index)?;
 
         while line_index < buffer.len_lines() {
-            if let Some(slice) = buffer.get_line_by_line_index(line_index) {
+            if let Ok(slice) = buffer.get_line_by_line_index(line_index) {
                 if slice.chars().all(|char| char.is_whitespace()) {
                     return Ok(self
                         .to_index(params, line_index)?
@@ -483,7 +483,7 @@ impl PositionBasedSelectionMode for LineTrimmed {
             }
         };
         let mut line_index = buffer.char_to_line(start_char_index)?;
-        while let Some(slice) = buffer.get_line_by_line_index(line_index) {
+        while let Ok(slice) = buffer.get_line_by_line_index(line_index) {
             if slice.chars().all(|char| char.is_whitespace()) {
                 return Ok(self
                     .get_current_selection_by_cursor(


### PR DESCRIPTION
Because that's more conventional in the codebase, and calling this Option-returning function in a Result-returning function (which most functions are) involves tedious manual handling.