### PR TITLE
feat(char): first/last = line edges, previous/next = non-whitespace edges

### DIFF
--- a/docs/docs/normal-mode/selection-modes/primary.md
+++ b/docs/docs/normal-mode/selection-modes/primary.md
@@ -206,6 +206,9 @@ Character.
 
 In this selection mode, the movements behave like the usual editor, where [Left/Right](./../core-movements.md#--leftright) means left/right, and so on.
 
-[First/Last](./../core-movements.md#--firstlast) means the first/last character of the current word.
+| Movement      | Meaning                                                                    |
+| ------------- | -------------------------------------------------------------------------- |
+| First/Last    | First/last character of the current line (last may be a newline character) |
+| Previous/Next | First/last non-whitespace character of the current line                    |
 
 <TutorialFallback filename="char"/>

--- a/src/components/test_editor.rs
+++ b/src/components/test_editor.rs
@@ -3550,7 +3550,7 @@ fn select_next_line_when_cursor_is_at_last_space_of_current_line() -> anyhow::Re
             }),
             Editor(SetContent("abc \n yo".to_string())),
             Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Character)),
-            Editor(MoveSelection(Last)),
+            Editor(MoveSelection(Next)),
             Editor(MoveSelection(Right)),
             Expect(CurrentSelectedTexts(&[" "])),
             Editor(MoveSelection(Left)),

--- a/src/components/test_editor.rs
+++ b/src/components/test_editor.rs
@@ -3572,13 +3572,13 @@ fn first_last_char() -> anyhow::Result<()> {
                 owner: BufferOwner::User,
                 focus: true,
             }),
-            Editor(SetContent("babyHelloCamp".to_string())),
+            Editor(SetContent(" babyHelloCamp\n".to_string())),
             Editor(MatchLiteral("Hello".to_string())),
             Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Character)),
             Editor(MoveSelection(Last)),
-            Expect(CurrentSelectedTexts(&["o"])),
+            Expect(CurrentSelectedTexts(&["\n"])),
             Editor(MoveSelection(First)),
-            Expect(CurrentSelectedTexts(&["H"])),
+            Expect(CurrentSelectedTexts(&[" "])),
         ])
     })
 }

