### PR TITLE
fix(language/go): return null for unhandled lsp request

### DIFF
--- a/src/lsp/process.rs
+++ b/src/lsp/process.rs
@@ -980,6 +980,11 @@ impl LspServerProcess {
 
                         self.send_reply(request.id, serde_json::Value::Null)?;
                     }
+                    "window/workDoneProgress/create" => {
+                        // This reply is necessary for the Go LSP (gopls) to work
+                        // Null as the response is fine but maybe this should be handled properly
+                        self.send_reply(request.id, serde_json::Value::Null)?;
+                    }
                     "window/logMessage" => {
                         let command = self.lsp_command();
                         let params: <lsp_notification!("window/logMessage") as Notification>::Params =


### PR DESCRIPTION
gopls sends this request during startup and stops functioning if it does not receive a response.
Returning null is valid according to the [LSP specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#window_workDoneProgress_create).
This does not implement the actual intent of the request.