### PR TITLE
feat(search): prepend /l when using Search With

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1297,6 +1297,7 @@ impl<T: Frontend> App<T> {
             .borrow()
             .editor()
             .current_primary_selection()?;
+        let current_line = format!("l/{}", current_line.replace("/", r#"\/"#));
         self.open_search_prompt(scope, IfCurrentNotFound::LookForward, Some(current_line))
     }
 

--- a/src/test_app.rs
+++ b/src/test_app.rs
@@ -2830,7 +2830,7 @@ fn open_search_prompt_with_current_selection() -> anyhow::Result<()> {
                 prior_change: None,
             }),
             Expect(CurrentComponentTitle("Local search".to_string())),
-            Expect(CurrentComponentContent("mod foo;")),
+            Expect(CurrentComponentContent("l/mod foo;")),
         ])
     })
 }


### PR DESCRIPTION
Fixes #1397