### PR TITLE
feat(languages): add Devicetree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2515,6 +2515,7 @@ dependencies = [
  "tree-sitter-clojure",
  "tree-sitter-cpp",
  "tree-sitter-css",
+ "tree-sitter-devicetree",
  "tree-sitter-diff",
  "tree-sitter-elixir",
  "tree-sitter-fish",
@@ -2973,6 +2974,16 @@ name = "tree-sitter-css"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ad6489794d41350d12a7fbe520e5199f688618f43aace5443980d1ddcf1b29e"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-devicetree"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6264316c288e1d4fed3002fb6c2d7a8e90d65d519e2ecf64a60c5abd0ee35481"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/contrib/emoji-icon-theme.json
+++ b/contrib/emoji-icon-theme.json
@@ -114,7 +114,10 @@
         "mp4": "🎞",
         "mov": "🎞",
         "mp3": "🔈",
-        "wav": "🔈"
+        "wav": "🔈",
+        "keymap": "⌨",
+        "dts": "🪁",
+        "dtsi": "🪁"
     },
     "fileNames": {
         ".gitignore": "🙈",

--- a/docs/static/app_config_json_schema.json
+++ b/docs/static/app_config_json_schema.json
@@ -112,7 +112,8 @@
                 "CSharp",
                 "Clojure",
                 "FSharp",
-                "Scala"
+                "Scala",
+                "Devicetree"
             ]
         },
         "Command": {

--- a/nvim-treesitter-highlight-queries/build.rs
+++ b/nvim-treesitter-highlight-queries/build.rs
@@ -7,6 +7,7 @@ const INCLUDED_NVIM_TREESITTER_LANGUAGES: &[&str] = &[
     "cpp",
     "css",
     "csv",
+    "devicetree",
     "diff",
     "dockerfile",
     "dune",

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -63,6 +63,7 @@ tree-sitter-c-sharp = "0.23.1"
 tree-sitter-fsharp = "0.2.2"
 tree-sitter-perl-next = "0.1.0"
 codebook-tree-sitter-latex = "0.6.1"
+tree-sitter-devicetree = "0.15.0"
 
 
 [dev-dependencies]

--- a/shared/src/language.rs
+++ b/shared/src/language.rs
@@ -106,6 +106,7 @@ pub enum CargoLinkedTreesitterLanguage {
     Clojure,
     FSharp,
     Scala,
+    Devicetree,
 }
 
 impl CargoLinkedTreesitterLanguage {
@@ -158,6 +159,7 @@ impl CargoLinkedTreesitterLanguage {
             CargoLinkedTreesitterLanguage::Clojure => tree_sitter_clojure::LANGUAGE.into(),
             CargoLinkedTreesitterLanguage::FSharp => tree_sitter_fsharp::LANGUAGE_FSHARP.into(),
             CargoLinkedTreesitterLanguage::Scala => tree_sitter_scala::LANGUAGE.into(),
+            CargoLinkedTreesitterLanguage::Devicetree => tree_sitter_devicetree::LANGUAGE.into(),
         }
     }
 
@@ -212,6 +214,9 @@ impl CargoLinkedTreesitterLanguage {
             CargoLinkedTreesitterLanguage::Clojure => None,
             CargoLinkedTreesitterLanguage::FSharp => Some(tree_sitter_fsharp::HIGHLIGHTS_QUERY),
             CargoLinkedTreesitterLanguage::Scala => Some(tree_sitter_scala::HIGHLIGHTS_QUERY),
+            CargoLinkedTreesitterLanguage::Devicetree => {
+                Some(tree_sitter_devicetree::HIGHLIGHTS_QUERY)
+            }
         }
     }
 }

--- a/shared/src/languages.rs
+++ b/shared/src/languages.rs
@@ -23,6 +23,7 @@ pub fn languages() -> HashMap<String, Language> {
         ("c_sharp", c_sharp()),
         ("css", css()),
         ("csv", csv()),
+        ("devicetree", devicetree()),
         ("diff", diff()),
         ("dockerfile", dockerfile()),
         ("elixir", elixir()),
@@ -251,6 +252,22 @@ fn css() -> Language {
             id: "css".to_string(),
             kind: GrammarConfigKind::CargoLinked(CargoLinkedTreesitterLanguage::CSS),
         }),
+        block_comment_affixes: Some(("/*".to_string(), "*/".to_string())),
+        ..Language::new()
+    }
+}
+
+fn devicetree() -> Language {
+    Language {
+        extensions: to_vec(&["dts", "dtsi", "keymap"]),
+        formatter: None,
+        lsp_command: None,
+        lsp_language_id: None,
+        tree_sitter_grammar_config: Some(GrammarConfig {
+            id: "devicetree".to_string(),
+            kind: GrammarConfigKind::CargoLinked(CargoLinkedTreesitterLanguage::Devicetree),
+        }),
+        line_comment_prefix: Some("//".to_string()),
         block_comment_affixes: Some(("/*".to_string(), "*/".to_string())),
         ..Language::new()
     }


### PR DESCRIPTION
This adds tree-sitter support for Zephyr (.dts, .dtsi) and Zephyr related projects, such as ZMK (.keymap)