--- a/src/recipes.rs
+++ b/src/recipes.rs
@@ -1147,9 +1147,9 @@ camelCase , kebab-case : snake_case
             filename: "char",
             recipes: [
                 Recipe {
-                    description: "Char: up/down/left/right movement",
+                    description: "Character: up/down/left/right movement",
                     content: "
-camel 
+camel
 snake
 "
                     .trim(),
@@ -1162,12 +1162,23 @@ snake
                     only: false,
                 },
                 Recipe {
-                    description: "Char: first/last movement (first/last char of current subword)",
-                    content: "campHelloDun".trim(),
+                    description: "Character: First/Last",
+                    content: "  hello\nworld",
                     file_extension: "md",
-                    prepare_events: keys!("n d h e l l o enter"),
+                    prepare_events: &[],
                     events: keys!("W p y"),
-                    expectations: Box::new([CurrentSelectedTexts(&["H"])]),
+                    expectations: Box::new([CurrentSelectedTexts(&[" "])]),
+                    terminal_height: None,
+                    similar_vim_combos: &[],
+                    only: false,
+                },
+                Recipe {
+                    description: "Character: Previous/Next",
+                    content: "  hello\nworld",
+                    file_extension: "md",
+                    prepare_events: &[],
+                    events: keys!("W o u"),
+                    expectations: Box::new([CurrentSelectedTexts(&["h"])]),
                     terminal_height: None,
                     similar_vim_combos: &[],
                     only: false,

--- a/src/selection_mode/character.rs
+++ b/src/selection_mode/character.rs
@@ -1,25 +1,83 @@
 use crate::components::editor::IfCurrentNotFound;
+use crate::selection::{CharIndex, Selection};
+use itertools::Either;
+use ropey::Rope;
 
-use super::{
-    subword::SelectionPosition, ByteRange, PositionBased, PositionBasedSelectionMode,
-    SelectionModeTrait, Subword,
-};
+use super::{ByteRange, PositionBasedSelectionMode};
 
 pub struct Character;
 
-impl PositionBasedSelectionMode for Character {
-    fn first(
-        &self,
-        params: &super::SelectionModeParams,
-    ) -> anyhow::Result<Option<crate::selection::Selection>> {
-        get_char(params, SelectionPosition::First)
+struct CurrentLine {
+    line: Rope,
+    first_char_index: CharIndex,
+}
+
+impl CurrentLine {
+    fn from_params(params: &super::SelectionModeParams) -> anyhow::Result<Self> {
+        let buffer = params.buffer;
+        let cursor = params
+            .current_selection
+            .to_char_index(params.cursor_direction);
+        let line_number = buffer.char_to_line(cursor)?;
+        let first_char_index = buffer.line_to_char(line_number)?;
+        let line = buffer.get_line_by_char_index(cursor)?;
+        Ok(Self {
+            line,
+            first_char_index,
+        })
     }
 
-    fn last(
+    fn char_at(
         &self,
         params: &super::SelectionModeParams,
-    ) -> anyhow::Result<Option<crate::selection::Selection>> {
-        get_char(params, SelectionPosition::Last)
+        offset: usize,
+    ) -> anyhow::Result<Option<Selection>> {
+        char_index_to_selection(
+            params.buffer,
+            params.current_selection,
+            self.first_char_index + offset,
+        )
+    }
+
+    fn first_non_whitespace(
+        &self,
+        params: &super::SelectionModeParams,
+        reversed: bool,
+    ) -> anyhow::Result<Option<Selection>> {
+        let line_len = self.line.len_chars();
+        let mut indices = if reversed {
+            Either::Left((0..line_len).rev())
+        } else {
+            Either::Right(0..line_len)
+        };
+        Ok(indices
+            .find(|&i| !self.line.char(i).is_whitespace())
+            .map(|index| self.char_at(params, index))
+            .transpose()?
+            .flatten())
+    }
+}
+
+impl PositionBasedSelectionMode for Character {
+    fn first(&self, params: &super::SelectionModeParams) -> anyhow::Result<Option<Selection>> {
+        CurrentLine::from_params(params)?.char_at(params, 0)
+    }
+
+    fn last(&self, params: &super::SelectionModeParams) -> anyhow::Result<Option<Selection>> {
+        let current_line = CurrentLine::from_params(params)?;
+        let line_len = current_line.line.len_chars();
+        if line_len == 0 {
+            return Ok(None);
+        }
+        current_line.char_at(params, line_len - 1)
+    }
+
+    fn previous(&self, params: &super::SelectionModeParams) -> anyhow::Result<Option<Selection>> {
+        CurrentLine::from_params(params)?.first_non_whitespace(params, false)
+    }
+
+    fn next(&self, params: &super::SelectionModeParams) -> anyhow::Result<Option<Selection>> {
+        CurrentLine::from_params(params)?.first_non_whitespace(params, true)
     }
 
     fn get_current_meaningful_selection_by_cursor(
@@ -40,33 +98,24 @@ impl PositionBasedSelectionMode for Character {
     }
 }
 
-fn get_char(
-    params: &super::SelectionModeParams,
-    position: SelectionPosition,
-) -> anyhow::Result<Option<crate::selection::Selection>> {
-    if let Some(current_word) = PositionBased(Subword).current(
-        params,
-        crate::components::editor::IfCurrentNotFound::LookForward,
-    )? {
-        let start = match position {
-            SelectionPosition::First => current_word.range().start,
-            SelectionPosition::Last => current_word.range().end - 1,
-        };
-        return Ok(Some(
-            params
-                .current_selection
-                .clone()
-                .set_range((start..start + 1).into()),
-        ));
-    }
-    Ok(None)
+fn char_index_to_selection(
+    buffer: &crate::buffer::Buffer,
+    current_selection: &Selection,
+    char_index: CharIndex,
+) -> anyhow::Result<Option<Selection>> {
+    let byte_start = buffer.char_to_byte(char_index)?;
+    let ch = buffer.char(char_index)?;
+    let byte_range = ByteRange::new(byte_start..byte_start + ch.len_utf8());
+    Ok(Some(byte_range.to_selection(buffer, current_selection)?))
 }
 
 #[cfg(test)]
 mod test_character {
     use crate::app::Dimension;
     use crate::buffer::BufferOwner;
+    use crate::components::editor::Movement;
     use crate::selection::SelectionMode;
+    use crate::selection_mode::{PositionBased, SelectionModeTrait};
     use crate::test_app::*;
 
     use crate::{buffer::Buffer, selection::Selection};
@@ -197,6 +246,75 @@ mod test_character {
                 Expect(JumpChars(&[
                     '\n', '\n', 'a', 'a', 'b', 'f', 'm', 'o', 'o', 'p', 'r', 's',
                 ])),
+            ])
+        })
+    }
+
+    #[test]
+    fn first_last_of_line() -> anyhow::Result<()> {
+        execute_test(|s| {
+            Box::new([
+                App(OpenFile {
+                    path: s.main_rs(),
+                    owner: BufferOwner::User,
+                    focus: true,
+                }),
+                Editor(SetContent("foo\nbar".to_string())),
+                Editor(SetSelectionMode(
+                    IfCurrentNotFound::LookForward,
+                    SelectionMode::Character,
+                )),
+                // Cursor starts at 'f'
+                Expect(CurrentSelectedTexts(&["f"])),
+                // First of line -> 'f' (already at first)
+                Editor(MoveSelection(Movement::First)),
+                Expect(CurrentSelectedTexts(&["f"])),
+                // Last of line -> '\n'
+                Editor(MoveSelection(Movement::Last)),
+                Expect(CurrentSelectedTexts(&["\n"])),
+                // Move to second line
+                Editor(MoveSelection(Right)),
+                Expect(CurrentSelectedTexts(&["b"])),
+                // First of second line -> 'b'
+                Editor(MoveSelection(Movement::First)),
+                Expect(CurrentSelectedTexts(&["b"])),
+                // Last of second line -> 'm'
+                Editor(MoveSelection(Movement::Last)),
+                Expect(CurrentSelectedTexts(&["r"])),
+            ])
+        })
+    }
+
+    #[test]
+    fn previous_next_non_whitespace() -> anyhow::Result<()> {
+        execute_test(|s| {
+            Box::new([
+                App(OpenFile {
+                    path: s.main_rs(),
+                    owner: BufferOwner::User,
+                    focus: true,
+                }),
+                Editor(SetContent("  foo  \n  bar  ".to_string())),
+                Editor(SetSelectionMode(
+                    IfCurrentNotFound::LookForward,
+                    SelectionMode::Character,
+                )),
+                // Cursor starts at first char ' '
+                Expect(CurrentSelectedTexts(&[" "])),
+                // Previous (first non-whitespace of line) -> 'f'
+                Editor(MoveSelection(Movement::Previous)),
+                Expect(CurrentSelectedTexts(&["f"])),
+                // Next (last non-whitespace of line) -> 'o'
+                Editor(MoveSelection(Movement::Next)),
+                Expect(CurrentSelectedTexts(&["o"])),
+                // Move to second line
+                Editor(MoveSelection(Down)),
+                // Previous (first non-whitespace of second line) -> 'b'
+                Editor(MoveSelection(Movement::Previous)),
+                Expect(CurrentSelectedTexts(&["b"])),
+                // Next (last non-whitespace of second line) -> 'r'
+                Editor(MoveSelection(Movement::Next)),
+                Expect(CurrentSelectedTexts(&["r"])),
             ])
         })
     }


### PR DESCRIPTION
## Summary

- First/Last = first/last character of the current line (may be a newline char)
- Previous/Next = first non-whitespace character of the current line


As discussed in [#🎹 Keymap > Major reform](https://ki-editor.zulipchat.com/#narrow/channel/543759/topic/Major.20reform/with/584653227)