### PR TITLE
feat(editor): Undo/Redo MoL

### DIFF
--- a/docs/docs/momentary-layers/undo-redo-mol.mdx
+++ b/docs/docs/momentary-layers/undo-redo-mol.mdx
@@ -1,0 +1,16 @@
+# ≡ Undo/Redo
+
+## Keymap
+
+<KeymapFallback filename="Undo/Redo"/>
+
+## Description
+
+Undo/Redo comes in two categories:
+
+1. Coarse
+2. Fine
+
+Both behave identically for actions executed in normal modes.
+
+The difference only surfaces in Insert mode: Fine undo/redo operates character by character, while Coarse undo/redo deletes or reinserts the entire chunk of text entered during the last Insert session.

--- a/docs/docs/momentary-layers/undo-redo-mol.mdx
+++ b/docs/docs/momentary-layers/undo-redo-mol.mdx
@@ -13,4 +13,4 @@ Undo/Redo comes in two categories:
 
 Both behave identically for actions executed in normal modes.
 
-The difference only surfaces in Insert mode: Fine undo/redo operates character by character, while Coarse undo/redo deletes or reinserts the entire chunk of text entered during the last Insert session.
+The difference only surfaces in Insert mode: Fine undo/redo operates character by character, while Coarse undo/redo deletes or reinserts the entire chunk of text typed during the last Insert session.

--- a/docs/docs/momentary-layers/undo-redo-mol.mdx
+++ b/docs/docs/momentary-layers/undo-redo-mol.mdx
@@ -2,7 +2,7 @@
 
 ## Keymap
 
-<KeymapFallback filename="Undo/Redo"/>
+<KeymapFallback filename="Undo-Redo"/>
 
 ## Description
 

--- a/docs/docs/momentary-layers/undo-redo-mol.mdx
+++ b/docs/docs/momentary-layers/undo-redo-mol.mdx
@@ -1,3 +1,5 @@
+import {KeymapFallback} from '@site/src/components/KeymapFallback';
+
 # ≡ Undo/Redo
 
 ## Keymap

--- a/docs/docs/normal-mode/actions.md
+++ b/docs/docs/normal-mode/actions.md
@@ -154,13 +154,6 @@ File unmarking has two behaviors:
 
 To move between marked files, see [≡ Buffer](../momentary-layers/buffer-mol).
 
-### `Undo`/`Redo`
-
-Notes:
-
-1. Undo/redo works for multi-cursors as well
-2. The current implementation is naive, it undoes/redoes character-by-character, instead of chunk-by-chunk, so it can be mildly frustrating
-
 ### Save
 
 Keybinding: `enter`

--- a/reference/Coarse Redo.md
+++ b/reference/Coarse Redo.md
@@ -1,0 +1,1 @@
+Performs a Coarse Undo, which redoes ALL the characters typed in the last Insert session.

--- a/reference/Coarse Undo.md
+++ b/reference/Coarse Undo.md
@@ -1,0 +1,1 @@
+Performs a Coarse Undo, which undoes ALL the characters typed in the last Insert session.

--- a/reference/Fine Redo.md
+++ b/reference/Fine Redo.md
@@ -1,0 +1,1 @@
+Performs a Fine Redo, which redoes a single character typed in the current or last Insert session.

--- a/reference/Fine Undo.md
+++ b/reference/Fine Undo.md
@@ -1,0 +1,1 @@
+Performs a Fine Redo, which undoes a single character typed in the current or last Insert session.

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -550,6 +550,7 @@ impl Buffer {
         reparse_tree: bool,
         update_undo_stack: bool,
         last_visible_line: usize,
+        kind: EditHistoryKind,
     ) -> Result<(SelectionSet, Dispatches, Vec<ki_protocol_types::DiffEdit>), anyhow::Error> {
         let new_selection_set = edit_transaction
             .non_empty_selections()
@@ -593,6 +594,7 @@ impl Buffer {
                 inverted_unnormalized_edits: applied_vscode_edits.clone(),
                 old_state: current_buffer_state,
                 new_state: new_buffer_state,
+                kind,
             });
 
             // Clear the redo stack when a new edit is made
@@ -848,6 +850,7 @@ impl Buffer {
             true,
             true,
             last_visible_line,
+            EditHistoryKind::Coarse,
         )?;
         Ok(dispatches)
     }
@@ -1093,6 +1096,7 @@ impl Buffer {
             true,
             true,
             last_visible_line,
+            EditHistoryKind::Coarse,
         )?;
         let after = self.content();
         let modified = before != after;
@@ -1190,10 +1194,11 @@ impl Buffer {
             self.reparse_tree()?;
 
             let selection_set = history.old_state.selection_set.clone();
+            let kind = history.kind.clone();
             self.undo_stack.push(history.inverse());
 
             // Return both the selection set and the applied transaction
-            Ok(Some((dispatches, selection_set, diff_edits, edits)))
+            Ok(Some((dispatches, selection_set, diff_edits, edits, kind)))
         } else {
             Ok(None)
         }
@@ -1219,13 +1224,22 @@ impl Buffer {
             self.reparse_tree()?;
 
             let selection_set = history.old_state.selection_set.clone();
+            let kind = history.kind.clone();
             self.redo_stack.push(history.inverse());
 
             // Return both the selection set and the applied transaction
-            Ok(Some((dispatches, selection_set, diff_edits, edits)))
+            Ok(Some((dispatches, selection_set, diff_edits, edits, kind)))
         } else {
             Ok(None)
         }
