### PR TITLE
fix(render): reapply colors when text attributes change

### DIFF
--- a/src/frontend/render.rs
+++ b/src/frontend/render.rs
@@ -107,40 +107,51 @@ impl<'a> TerminalState<'a> {
         Ok(())
     }
 
-    fn bold(&mut self, cell: &PositionedCell) -> anyhow::Result<()> {
-        if self.bold != cell.cell.is_bold {
+    fn bold(&mut self, cell: &PositionedCell) -> anyhow::Result<bool> {
+        let changed = self.bold != cell.cell.is_bold;
+        if changed {
             self.renderer.bold(cell)?;
         }
         self.bold = cell.cell.is_bold;
-        Ok(())
+        Ok(changed)
     }
 
-    fn underline_color(&mut self, cell: &PositionedCell) -> anyhow::Result<()> {
-        if self.underline_color != cell_underline_color(cell) {
+    fn underline_color(&mut self, cell: &PositionedCell) -> anyhow::Result<bool> {
+        let changed = self.underline_color != cell_underline_color(cell);
+        if changed {
             self.renderer.underline_color(cell)?;
         }
         self.underline_color = cell_underline_color(cell);
-        Ok(())
+        Ok(changed)
     }
 
-    fn underline_state(&mut self, cell: &PositionedCell) -> anyhow::Result<()> {
-        if self.underline_state != cell_underline_state(cell) {
+    fn underline_state(&mut self, cell: &PositionedCell) -> anyhow::Result<bool> {
+        let changed = self.underline_state != cell_underline_state(cell);
+        if changed {
             self.renderer.underline_state(cell)?;
         }
         self.underline_state = cell_underline_state(cell);
-        Ok(())
+        Ok(changed)
     }
 
-    fn background_color(&mut self, cell: &PositionedCell) -> anyhow::Result<()> {
-        if self.background_color != cell.cell.background_color {
+    fn background_color(
+        &mut self,
+        cell: &PositionedCell,
+        force_reapply: bool,
+    ) -> anyhow::Result<()> {
+        if force_reapply || self.background_color != cell.cell.background_color {
             self.renderer.background_color(cell)?;
         }
         self.background_color = cell.cell.background_color;
         Ok(())
     }
 
-    fn foreground_color(&mut self, cell: &PositionedCell) -> anyhow::Result<()> {
-        if self.foreground_color != cell.cell.foreground_color {
+    fn foreground_color(
+        &mut self,
+        cell: &PositionedCell,
+        force_reapply: bool,
+    ) -> anyhow::Result<()> {
+        if force_reapply || self.foreground_color != cell.cell.foreground_color {
             self.renderer.foreground_color(cell)?;
         }
         self.foreground_color = cell.cell.foreground_color;
@@ -180,11 +191,13 @@ pub(super) fn render_cells(
 
     for cell in cells {
         terminal_state.move_to(&cell)?;
-        terminal_state.bold(&cell)?;
-        terminal_state.underline_color(&cell)?;
-        terminal_state.underline_state(&cell)?;
-        terminal_state.background_color(&cell)?;
-        terminal_state.foreground_color(&cell)?;
+        let should_reapply_colors = terminal_state.bold(&cell)?
+            || terminal_state.underline_color(&cell)?
+            || terminal_state.underline_state(&cell)?;
+        // Some terminals may implicitly reset colors when text attributes change.
+        // Re-apply colors to keep the background/foreground stable.
+        terminal_state.background_color(&cell, should_reapply_colors)?;
+        terminal_state.foreground_color(&cell, should_reapply_colors)?;
         // The symbol is always printed, otherwise the attributes aren't applied
         terminal_state.renderer.print(&cell)?;
     }
@@ -197,5 +210,58 @@ fn reveal(s: char) -> char {
         '\n' => ' ',
         '\t' => ' ',
         _ => s,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        frontend::{render::render_cells, MyWriter, StringWriter},
+        grid::{Cell, CellLine, CellLineStyle, PositionedCell},
+        position::Position,
+        themes::Color,
+    };
+
+    #[test]
+    fn reapply_colors_when_underline_state_changes() {
+        let mut writer: Box<dyn MyWriter> = Box::new(StringWriter::new());
+        let foreground = Color::new(1, 2, 3);
+        let background = Color::new(250, 251, 252);
+
+        let cells = vec![
+            PositionedCell {
+                position: Position::new(0, 1),
+                cell: Cell {
+                    symbol: 'a',
+                    foreground_color: foreground,
+                    background_color: background,
+                    line: None,
+                    ..Cell::default()
+                },
+            },
+            PositionedCell {
+                position: Position::new(0, 0),
+                cell: Cell {
+                    symbol: 'b',
+                    foreground_color: foreground,
+                    background_color: background,
+                    line: Some(CellLine {
+                        color: foreground,
+                        style: CellLineStyle::Underline,
+                    }),
+                    ..Cell::default()
+                },
+            },
+        ];
+
+        render_cells(&mut writer, cells).unwrap();
+
+        let ansi = writer
+            .as_any()
+            .downcast_ref::<StringWriter>()
+            .unwrap()
+            .get_string();
+        assert_eq!(ansi.matches("[48;2;250;251;252m").count(), 2);
+        assert_eq!(ansi.matches("[38;2;1;2;3m").count(), 2);
     }
 }


### PR DESCRIPTION
<img width="1858" height="941" alt="image" src="https://github.com/user-attachments/assets/0da121ac-03b7-4c7d-a152-ffe6ea1f5493" />

When switching underline/bold attributes, some terminals may "secretly reset" colors, but our current optimization logic doesn't resend the foreground/background colors, which can easily leave black background artifacts.

Now I'll modify according to this plan:

In src/frontend/render.rs, adjust TerminalState:

bold/underline_* return "whether changed"
If changed, force resend the current cell's foreground and background colors (even if color values haven't changed)
Add a unit test to reproduce this edge case:
Two consecutive cells with the same color, but underline state changes
Assert that foreground/background color sequences appear twice in ANSI output (proving the second cell also replenished colors)
Run targeted tests to verify the fix doesn't break existing behavior
Now I'll start modifying the code.