### PR TITLE
fix(logging): remove noisy entries from `notify::fsevent`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,10 @@ fn init_logger() -> anyhow::Result<()> {
             tracing_subscriber::fmt::layer()
                 .with_writer(open_log_file(grammar::default_log_file())?)
                 .with_line_number(true)
-                .with_ansi(false),
+                .with_ansi(false)
+                .with_filter(tracing_subscriber::filter::filter_fn(|metadata| {
+                    !metadata.target().starts_with("notify::fsevent")
+                })),
         )
         .with(
             tracing_subscriber::fmt::layer()


### PR DESCRIPTION
...which are fired whenever the file system is updated.