### PR TITLE
refactor: Rename Movement History to Move Hist

### DIFF
--- a/docs/docs/momentary-layers/movement-history-mol.mdx
+++ b/docs/docs/momentary-layers/movement-history-mol.mdx
@@ -1,7 +1,7 @@
 import {TutorialFallback} from '@site/src/components/TutorialFallback';
 import {KeymapFallback} from '@site/src/components/KeymapFallback';
 
-# ≡ Movement History
+# ≡ Move Hist (Movement History)
 
 The keybinds in this Momentary Layer (≡) navigate you to cursor and file positions in their historical orders.
 

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -1384,9 +1384,9 @@ pub fn keymap_other_movements() -> Vec<Keybinding> {
         ),
         Keybinding::app_momentary_layer(MomentaryLayer {
             key: "q",
-            name: "≡ Movement History".to_string(),
+            name: "≡ Move Hist".to_string(),
             config: KeymapLegendConfig {
-                title: "≡ Movement History".to_string(),
+                title: "≡ Move Hist".to_string(),
                 keymap: movement_history_keymap(),
             },
             on_tap: None,
@@ -1653,7 +1653,7 @@ pub fn movement_history_keymap() -> Keymap {
         .map(|(movement, key)| {
             Keybinding::new(
                 key,
-                movement.format_action("Movement History"),
+                movement.format_action("Move Hist"),
                 Dispatch::MovementHistoryNavigation(movement),
             )
         })


### PR DESCRIPTION
[#🧩 Feature > ✔ ≡ Movement History too wide. How about ≡ Movement ⧖](https://ki-editor.zulipchat.com/#narrow/channel/551672-.F0.9F.A7.A9-Feature/topic/.E2.9C.94.20.E2.89.A1.20Movement.20History.20too.20wide.2E.20How.20about.20.E2.89.A1.20Movement.20.E2.A7.96/with/583227527)[#🧩 Feature > ✔ ≡ Movement History too wide. How about ≡ Movement ⧖](https://ki-editor.zulipchat.com/#narrow/channel/551672-.F0.9F.A7.A9-Feature/topic/.E2.9C.94.20.E2.89.A1.20Movement.20History.20too.20wide.2E.20How.20about.20.E2.89.A1.20Movement.20.E2.A7.96/with/583227527)