### PR TITLE
refactor(location_history): make clearing location_history explicit

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1585,6 +1585,7 @@ impl<T: Frontend> App<T> {
 
         if store_history {
             self.push_current_location_into_navigation_history(true);
+            self.context.clear_forward_history();
         }
 
         // Check if the file is opened before so that we won't notify the LSP twice
@@ -2946,6 +2947,7 @@ impl<T: Frontend> App<T> {
             if location.path.exists() {
                 self.push_current_location_into_navigation_history(true);
                 self.go_to_location(&location, false)?;
+                return Ok(());
             }
         }
         Ok(())

--- a/src/context.rs
+++ b/src/context.rs
@@ -531,10 +531,13 @@ impl Context {
     pub fn push_location_history(&mut self, location: Location, backward: bool) {
         if backward {
             self.location_history_backward.push(location);
-            self.location_history_forward.clear();
         } else {
             self.location_history_forward.push(location);
         }
+    }
+
+    pub fn clear_forward_history(&mut self) {
+            self.location_history_forward.clear();
     }
 
     pub fn location_previous(&mut self) -> Option<Location> {

--- a/src/context.rs
+++ b/src/context.rs
@@ -537,7 +537,7 @@ impl Context {
     }
 
     pub fn clear_forward_history(&mut self) {
-            self.location_history_forward.clear();
+        self.location_history_forward.clear();
     }
 
     pub fn location_previous(&mut self) -> Option<Location> {

--- a/src/recipes.rs
+++ b/src/recipes.rs
@@ -2782,7 +2782,7 @@ fn movement_history_mol_in_file() -> RecipeGroup {
                 file_extension: "md",
                 prepare_events: keys!("space ; n d s r c enter enter n d m a enter enter e k release-e space ; n d f o enter enter e k release-e space ; n d t e m enter enter e k release-e space ; n d g i t enter enter"),
                 events: keys!("e j j release-e l l l e j release-e q j j j l l release-q"),
-                expectations: Box::new([CurrentSelectedTexts(&[""])]),
+                expectations: Box::new([CurrentSelectedTexts(&["println!(\"Hello, world!\");"])]),
                 terminal_height: Some(10),
                 similar_vim_combos: &[""],
                 only: false,


### PR DESCRIPTION
Fixes #1487 
Fixes #1519

`push_location_history(true)` clears `location_history_forward` which it shouldn't if it gets called by doing `Nav ->`.
To fix this I made it so `push_location_history` never clears `location_history_forward` and added the `clear_location_history` function, which is used in `open_file` (since you do want to clear `location_history_forward` in that case).
I also made it so `location_next` returns at the first match (since `location_history_forward` doesn't get cleared anymore, without this change it would go to the last match, which doesn't make much sense).

I am not 100% convinced this is the cleanest way to go about it though (for example, I made it so `clear_location_history` can be used for clearing both forward and backward location history, but currently `location_history_backward` is never cleared, so I'm not sure if making it work both ways is needed or just makes things more confusing).