### PR TITLE
refactor(event): map repeat events to press

### DIFF
--- a/event/src/event.rs
+++ b/event/src/event.rs
@@ -1,7 +1,5 @@
 use std::{collections::HashSet, fmt};
 
-use crossterm::event::KeyEventKind;
-
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Event {
     Key(KeyEvent),
@@ -25,15 +23,33 @@ impl From<crossterm::event::Event> for Event {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum KeyEventKind {
+    Press,
+    Release,
+}
+
+impl From<crossterm::event::KeyEventKind> for KeyEventKind {
+    fn from(value: crossterm::event::KeyEventKind) -> Self {
+        match value {
+            crossterm::event::KeyEventKind::Press => Self::Press,
+            crossterm::event::KeyEventKind::Repeat => Self::Press,
+            crossterm::event::KeyEventKind::Release => Self::Release,
+        }
+    }
+}
+
 /// This struct is created to enable pattern-matching
 /// on combined modifier keys like Ctrl+Alt+Shift.
 ///
 /// The `crossterm` crate does not support this out of the box.
+///
+/// It also replaces Repeat events with Press events
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct KeyEvent {
     pub code: crossterm::event::KeyCode,
     pub modifiers: KeyModifiers,
-    pub kind: crossterm::event::KeyEventKind,
+    pub kind: KeyEventKind,
 }
 impl fmt::Debug for KeyEvent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -45,7 +61,7 @@ impl KeyEvent {
         KeyEvent {
             code: key,
             modifiers,
-            kind: crossterm::event::KeyEventKind::Press,
+            kind: KeyEventKind::Press,
         }
     }
 
@@ -53,21 +69,13 @@ impl KeyEvent {
         KeyEvent {
             code: key,
             modifiers,
-            kind: crossterm::event::KeyEventKind::Release,
-        }
-    }
-
-    pub const fn repeated(key: crossterm::event::KeyCode, modifiers: KeyModifiers) -> KeyEvent {
-        KeyEvent {
-            code: key,
-            modifiers,
-            kind: crossterm::event::KeyEventKind::Repeat,
+            kind: KeyEventKind::Release,
         }
     }
 
     pub fn to_rust_code(&self) -> String {
         format!(
-            "event::KeyEvent {{ code: crossterm::event::KeyCode::{:#?}, modifiers: event::KeyModifiers::{:#?}, kind: crossterm::event::KeyEventKind::{:#?} }}",
+            "event::KeyEvent {{ code: crossterm::event::KeyCode::{:#?}, modifiers: event::KeyModifiers::{:#?}, kind: event::KeyEventKind::{:#?} }}",
             self.code, self.modifiers, self.kind
         )
     }
@@ -131,17 +139,6 @@ impl KeyEvent {
     pub fn set_event_kind(self, kind: KeyEventKind) -> KeyEvent {
         Self { kind, ..self }
     }
-
-    #[allow(clippy::match_like_matches_macro)]
-    pub fn is_press_or_repeat_equivalent(&self, event: &KeyEvent) -> bool {
-        match (self.kind, event.kind) {
-            (
-                KeyEventKind::Press | KeyEventKind::Repeat,
-                KeyEventKind::Press | KeyEventKind::Repeat,
-            ) if self.code == event.code && self.modifiers == event.modifiers => true,
-            _ => false,
-        }
-    }
 }
 
 impl From<crossterm::event::KeyEvent> for KeyEvent {
@@ -149,7 +146,7 @@ impl From<crossterm::event::KeyEvent> for KeyEvent {
         Self {
             code: value.code,
             modifiers: value.modifiers.into(),
-            kind: value.kind,
+            kind: value.kind.into(),
         }
     }
 }

--- a/event/src/lib.rs
+++ b/event/src/lib.rs
@@ -2,9 +2,9 @@ pub mod event;
 
 use std::collections::HashSet;
 
-pub use crate::event::{KeyEvent, KeyModifiers};
+pub use crate::event::{KeyEvent, KeyEventKind, KeyModifiers};
 
-use crossterm::event::{KeyCode, KeyEventKind};
+use crossterm::event::KeyCode;
 
 #[derive(Debug, PartialEq)]
 struct Token(String);
@@ -29,7 +29,6 @@ impl Token {
         ) -> KeyEvent {
             match event_kind {
                 KeyEventKind::Press => KeyEvent::pressed(key_code, modifiers),
-                KeyEventKind::Repeat => KeyEvent::repeated(key_code, modifiers),
                 KeyEventKind::Release => KeyEvent::released(key_code, modifiers),
             }
         }
@@ -44,7 +43,7 @@ impl Token {
             if token.0.starts_with("repeat-") {
                 return to_key_event(
                     &Token(token.0.trim_start_matches("repeat-").to_string()),
-                    KeyEventKind::Repeat,
+                    KeyEventKind::Press,
                 );
             }
             match token.0.split('+').collect::<Vec<_>>().split_last() {

--- a/src/components/editor.rs
+++ b/src/components/editor.rs
@@ -35,8 +35,8 @@ use crate::{
     transformation::{MyRegex, Transformation},
 };
 use crate::{grid::LINE_NUMBER_VERTICAL_BORDER, selection_mode::PositionBasedSelectionMode};
-use crossterm::event::{KeyCode, KeyEventKind, MouseButton, MouseEventKind};
-use event::KeyEvent;
+use crossterm::event::{KeyCode, MouseButton, MouseEventKind};
+use event::{KeyEvent, KeyEventKind};
 use itertools::{Either, Itertools};
 use my_proc_macros::key;
 use nonempty::NonEmpty;

--- a/src/components/editor_keymap_legend.rs
+++ b/src/components/editor_keymap_legend.rs
@@ -1,8 +1,8 @@
-use crossterm::event::{KeyCode, KeyEventKind};
+use crossterm::event::KeyCode;
 use SelectionMode::*;
 
 use convert_case::Case;
-use event::KeyEvent;
+use event::{KeyEvent, KeyEventKind};
 use itertools::Itertools;
 
 use crate::{
@@ -590,17 +590,11 @@ impl Editor {
         if let Some(dispatches) = self
             .insert_mode_keymap(true)
             .iter()
-            .find(|keymap| {
-                keymap
-                    .event()
-                    .is_press_or_repeat_equivalent(&translated_event)
-            })
+            .find(|keymap| keymap.event() == &translated_event)
             .map(|keymap| keymap.get_dispatches())
         {
             Ok(dispatches)
-        } else if let (KeyCode::Char(c), KeyEventKind::Press | KeyEventKind::Repeat) =
-            (event.code, event.kind)
-        {
+        } else if let (KeyCode::Char(c), KeyEventKind::Press) = (event.code, event.kind) {
             self.insert(&c.to_string(), context)
         } else {
             Ok(Dispatches::default())

--- a/src/components/keymap_legend.rs
+++ b/src/components/keymap_legend.rs
@@ -1,4 +1,4 @@
-use event::{parse_key_event, KeyEvent};
+use event::{parse_key_event, KeyEvent, KeyEventKind};
 
 use itertools::Itertools;
 use my_proc_macros::key;
@@ -278,7 +278,7 @@ impl KeymapLegend {
         let release_key = release_key.map(|release_key| ParsedReleaseKey {
             key: release_key.key,
             key_event: KeyEvent {
-                kind: crossterm::event::KeyEventKind::Release,
+                kind: KeyEventKind::Release,
                 ..parse_key_event(release_key.key).unwrap()
             },
             on_tap: release_key.on_tap,
@@ -431,7 +431,6 @@ mod test_keymap_legend {
         app::Dimension, buffer::BufferOwner, components::editor::DispatchEditor,
         position::Position, test_app::*,
     };
-    use crossterm::event::KeyEventKind;
     use my_proc_macros::keys;
 
     #[test]

--- a/src/components/suggestive_editor.rs
+++ b/src/components/suggestive_editor.rs
@@ -3,7 +3,7 @@ use crate::context::{Context, GlobalMode};
 use crate::grid::StyleKey;
 use crate::selection::SelectionMode;
 use crate::thread::Callback;
-use crossterm::event::KeyEventKind;
+use event::KeyEventKind;
 use DispatchEditor::*;
 
 use crate::selection_range::SelectionRange;


### PR DESCRIPTION
We never have a real need for distinguishing repeat events at the
moment, and it complicates code in a number of places.