### PR TITLE
feat(config/lsp): allow specifying environment variables

### DIFF
--- a/docs/static/app_config_json_schema.json
+++ b/docs/static/app_config_json_schema.json
@@ -310,6 +310,14 @@
                 "command": {
                     "$ref": "#/$defs/Command"
                 },
+                "environment": {
+                    "description": "Environment variables to set when spawning the LSP process.\nExample: `{ \"CARGO_TARGET_DIR\": \"target/analyzer\" }`",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "default": {}
+                },
                 "initialization_options": true
             },
             "additionalProperties": false,

--- a/shared/src/language.rs
+++ b/shared/src/language.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use grammar::grammar::GrammarConfiguration;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -226,6 +228,10 @@ impl CargoLinkedTreesitterLanguage {
 pub struct LspCommand {
     pub(crate) command: Command,
     pub(crate) initialization_options: Option<serde_json::Value>,
+    /// Environment variables to set when spawning the LSP process.
+    /// Example: `{ "CARGO_TARGET_DIR": "target/analyzer" }`
+    #[serde(default)]
+    pub(crate) environment: HashMap<String, String>,
 }
 
 impl Language {
@@ -256,6 +262,13 @@ impl Language {
 
     pub fn block_comment_affixes(&self) -> Option<(String, String)> {
         self.block_comment_affixes.clone()
+    }
+
+    pub fn lsp_environment(&self) -> HashMap<String, String> {
+        self.lsp_command
+            .as_ref()
+            .map(|c| c.environment.clone())
+            .unwrap_or_default()
     }
 }
 
@@ -378,7 +391,11 @@ impl Language {
 
     pub fn lsp_process_command(&self) -> Option<ProcessCommand> {
         self.lsp_command.as_ref().map(|command| {
-            ProcessCommand::new(&command.command.command, &command.command.arguments)
+            ProcessCommand::with_environment(
+                &command.command.command,
+                &command.command.arguments,
+                &command.environment,
+            )
         })
     }
 

--- a/shared/src/languages.rs
+++ b/shared/src/languages.rs
@@ -307,6 +307,7 @@ fn elixir() -> Language {
         lsp_command: Some(LspCommand {
             command: Command::new("elixir-ls", &[]),
             initialization_options: None,
+            environment: HashMap::new(),
         }),
         lsp_language_id: Some(LanguageId::new("elixir")),
         tree_sitter_grammar_config: Some(GrammarConfig {
@@ -466,6 +467,7 @@ fn graphql() -> Language {
             initialization_options: Some(
                 json! {r#"{ "graphql-config.load.legacy": true }"#.to_string()},
             ),
+            environment: HashMap::new(),
         }),
         lsp_language_id: Some(LanguageId::new("graphql")),
         tree_sitter_grammar_config: Some(GrammarConfig {
@@ -513,6 +515,7 @@ fn heex() -> Language {
         lsp_command: Some(LspCommand {
             command: Command::new("elixir-ls", &[]),
             initialization_options: None,
+            environment: HashMap::new(),
         }),
         lsp_language_id: Some(LanguageId::new("heex")),
         tree_sitter_grammar_config: Some(GrammarConfig {
@@ -531,6 +534,7 @@ fn latex() -> Language {
         lsp_command: Some(LspCommand {
             command: Command::new("texlab", &[]),
             initialization_options: None,
+            environment: HashMap::new(),
         }),
         lsp_language_id: Some(LanguageId::new("latex")),
         line_comment_prefix: Some("%".to_string()),

--- a/shared/src/process_command.rs
+++ b/shared/src/process_command.rs
@@ -1,10 +1,14 @@
 use anyhow::Context;
-use std::io::{Read, Write};
+use std::{
+    collections::HashMap,
+    io::{Read, Write},
+};
 
 #[derive(Debug)]
 pub struct ProcessCommand {
     command: String,
     args: Vec<String>,
+    environment: HashMap<String, String>,
 }
 
 pub enum SpawnCommandResult {
@@ -30,6 +34,19 @@ impl ProcessCommand {
         Self {
             command: command.to_string(),
             args: args.iter().map(|s| s.to_string()).collect(),
+            environment: HashMap::new(),
+        }
+    }
+
+    pub fn with_environment(
+        command: &str,
+        args: &[String],
+        environment: &HashMap<String, String>,
+    ) -> Self {
+        Self {
+            command: command.to_string(),
+            args: args.iter().map(|s| s.to_string()).collect(),
+            environment: environment.clone(),
         }
     }
 
@@ -51,6 +68,7 @@ impl ProcessCommand {
                 .stdin(std::process::Stdio::piped())
                 .stdout(std::process::Stdio::piped())
                 .stderr(std::process::Stdio::piped())
+                .envs(&self.environment)
                 .spawn()
                 .map_err(|e| {
                     anyhow::anyhow!(


### PR DESCRIPTION
Solving an issue raised here:

@_**Irevoire|1045485** [said](https://ki-editor.zulipchat.com/#narrow/channel/538719-.F0.9F.9B.9F-Help/topic/Rust-analyzer.20config/near/585629527) in [#**🛟 Help>Rust-analyzer config**](#narrow/channel/538719-.F0.9F.9B.9F-Help/topic/Rust-analyzer.20config/with/585629527):

> From what I see of the conf we're missing the environment configuration right?
