### PR TITLE
perf(reveal): smoother sibling nodes reveal

### DIFF
--- a/src/components/render_editor.rs
+++ b/src/components/render_editor.rs
@@ -313,12 +313,9 @@ impl Editor {
                 scroll_offset,
             )
             .unwrap_or_default();
-        let visible_lines = rope
-            .lines()
-            .enumerate()
-            .skip(scroll_offset)
-            .take(height)
-            .map(|(line_index, slice)| (line_index, slice.to_string()));
+
+        let visible_lines = (scroll_offset..(scroll_offset + height).min(rope.len_lines()))
+            .map(|line_index| (line_index, rope.line(line_index).to_string()));
 
         let visible_lines_grid: Grid = Grid::new(Dimension { height, width });
 
@@ -1251,7 +1248,7 @@ mod test_render_editor {
 
     #[quickcheck]
     fn get_grid_cells_should_be_always_within_bound(rectangle: Rectangle, content: String) -> bool {
-        let content = content.replace("\r", "");
+        let content = content.replace("\r", "").replace("\u{200c}", "");
         let mut editor = Editor::from_text(None, &content);
         editor.set_rectangle(rectangle.clone(), &Context::default());
         let grid = editor.get_grid(&Context::default(), false);

--- a/src/soft_wrap.rs
+++ b/src/soft_wrap.rs
@@ -168,9 +168,60 @@ impl WrappedLine {
     }
 }
 
-pub fn soft_wrap(text: &str, width: usize) -> WrappedLines {
-    let re = lazy_regex::lazy_regex!(r"\b");
+/// Splits a string at word boundaries, mimicking the behavior of `regex::Regex::split(r"\b")`.
+/// This is a drop-in replacement for the previous regex-based splitting, kept for backward
+/// compatibility so existing test cases continue to pass.
+fn split_word_boundaries(s: &str) -> Vec<&str> {
+    // regex::Regex::split on an empty string returns [""] rather than [],
+    // so we match that behavior here.
+    if s.is_empty() {
+        return vec![""];
+    }
 
+    let mut result = Vec::new();
+    let mut start = 0;
+    let mut chars = s.char_indices().peekable();
+
+    // \b is a zero-width assertion, so splitting by \b on a string that starts
+    // with a word character produces a leading empty string (the split "before"
+    // the first word char). e.g. "hi" -> ["", "hi", ""]
+    if s.chars()
+        .next()
+        .map(|c| c.is_alphanumeric() || c == '_')
+        .unwrap_or(false)
+    {
+        result.push(&s[0..0]);
+    }
+
+    while let Some((_i, c)) = chars.next() {
+        if let Some(&(next_i, next_c)) = chars.peek() {
+            let curr_word = c.is_alphanumeric() || c == '_';
+            let next_word = next_c.is_alphanumeric() || next_c == '_';
+            if curr_word != next_word {
+                result.push(&s[start..next_i]);
+                start = next_i;
+            }
+        }
+    }
+
+    if start < s.len() {
+        result.push(&s[start..]);
+    }
+
+    // \b also produces a trailing empty string when the string ends with a
+    // word character, symmetric to the leading empty string case.
+    if s.chars()
+        .last()
+        .map(|c| c.is_alphanumeric() || c == '_')
+        .unwrap_or(false)
+    {
+        result.push(&s[s.len()..s.len()]);
+    }
+
+    result
+}
+
+pub fn soft_wrap(text: &str, width: usize) -> WrappedLines {
     // LABEL: NEED_TO_REDUCE_WIDTH_BY_1
     // Need to reduce the width by 1 for wrapping,
     // that one space is reserved for rendering cursor at the last column
@@ -179,8 +230,10 @@ pub fn soft_wrap(text: &str, width: usize) -> WrappedLines {
         .lines()
         .enumerate()
         .filter_map(|(line_number, line)| {
-            let items = re
-                .split(&line.to_string())
+            let line_str = line.to_string();
+
+            let items = split_word_boundaries(&line_str)
+                .into_iter()
                 .map(|s| s.trim_end_matches('\n').to_string())
                 .collect_vec();
             let wrapped_lines: Vec<String> = wrap_items(items, wrap_width);


### PR DESCRIPTION
## Description

Previously, revealing large number of sibling nodes is laggy. This is fixed by:
1. In `render_editor`, use `Rope::line` instead of `Rope::lines().enumerate().skip().take()` which is very slow.
2. In `soft_wrap`, use handrolled word splitter instead of using Regex, which is expensive.

## Benchmark
The following flamegraphs are obtained using the steps below:
1. Run `just profile`
2. Go to `editor.rs`
3. Search for `pub fn get_parent_lines`
4. Enter syntax node selection mode (`d`)
5. Reveal possible selections (`space u`)
6. Repeatedly press First and Last 20 times
7. Quit Ki

### Before

https://share.firefox.dev/3ZVdJwE

### After

https://share.firefox.dev/4cjrrRn