### PR TITLE
fix(list/grep): replace not working if dirty bit was false

### DIFF
--- a/src/list/grep.rs
+++ b/src/list/grep.rs
@@ -114,7 +114,7 @@ pub fn replace(
         .into_iter()
         .map(|mut buffer| {
             buffer
-                .save_without_formatting(context, false)
+                .save_without_formatting(context, true)
                 .map(|(d, _)| d)
         })
         .collect::<anyhow::Result<Vec<_>>>()?


### PR DESCRIPTION
Fixes: #1466.