+    }
+
+    pub fn peek_undo_stack(&self) -> Option<&EditHistory> {
+        self.undo_stack.last()
+    }
+
+    pub fn peek_redo_stack(&self) -> Option<&EditHistory> {
+        self.redo_stack.last()
     }
 
     pub fn line_to_char_range(&self, line: usize) -> anyhow::Result<CharIndexRange> {
@@ -1553,7 +1567,7 @@ fn f(
     }
 
     mod patch_edit {
-        use crate::edit::EditTransaction;
+        use crate::{buffer::EditHistoryKind, edit::EditTransaction};
 
         use super::*;
         fn run_test(old: &str, new: &str) -> anyhow::Result<EditTransaction> {
@@ -1568,6 +1582,7 @@ fn f(
                 true,
                 true,
                 0,
+                EditHistoryKind::Coarse,
             )?;
 
             // Expect the content to be the same as the 2nd files
@@ -1688,12 +1703,12 @@ impl std::fmt::Display for BufferState {
     }
 }
 
-// New structure to store edits and their inverses for undo/redo
 #[derive(Clone)]
 pub struct EditHistory {
     pub edit_transaction: EditTransaction,
     pub old_state: BufferState,
     pub new_state: BufferState,
+    pub kind: EditHistoryKind,
 
     /// This is required by VS Code because VS Code will offset the edits on their end.
     unnormalized_edits: Vec<ki_protocol_types::DiffEdit>,
@@ -1703,6 +1718,13 @@ pub struct EditHistory {
     /// without relying on the pre-edited buffer.
     inverted_unnormalized_edits: Vec<ki_protocol_types::DiffEdit>,
 }
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EditHistoryKind {
+    Coarse,
+    Fine,
+}
+
 impl EditHistory {
     fn inverse(self) -> EditHistory {
         EditHistory {
@@ -1711,6 +1733,7 @@ impl EditHistory {
             new_state: self.old_state,
             inverted_unnormalized_edits: self.unnormalized_edits,
             unnormalized_edits: self.inverted_unnormalized_edits,
+            kind: self.kind,
         }
     }
 }
@@ -1720,4 +1743,5 @@ type UndoRedoReturn = Option<(
     SelectionSet,
     Vec<ki_protocol_types::DiffEdit>,
     Vec<Edit>,
+    EditHistoryKind,
 )>;

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1174,7 +1174,11 @@ impl Buffer {
         Ok(start..end)
     }
 
-    pub fn redo(&mut self, last_visible_line: usize) -> Result<UndoRedoReturn, anyhow::Error> {
+    pub fn redo(
+        &mut self,
+        last_visible_line: usize,
+        reparse_tree: bool,
+    ) -> Result<UndoRedoReturn, anyhow::Error> {
         if let Some(history) = self.redo_stack.pop() {
             let diff_edits = history.unnormalized_edits.clone();
 
@@ -1191,7 +1195,9 @@ impl Buffer {
                     Ok(dispatches.chain(self.apply_edit(&edit, last_visible_line)?))
                 },
             )?;
-            self.reparse_tree()?;
+            if reparse_tree {
+                self.reparse_tree()?;
+            }
 
             let selection_set = history.old_state.selection_set.clone();
             let kind = history.kind.clone();
@@ -1204,7 +1210,11 @@ impl Buffer {
         }
     }
 
-    pub fn undo(&mut self, last_visible_line: usize) -> Result<UndoRedoReturn, anyhow::Error> {
+    pub fn undo(
+        &mut self,
+        last_visible_line: usize,
+        reparse_tree: bool,
+    ) -> Result<UndoRedoReturn, anyhow::Error> {
         if let Some(history) = self.undo_stack.pop() {
             let diff_edits = history.unnormalized_edits.clone();
 
@@ -1221,7 +1231,9 @@ impl Buffer {
                     Ok(dispatches.chain(self.apply_edit(&edit, last_visible_line)?))
                 },
             )?;
-            self.reparse_tree()?;
+            if reparse_tree {
+                self.reparse_tree()?;
+            }
 
             let selection_set = history.old_state.selection_set.clone();
             let kind = history.kind.clone();
@@ -1487,7 +1499,7 @@ fn f(
                 assert_ne!(buffer.rope.to_string(), original);
 
                 // Undo the buffer
-                buffer.undo(0).unwrap();
+                buffer.undo(0, true).unwrap();
 
                 let content = buffer.rope.to_string();
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -63,6 +63,9 @@ pub struct Buffer {
 
     /// Timestamp of the file when we last read/wrote it
     last_synced_time: Option<SystemTime>,
+
+    #[cfg(test)]
+    pub tree_reparsed_count: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -111,6 +114,8 @@ impl Buffer {
             batch_id: SyntaxHighlightRequestBatchId::default(),
             cached_hunks: None,
             last_synced_time: None,
+            #[cfg(test)]
+            tree_reparsed_count: 0,
         }
     }
 
@@ -722,6 +727,11 @@ impl Buffer {
         if let Some(tree) = self.tree.as_ref() {
             parser.set_language(&tree.language())?;
             self.tree = parser.parse(self.rope.to_string(), None);
+
+            #[cfg(test)]
+            {
+                self.tree_reparsed_count += 1;
+            }
         }
         Ok(())
     }

--- a/src/components/editor/mod.rs
+++ b/src/components/editor/mod.rs
@@ -121,7 +121,7 @@ impl Component for Editor {
         content: String,
         context: &Context,
     ) -> anyhow::Result<Dispatches> {
-        self.insert(&content, context)
+        self.insert(&content, context, EditHistoryKind::Coarse)
     }
 
     fn get_cursor_position(&self) -> anyhow::Result<Position> {
@@ -256,7 +256,7 @@ impl Component for Editor {
             EnableSelectionExtension => self.enable_selection_extension(),
             DisableSelectionExtension => self.disable_selection_extension(),
             EnterInsertMode(direction) => return self.enter_insert_mode(direction, context),
-            Insert(string) => return self.insert(&string, context),
+            Insert(string) => return self.insert(&string, context, EditHistoryKind::Coarse),
             #[cfg(test)]
             MatchLiteral(literal) => return self.match_literal(&literal, context),
             EnterNormalMode => self.enter_normal_mode(context)?,
@@ -440,6 +440,7 @@ impl Component for Editor {
             DuplicateVertically(direction) => return self.duplicate_vertically(context, direction),
             CoarseUndo => return self.coarse_undo(context),
             CoarseRedo => return self.coarse_redo(context),
+            InsertChar(c) => return self.insert_char(context, c),
         }
         Ok(Dispatches::default())
     }
@@ -1571,17 +1572,14 @@ impl Editor {
             .chain(dispatches))
     }
 
-    pub fn apply_edit_transaction(
+    fn apply_edit_transaction_with_edit_history_kind(
         &mut self,
         edit_transaction: EditTransaction,
         context: &Context,
+        kind: EditHistoryKind,
     ) -> anyhow::Result<Dispatches> {
         // Apply the transaction to the buffer
         let last_visible_line = self.last_visible_line(context);
-        let kind = match self.mode {
-            Mode::Insert => EditHistoryKind::Fine,
-            _ => EditHistoryKind::Coarse,
-        };
         let (new_selection_set, dispatches, diff_edits) =
             self.buffer.borrow_mut().apply_edit_transaction(
                 &edit_transaction,
@@ -1627,6 +1625,18 @@ impl Editor {
             .chain(dispatches);
 
         Ok(dispatches)
+    }
+
+    pub fn apply_edit_transaction(
+        &mut self,
+        edit_transaction: EditTransaction,
+        context: &Context,
+    ) -> anyhow::Result<Dispatches> {
+        self.apply_edit_transaction_with_edit_history_kind(
+            edit_transaction,
+            context,
+            EditHistoryKind::Coarse,
+        )
     }
 
     pub fn get_document_did_change_dispatch(&mut self) -> Dispatches {
@@ -1819,7 +1829,12 @@ impl Editor {
         Ok(self.copy().chain(self.change(context)?))
     }
 
-    pub fn insert(&mut self, s: &str, context: &Context) -> anyhow::Result<Dispatches> {
+    pub fn insert(
+        &mut self,
+        s: &str,
+        context: &Context,
+        kind: EditHistoryKind,
+    ) -> anyhow::Result<Dispatches> {
         let edit_transaction = EditTransaction::from_action_groups(
             self.selection_set
                 .map(|selection| {
@@ -1847,7 +1862,7 @@ impl Editor {
                 .into(),
         );
 
-        self.apply_edit_transaction(edit_transaction, context)
+        self.apply_edit_transaction_with_edit_history_kind(edit_transaction, context, kind)
     }
 
     pub fn get_request_params(&self) -> Option<RequestParams> {
@@ -4748,6 +4763,10 @@ impl Editor {
             |accumulated_dispatches, dispatches| Ok(accumulated_dispatches?.chain(dispatches)),
         )
     }
+
+    fn insert_char(&mut self, context: &Context, c: char) -> Result<Dispatches, anyhow::Error> {
+        self.insert(&c.to_string(), context, EditHistoryKind::Fine)
+    }
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug)]
@@ -4807,6 +4826,7 @@ pub enum DispatchEditor {
     SelectLine(Movement),
     Backspace,
     Insert(String),
+    InsertChar(char),
     MoveToLineStart,
     MoveToLineEnd,
     #[cfg(test)]

--- a/src/components/editor/mod.rs
+++ b/src/components/editor/mod.rs
@@ -273,12 +273,7 @@ impl Component for Editor {
                     .chain(self.get_document_did_change_dispatch())
                     .chain(dispatches));
             }
-            FineUndo => {
-                return Ok(self
-                    .undo(context)?
-                    .map(|(dispatches, _)| dispatches)
-                    .unwrap_or_default())
-            }
+            FineUndo => return self.fine_undo(context),
             KillLine(direction) => return self.kill_line(direction, context),
             #[cfg(test)]
             Reset => self.reset(),
@@ -290,12 +285,7 @@ impl Component for Editor {
             MoveToLineStart => return self.move_to_line_start(context),
             MoveToLineEnd => return self.move_to_line_end(),
             SelectLine(movement) => return self.select_line(movement, context),
-            FineRedo => {
-                return Ok(self
-                    .redo(context)?
-                    .map(|(dispatches, _)| dispatches)
-                    .unwrap_or_default())
-            }
+            FineRedo => return self.fine_redo(context),
             DeleteOne => return self.delete_one(context, false),
             CutOne => return self.delete_one(context, true),
             Change => return self.change(context),
@@ -1655,15 +1645,17 @@ impl Editor {
     pub fn undo(
         &mut self,
         context: &Context,
+        reparse_tree: bool,
     ) -> anyhow::Result<Option<(Dispatches, EditHistoryKind)>> {
-        self.undo_or_redo(true, context)
+        self.undo_or_redo(true, context, reparse_tree)
     }
 
     pub fn redo(
         &mut self,
         context: &Context,
+        reparse_tree: bool,
     ) -> anyhow::Result<Option<(Dispatches, EditHistoryKind)>> {
-        self.undo_or_redo(false, context)
+        self.undo_or_redo(false, context, reparse_tree)
     }
 
     pub fn swap_cursor(&mut self, context: &Context) {
@@ -3222,14 +3214,15 @@ impl Editor {
         &mut self,
         undo: bool,
         context: &Context,
+        reparse_tree: bool,
     ) -> Result<Option<(Dispatches, EditHistoryKind)>, anyhow::Error> {
         let last_visible_line = self.last_visible_line(context);
 
         // Call the appropriate buffer method to perform undo/redo
         let result = if undo {
-            self.buffer_mut().undo(last_visible_line)
+            self.buffer_mut().undo(last_visible_line, reparse_tree)
         } else {
-            self.buffer_mut().redo(last_visible_line)
+            self.buffer_mut().redo(last_visible_line, reparse_tree)
         }?;
 
         // Create dispatches for document changes and buffer edit transaction
@@ -4705,7 +4698,7 @@ impl Editor {
     }
 
     fn coarse_undo(&mut self, context: &Context) -> Result<Dispatches, anyhow::Error> {
-        let Some((first_dispatches, edit_history_kind)) = self.undo(context)? else {
+        let Some((first_dispatches, edit_history_kind)) = self.undo(context, false)? else {
             return Ok(Dispatches::default());
         };
 
@@ -4714,7 +4707,7 @@ impl Editor {
         }
 
         // If edit_history_kind is Fine: keep undoing until the next edit history on the stack is a Coarse one
-        std::iter::from_fn(|| {
+        let dispatches = std::iter::from_fn(|| {
             let last_edit_history_is_fine = self
                 .buffer()
                 .peek_undo_stack()
@@ -4722,20 +4715,22 @@ impl Editor {
                 .unwrap_or(false);
 
             if last_edit_history_is_fine {
-                self.undo(context).ok().flatten()
+                self.undo(context, false).ok().flatten()
             } else {
                 None
             }
         })
         .map(|(dispatches, _)| dispatches)
-        .fold(
-            Ok(first_dispatches),
-            |accumulated_dispatches, dispatches| Ok(accumulated_dispatches?.chain(dispatches)),
-        )
+        .fold(first_dispatches, |accumulated_dispatches, dispatches| {
+            accumulated_dispatches.chain(dispatches)
+        });
+
+        self.buffer_mut().reparse_tree()?;
+        Ok(dispatches)
     }
 
     fn coarse_redo(&mut self, context: &Context) -> Result<Dispatches, anyhow::Error> {
-        let Some((first_dispatches, edit_history_kind)) = self.redo(context)? else {
+        let Some((first_dispatches, edit_history_kind)) = self.redo(context, false)? else {
             return Ok(Dispatches::default());
         };
 
@@ -4744,7 +4739,7 @@ impl Editor {
         }
 
         // If edit_history_kind is Fine: keep redoing until the next edit history on the stack is a Coarse one
-        std::iter::from_fn(|| {
+        let dispatches = std::iter::from_fn(|| {
             let last_edit_history_is_fine = self
                 .buffer()
                 .peek_redo_stack()
@@ -4752,20 +4747,35 @@ impl Editor {
                 .unwrap_or(false);
 
             if last_edit_history_is_fine {
-                self.redo(context).ok().flatten()
+                self.redo(context, false).ok().flatten()
             } else {
                 None
             }
         })
         .map(|(dispatches, _)| dispatches)
-        .fold(
-            Ok(first_dispatches),
-            |accumulated_dispatches, dispatches| Ok(accumulated_dispatches?.chain(dispatches)),
-        )
+        .fold(first_dispatches, |accumulated_dispatches, dispatches| {
+            accumulated_dispatches.chain(dispatches)
+        });
+        self.buffer_mut().reparse_tree()?;
+        Ok(dispatches)
     }
 
     fn insert_char(&mut self, context: &Context, c: char) -> Result<Dispatches, anyhow::Error> {
         self.insert(&c.to_string(), context, EditHistoryKind::Fine)
+    }
+
+    fn fine_undo(&mut self, context: &Context) -> Result<Dispatches, anyhow::Error> {
+        Ok(self
+            .undo(context, true)?
+            .map(|(dispatches, _)| dispatches)
+            .unwrap_or_default())
+    }
+
+    fn fine_redo(&mut self, context: &Context) -> Result<Dispatches, anyhow::Error> {
+        Ok(self
+            .redo(context, true)?
+            .map(|(dispatches, _)| dispatches)
+            .unwrap_or_default())
     }
 }
 

--- a/src/components/editor/mod.rs
+++ b/src/components/editor/mod.rs
@@ -8,7 +8,7 @@ use super::{
 };
 use crate::{
     app::{Dimension, Dispatch, Dispatches, RequestParams, Scope, ToHostApp},
-    buffer::{Buffer, Line},
+    buffer::{Buffer, EditHistoryKind, Line},
     char_index_range::{range_intersects, CharIndexRange},
     clipboard::Texts,
     components::component::{Component, RenderTitleMode},
@@ -273,9 +273,11 @@ impl Component for Editor {
                     .chain(self.get_document_did_change_dispatch())
                     .chain(dispatches));
             }
-            Undo => {
-                let dispatches = self.undo(context);
-                return dispatches;
+            FineUndo => {
+                return Ok(self
+                    .undo(context)?
+                    .map(|(dispatches, _)| dispatches)
+                    .unwrap_or_default())
             }
             KillLine(direction) => return self.kill_line(direction, context),
             #[cfg(test)]
@@ -288,7 +290,12 @@ impl Component for Editor {
             MoveToLineStart => return self.move_to_line_start(context),
             MoveToLineEnd => return self.move_to_line_end(),
             SelectLine(movement) => return self.select_line(movement, context),
-            Redo => return self.redo(context),
+            FineRedo => {
+                return Ok(self
+                    .redo(context)?
+                    .map(|(dispatches, _)| dispatches)
+                    .unwrap_or_default())
+            }
             DeleteOne => return self.delete_one(context, false),
             CutOne => return self.delete_one(context, true),
             Change => return self.change(context),
@@ -431,6 +438,8 @@ impl Component for Editor {
                 return self.duplicate_with_movement(context, get_gap_movement)
             }
             DuplicateVertically(direction) => return self.duplicate_vertically(context, direction),
+            CoarseUndo => return self.coarse_undo(context),
+            CoarseRedo => return self.coarse_redo(context),
         }
         Ok(Dispatches::default())
     }
@@ -1569,6 +1578,10 @@ impl Editor {
     ) -> anyhow::Result<Dispatches> {
         // Apply the transaction to the buffer
         let last_visible_line = self.last_visible_line(context);
+        let kind = match self.mode {
+            Mode::Insert => EditHistoryKind::Fine,
+            _ => EditHistoryKind::Coarse,
+        };
         let (new_selection_set, dispatches, diff_edits) =
             self.buffer.borrow_mut().apply_edit_transaction(
                 &edit_transaction,
@@ -1576,6 +1589,7 @@ impl Editor {
                 self.mode != Mode::Insert,
                 true,
                 last_visible_line,
+                kind,
             )?;
 
         // Create a BufferEditTransaction dispatch for external integrations
@@ -1628,11 +1642,17 @@ impl Editor {
         .into()
     }
 
-    pub fn undo(&mut self, context: &Context) -> anyhow::Result<Dispatches> {
+    pub fn undo(
+        &mut self,
+        context: &Context,
+    ) -> anyhow::Result<Option<(Dispatches, EditHistoryKind)>> {
         self.undo_or_redo(true, context)
     }
 
-    pub fn redo(&mut self, context: &Context) -> anyhow::Result<Dispatches> {
+    pub fn redo(
+        &mut self,
+        context: &Context,
+    ) -> anyhow::Result<Option<(Dispatches, EditHistoryKind)>> {
         self.undo_or_redo(false, context)
     }
 
@@ -2123,6 +2143,7 @@ impl Editor {
                         true,
                         true,
                         self.last_visible_line(context),
+                        EditHistoryKind::Coarse,
                     )
                     .is_err()
                 {
@@ -3182,7 +3203,11 @@ impl Editor {
         });
     }
 
-    fn undo_or_redo(&mut self, undo: bool, context: &Context) -> Result<Dispatches, anyhow::Error> {
+    fn undo_or_redo(
+        &mut self,
+        undo: bool,
+        context: &Context,
+    ) -> Result<Option<(Dispatches, EditHistoryKind)>, anyhow::Error> {
         let last_visible_line = self.last_visible_line(context);
 
         // Call the appropriate buffer method to perform undo/redo
@@ -3193,8 +3218,8 @@ impl Editor {
         }?;
 
         // Create dispatches for document changes and buffer edit transaction
-        let dispatches = match result {
-            Some((dispatches, selection_set, diff_edits, edits)) => {
+        let (dispatches, edit_history_kind) = match result {
+            Some((dispatches, selection_set, diff_edits, edits, edit_history_kind)) => {
                 // Update selection set
                 let update_selection_dispatches =
                     self.update_selection_set(selection_set, false, context);
@@ -3211,11 +3236,13 @@ impl Editor {
                     Dispatches::default()
                 };
 
-                dispatches
+                let dispatches = dispatches
                     .chain(update_selection_dispatches)
-                    .chain(dispatch)
+                    .chain(dispatch);
+
+                (dispatches, edit_history_kind)
             }
-            Option::None => Dispatches::default(),
+            Option::None => return Ok(None),
         };
 
         // Add document did change dispatch
@@ -3226,7 +3253,7 @@ impl Editor {
 
         log::trace!("undo_or_redo: Returning dispatches");
 
-        Ok(dispatches)
+        Ok(Some((dispatches, edit_history_kind)))
     }
 
     #[cfg(test)]
@@ -4661,6 +4688,66 @@ impl Editor {
     pub fn cycle_primary_selection_to_last(&mut self) {
         self.selection_set.cycle_primary_selection_to_last();
     }
+
+    fn coarse_undo(&mut self, context: &Context) -> Result<Dispatches, anyhow::Error> {
+        let Some((first_dispatches, edit_history_kind)) = self.undo(context)? else {
+            return Ok(Dispatches::default());
+        };
+
+        if edit_history_kind == EditHistoryKind::Coarse {
+            return Ok(first_dispatches);
+        }
+
+        // If edit_history_kind is Fine: keep undoing until the next edit history on the stack is a Coarse one
+        std::iter::from_fn(|| {
+            let last_edit_history_is_fine = self
+                .buffer()
+                .peek_undo_stack()
+                .map(|history| history.kind == EditHistoryKind::Fine)
+                .unwrap_or(false);
+
+            if last_edit_history_is_fine {
+                self.undo(context).ok().flatten()
+            } else {
+                None
+            }
+        })
+        .map(|(dispatches, _)| dispatches)
+        .fold(
+            Ok(first_dispatches),
+            |accumulated_dispatches, dispatches| Ok(accumulated_dispatches?.chain(dispatches)),
+        )
+    }
+
+    fn coarse_redo(&mut self, context: &Context) -> Result<Dispatches, anyhow::Error> {
+        let Some((first_dispatches, edit_history_kind)) = self.redo(context)? else {
+            return Ok(Dispatches::default());
+        };
+
+        if edit_history_kind == EditHistoryKind::Coarse {
+            return Ok(first_dispatches);
+        }
+
+        // If edit_history_kind is Fine: keep redoing until the next edit history on the stack is a Coarse one
+        std::iter::from_fn(|| {
+            let last_edit_history_is_fine = self
+                .buffer()
+                .peek_redo_stack()
+                .map(|history| history.kind == EditHistoryKind::Fine)
+                .unwrap_or(false);
+
+            if last_edit_history_is_fine {
+                self.redo(context).ok().flatten()
+            } else {
+                None
+            }
+        })
+        .map(|(dispatches, _)| dispatches)
+        .fold(
+            Ok(first_dispatches),
+            |accumulated_dispatches, dispatches| Ok(accumulated_dispatches?.chain(dispatches)),
+        )
+    }
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug)]
@@ -4739,8 +4826,8 @@ pub enum DispatchEditor {
     ReplacePattern {
         config: crate::context::LocalSearchConfig,
     },
-    Undo,
-    Redo,
+    FineUndo,
+    FineRedo,
     KillLine(Direction),
     #[cfg(test)]
     Reset,
@@ -4825,6 +4912,8 @@ pub enum DispatchEditor {
     PasteVertically(Direction),
     DuplicateWithMovement(GetGapMovement),
     DuplicateVertically(Direction),
+    CoarseUndo,
+    CoarseRedo,
 }
 
 #[derive(PartialEq, Eq, Debug, Clone)]

--- a/src/components/editor_keymap_legend.rs
+++ b/src/components/editor_keymap_legend.rs
@@ -28,7 +28,7 @@ impl Editor {
             Ok(dispatches)
         } else if let (KeyCode::Char(c), KeyEventKind::Press) = (event.code, event.kind) {
             Ok(Dispatches::one(Dispatch::ToEditor(
-                super::editor::DispatchEditor::Insert(c.to_string()),
+                super::editor::DispatchEditor::InsertChar(c),
             )))
         } else {
             Ok(Dispatches::default())

--- a/src/components/editor_keymap_printer.rs
+++ b/src/components/editor_keymap_printer.rs
@@ -380,7 +380,7 @@ impl KeymapPrintSections {
             KeymapPrintSection::from_keymap("Cut".to_string(), &cut_keymap()),
             KeymapPrintSection::from_keymap("Swap".to_string(), &swap_keymap()),
             KeymapPrintSection::from_keymap("Delete".to_string(), &delete_keymap()),
-            KeymapPrintSection::from_keymap("Undo/Redo".to_string(), &undo_redo_keymap()),
+            KeymapPrintSection::from_keymap("Undo-Redo".to_string(), &undo_redo_keymap()),
             KeymapPrintSection::from_keymap("Insert".to_string(), &insert_keymap()),
             KeymapPrintSection::from_keymap("Buffer".to_string(), &buffer_keymap(false)),
             KeymapPrintSection::from_keymap(

--- a/src/components/editor_keymap_printer.rs
+++ b/src/components/editor_keymap_printer.rs
@@ -21,7 +21,7 @@ use crate::{
         multicursor_menu_keymap, multicursor_momentary_layer_keymap, normal_mode_keymap,
         paste_keymap, secondary_selection_modes_keymap_legend_config,
         space_context_keymap_legend_config, space_editor_keymap_legend_config,
-        space_keymap_legend_config, space_pick_keymap_legend_config, swap_keymap,
+        space_keymap_legend_config, space_pick_keymap_legend_config, swap_keymap, undo_redo_keymap,
     },
 };
 use comfy_table::{
@@ -380,6 +380,7 @@ impl KeymapPrintSections {
             KeymapPrintSection::from_keymap("Cut".to_string(), &cut_keymap()),
             KeymapPrintSection::from_keymap("Swap".to_string(), &swap_keymap()),
             KeymapPrintSection::from_keymap("Delete".to_string(), &delete_keymap()),
+            KeymapPrintSection::from_keymap("Undo/Redo".to_string(), &undo_redo_keymap()),
             KeymapPrintSection::from_keymap("Insert".to_string(), &insert_keymap()),
             KeymapPrintSection::from_keymap("Buffer".to_string(), &buffer_keymap(false)),
             KeymapPrintSection::from_keymap(

--- a/src/components/test_editor.rs
+++ b/src/components/test_editor.rs
@@ -823,12 +823,12 @@ fn multi_raise() -> anyhow::Result<()> {
             Expect(CurrentSelectedTexts(&["a", "b"])),
             Editor(Replace(Expand)),
             Expect(CurrentComponentContent("fn f(){ let x = a; let y = b; }")),
-            Editor(Undo),
+            Editor(FineUndo),
             Expect(CurrentComponentContent(
                 "fn f(){ let x = S(a); let y = S(b); }",
             )),
             Expect(CurrentSelectedTexts(&["a", "b"])),
-            Editor(Redo),
+            Editor(FineRedo),
             Expect(CurrentComponentContent("fn f(){ let x = a; let y = b; }")),
             Expect(CurrentSelectedTexts(&["a", "b"])),
         ])
@@ -2228,12 +2228,12 @@ fn update_mark_position_with_undo_and_redo() -> anyhow::Result<()> {
             // Expect mark position is updated (still selects "spim")
             Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Mark)),
             Expect(CurrentSelectedTexts(&["spim"])),
-            Editor(Undo),
+            Editor(FineUndo),
             Expect(CurrentComponentContent("foo bar spim")),
             // Expect mark position is updated (still selects "spim")
             Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Mark)),
             Expect(CurrentSelectedTexts(&["spim"])),
-            Editor(Redo),
+            Editor(FineRedo),
             // Expect mark position is updated (still selects "spim")
             Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Mark)),
             Expect(CurrentSelectedTexts(&["spim"])),
@@ -2576,7 +2576,7 @@ fn undo_till_empty_should_not_crash_in_insert_mode() -> anyhow::Result<()> {
             Editor(EnterInsertMode(Direction::Start)),
             Editor(PasteWithMovement(GetGapMovement::Right)),
             Expect(CurrentComponentContent("foo")),
-            Editor(Undo),
+            Editor(FineUndo),
             Expect(CurrentComponentContent("")),
         ])
     })
@@ -4273,18 +4273,18 @@ fn undo_redo_1() -> anyhow::Result<()> {
             Editor(DeleteWithMovement(Right)),
             Editor(DeleteWithMovement(Right)),
             Expect(CurrentComponentContent("")),
-            Editor(Undo),
+            Editor(FineUndo),
             Expect(CurrentComponentContent("bar")),
             Expect(CurrentSelectedTexts(&["bar"])),
-            Editor(Undo),
+            Editor(FineUndo),
             Expect(CurrentComponentContent("foo bar")),
             Expect(CurrentSelectedTexts(&["foo"])),
-            Editor(Redo),
+            Editor(FineRedo),
             Expect(CurrentComponentContent("bar")),
             Expect(CurrentSelectedTexts(&["bar"])),
-            Editor(Redo),
+            Editor(FineRedo),
             Expect(CurrentComponentContent("")),
-            Editor(Undo),
+            Editor(FineUndo),
             Expect(CurrentComponentContent("bar")),
             Expect(CurrentSelectedTexts(&["bar"])),
         ])
@@ -4306,15 +4306,15 @@ fn undo_redo_should_clear_redo_stack_upon_new_edits() -> anyhow::Result<()> {
             Editor(DeleteWithMovement(Right)),
             Editor(DeleteWithMovement(Left)),
             Expect(CurrentComponentContent("")),
-            Editor(Undo),
+            Editor(FineUndo),
             Expect(CurrentComponentContent("bar")),
             Expect(CurrentSelectedTexts(&["bar"])),
             Editor(Copy),
             Editor(PasteWithMovement(GetGapMovement::Right)),
             Expect(CurrentComponentContent("barbar")),
-            Editor(Undo),
-            Editor(Redo),
-            Editor(Redo),
+            Editor(FineUndo),
+            Editor(FineRedo),
+            Editor(FineRedo),
             Expect(CurrentComponentContent("barbar")),
         ])
     })
@@ -4335,8 +4335,8 @@ fn undo_redo_multicursor() -> anyhow::Result<()> {
             Editor(EnterInsertMode(Direction::End)),
             App(HandleKeyEvents(keys!("x").to_vec())),
             Expect(CurrentComponentContent("foox barx")),
-            Editor(Undo),
-            Editor(Redo),
+            Editor(FineUndo),
+            Editor(FineRedo),
             Editor(EnterNormalMode),
             Expect(CurrentSelectedTexts(&["x", "x"])),
             Editor(SetSelectionMode(IfCurrentNotFound::LookBackward, Word)),
@@ -6314,4 +6314,30 @@ fn add_cursor_to_all_selections_should_not_toggle_reveal_if_all_cursors_are_with
     run_test(5, None)?;
     run_test(4, Some(Reveal::Cursor))?;
     Ok(())
+}
+
+#[test]
+fn coarse_undo_redo() -> anyhow::Result<()> {
+    execute_test(move |s| {
+        Box::new([
+            App(OpenFile {
+                path: s.main_rs(),
+                owner: BufferOwner::User,
+                focus: true,
+            }),
+            Editor(SetContent("hello world ".to_string())),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, LineFull)),
+            Editor(EnterInsertMode(Direction::End)),
+            App(HandleKeyEvents(keys!("a b c").to_vec())),
+            Expect(CurrentComponentContent("hello world abc")),
+            Editor(DispatchEditor::CoarseUndo),
+            Expect(CurrentComponentContent("hello world ")),
+            Editor(DispatchEditor::CoarseRedo),
+            Expect(CurrentComponentContent("hello world abc")),
+            Editor(DispatchEditor::FineUndo),
+            Expect(CurrentComponentContent("hello world ab")),
+            Editor(DispatchEditor::FineRedo),
+            Expect(CurrentComponentContent("hello world abc")),
+        ])
+    })
 }

--- a/src/components/test_editor.rs
+++ b/src/components/test_editor.rs
@@ -1,5 +1,5 @@
 use crate::app::{Dimension, LocalSearchConfigUpdate, Scope};
-use crate::buffer::BufferOwner;
+use crate::buffer::{BufferOwner, EditHistoryKind};
 use crate::char_index_range::CharIndexRange;
 use crate::clipboard::Texts;
 use crate::components::editor::Reveal;
@@ -2378,7 +2378,7 @@ fn tree_sitter_should_not_reparse_in_insert_mode() -> anyhow::Result<()> {
     let _ = editor.enter_insert_mode(Direction::End, &context)?;
 
     let current_range = editor.buffer().tree().unwrap().root_node().range();
-    let _ = editor.insert("fn hello() {}", &context)?;
+    let _ = editor.insert("fn hello() {}", &context, EditHistoryKind::Coarse)?;
     // Modifying the content in insert mode should not cause the tree to be reparsed
     let new_range = editor.buffer().tree().unwrap().root_node().range();
     assert_eq!(current_range, new_range);
@@ -6317,7 +6317,7 @@ fn add_cursor_to_all_selections_should_not_toggle_reveal_if_all_cursors_are_with
 }
 
 #[test]
-fn coarse_undo_redo() -> anyhow::Result<()> {
+fn coarse_undo_redo_with_basic_text_insertion() -> anyhow::Result<()> {
     execute_test(move |s| {
         Box::new([
             App(OpenFile {
@@ -6337,6 +6337,28 @@ fn coarse_undo_redo() -> anyhow::Result<()> {
             Editor(DispatchEditor::FineUndo),
             Expect(CurrentComponentContent("hello world ab")),
             Editor(DispatchEditor::FineRedo),
+            Expect(CurrentComponentContent("hello world abc")),
+        ])
+    })
+}
+#[test]
+/// Only typing should be treated as Fine actions
+fn coarse_undo_redo_with_insert_mode_actions() -> anyhow::Result<()> {
+    execute_test(move |s| {
+        Box::new([
+            App(OpenFile {
+                path: s.main_rs(),
+                owner: BufferOwner::User,
+                focus: true,
+            }),
+            Editor(SetContent("hello world ".to_string())),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, LineFull)),
+            Editor(EnterInsertMode(Direction::End)),
+            App(HandleKeyEvents(keys!("a b c").to_vec())),
+            Expect(CurrentComponentContent("hello world abc")),
+            Editor(DeleteWordBackward { short: false }),
+            Expect(CurrentComponentContent("hello world")),
+            Editor(CoarseUndo),
             Expect(CurrentComponentContent("hello world abc")),
         ])
     })

--- a/src/components/test_editor.rs
+++ b/src/components/test_editor.rs
@@ -6341,6 +6341,7 @@ fn coarse_undo_redo_with_basic_text_insertion() -> anyhow::Result<()> {
         ])
     })
 }
+
 #[test]
 /// Only typing should be treated as Fine actions
 fn coarse_undo_redo_with_insert_mode_actions() -> anyhow::Result<()> {
@@ -6360,6 +6361,33 @@ fn coarse_undo_redo_with_insert_mode_actions() -> anyhow::Result<()> {
             Expect(CurrentComponentContent("hello world")),
             Editor(CoarseUndo),
             Expect(CurrentComponentContent("hello world abc")),
+        ])
+    })
+}
+
+#[test]
+fn each_coarse_undo_or_redo_should_only_reparse_the_syntax_tree_once() -> anyhow::Result<()> {
+    execute_test(move |s| {
+        Box::new([
+            App(OpenFile {
+                path: s.main_rs(),
+                owner: BufferOwner::User,
+                focus: true,
+            }),
+            Editor(SetContent("hello world ".to_string())),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, LineFull)),
+            Editor(EnterInsertMode(Direction::End)),
+            App(HandleKeyEvents(keys!("a b c").to_vec())),
+            Expect(CurrentComponentContent("hello world abc")),
+            Expect(ExpectKind::CurrentTreeReparsedCount(0)),
+            Editor(CoarseUndo),
+            Expect(CurrentComponentContent("hello world ")),
+            // Expect the reparsed count is only incremented by one
+            Expect(ExpectKind::CurrentTreeReparsedCount(1)),
+            Editor(CoarseRedo),
+            Expect(CurrentComponentContent("hello world abc")),
+            // Expect the reparsed count is only incremented by one
+            Expect(ExpectKind::CurrentTreeReparsedCount(2)),
         ])
     })
 }

--- a/src/file_watcher/test.rs
+++ b/src/file_watcher/test.rs
@@ -234,7 +234,7 @@ fn saving_a_file_should_not_refreshes_the_buffer_due_to_incoming_file_modified_n
             Editor(Save),
             WaitForDuration(Duration::from_secs(2)),
             WaitForAppMessage(regex!("FileWatcherEvent.*ContentModified")),
-            Editor(Undo),
+            Editor(FineUndo),
             Expect(CurrentSelectedTexts(&["mod"])),
         ])
     })

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -1317,10 +1317,26 @@ pub fn keymap_actions(
 
 pub fn undo_redo_keymap() -> Keymap {
     Keymap::new(&[
-        Keybinding::new_undocumented("j", "<< Undo", Dispatch::ToEditor(CoarseUndo)),
-        Keybinding::new_undocumented("l", "Redo >>", Dispatch::ToEditor(CoarseRedo)),
-        Keybinding::new_undocumented("u", "< Undo", Dispatch::ToEditor(FineUndo)),
-        Keybinding::new_undocumented("o", "Redo >", Dispatch::ToEditor(FineRedo)),
+        Keybinding::new(
+            "j",
+            name_and_doc!("Coarse Undo"),
+            Dispatch::ToEditor(CoarseUndo),
+        ),
+        Keybinding::new(
+            "l",
+            name_and_doc!("Coarse Redo"),
+            Dispatch::ToEditor(CoarseRedo),
+        ),
+        Keybinding::new(
+            "u",
+            name_and_doc!("Fine Undo"),
+            Dispatch::ToEditor(FineUndo),
+        ),
+        Keybinding::new(
+            "o",
+            name_and_doc!("Fine Redo"),
+            Dispatch::ToEditor(FineRedo),
+        ),
     ])
 }
 

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -1284,8 +1284,15 @@ pub fn keymap_actions(
             Dispatch::ToEditor(AlignSelections(Direction::End)),
         ),
         Keybinding::new_undocumented("T", "Raise", Dispatch::ToEditor(Replace(Movement::Expand))),
-        Keybinding::new_undocumented("z", "Undo", Dispatch::ToEditor(Undo)),
-        Keybinding::new_undocumented("Z", "Redo", Dispatch::ToEditor(Redo)),
+        Keybinding::momentary_layer(MomentaryLayer {
+            key: "z",
+            name: "Undo/Redo".to_string(),
+            config: KeymapLegendConfig {
+                title: "Undo/Redo".to_string(),
+                keymap: undo_redo_keymap(),
+            },
+            on_tap: None,
+        }),
         Keybinding::new_undocumented("enter", "Save", Dispatch::SaveFile),
         Keybinding::new_undocumented("shift+enter", "Save As", Dispatch::OpenSaveAsPrompt),
         Keybinding::new_undocumented(
@@ -1306,6 +1313,15 @@ pub fn keymap_actions(
         normal_mode_override.clone(),
     ))
     .collect_vec()
+}
+
+pub fn undo_redo_keymap() -> Keymap {
+    Keymap::new(&[
+        Keybinding::new_undocumented("j", "<< Undo", Dispatch::ToEditor(CoarseUndo)),
+        Keybinding::new_undocumented("l", "Redo >>", Dispatch::ToEditor(CoarseRedo)),
+        Keybinding::new_undocumented("u", "< Undo", Dispatch::ToEditor(FineUndo)),
+        Keybinding::new_undocumented("o", "Redo >", Dispatch::ToEditor(FineRedo)),
+    ])
 }
 
 pub fn keymap_actions_overridable(

--- a/src/recipes.rs
+++ b/src/recipes.rs
@@ -2451,7 +2451,7 @@ hello_world
             content: "camelCase".trim(),
             file_extension: "md",
             prepare_events: &[],
-            events: keys!("w v l release-v z Z"),
+            events: keys!("w v l release-v z j l release-z"),
             expectations: Box::new([CurrentComponentContent("Case")]),
             terminal_height: None,
             similar_vim_combos: &["u", "ctrl+r"],

--- a/src/test_app.rs
+++ b/src/test_app.rs
@@ -2004,7 +2004,7 @@ fn test_global_search_replace(
                 owner: BufferOwner::User,
                 focus: true,
             }),
-            Editor(Undo),
+            Editor(FineUndo),
             // Expect the content of the main.rs buffer to be reverted
             Expect(FileContent(s.main_rs(), main_content.to_string())),
         ])
@@ -4530,6 +4530,45 @@ fn saving_content_of_pathless_buffer_into_a_new_file_using_enter() -> anyhow::Re
 
 #[test]
 fn cycling_window_focus_should_not_create_more_windows() -> anyhow::Result<()> {
+    execute_test(|s| {
+        Box::new([
+            App(OpenFile {
+                path: s.main_rs(),
+                owner: BufferOwner::User,
+                focus: true,
+            }),
+            App(OpenThemePicker),
+            Expect(CurrentComponentTitle("Theme".to_string())),
+            Expect(ComponentsLength(3)),
+            App(OtherWindow),
+            Expect(CurrentComponentTitle("Completion".to_string())),
+            Expect(ComponentsLength(3)),
+            App(OtherWindow),
+            Expect(CurrentComponentTitle(
+                "\u{200b} [ ] 🦀 main.rs \u{200b}".to_string(),
+            )),
+            Expect(ComponentsLength(3)),
+            App(OtherWindow),
+            Expect(CurrentComponentTitle("Theme".to_string())),
+            Expect(ComponentsLength(3)),
+            App(OtherWindow),
+            Expect(CurrentComponentTitle("Completion".to_string())),
+            Expect(ComponentsLength(3)),
+            App(OtherWindow),
+            Expect(CurrentComponentTitle(
+                "\u{200b} [ ] 🦀 main.rs \u{200b}".to_string(),
+            )),
+            Expect(ComponentsLength(3)),
+            App(OtherWindow),
+            Expect(CurrentComponentTitle("Theme".to_string())),
+            Expect(ComponentsLength(3)),
+        ])
+    })
+}
+
+#[test]
+/// This test case ensure that ctrl+z should not be treated as a positional keybinding.
+fn ctrl_z_should_trigger_suspend_regardless_of_current_layout() -> anyhow::Result<()> {
     execute_test(|s| {
         Box::new([
             App(OpenFile {

--- a/src/test_app.rs
+++ b/src/test_app.rs
@@ -217,6 +217,7 @@ pub enum ExpectKind {
     GlobalMultiCursorActivated(bool),
     AppCursorPosition(Position),
     CurrentMarks(Vec<(AbsolutePath, Vec<CharIndexRange>)>),
+    CurrentTreeReparsedCount(usize),
 }
 fn log<T: std::fmt::Debug>(s: T) {
     if !is_ci::cached() {
@@ -699,6 +700,14 @@ impl ExpectKind {
                     .filter(|(_, marks)| !marks.is_empty())
                     .sorted_by_key(|(path, _)| path.clone())
                     .collect_vec(),
+            ),
+            CurrentTreeReparsedCount(expected) => contextualize(
+                expected,
+                &app.get_current_editor()
+                    .borrow()
+                    .editor()
+                    .buffer()
+                    .tree_reparsed_count,
             ),
         })
     }


### PR DESCRIPTION
This allows user to Undo/Redo the whole chunk of text inserted in the last session without needing to undo/redo character by character (the existing undo/redo behavior).