### PR TITLE
Add support for qml language

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2352,6 +2352,8 @@ dependencies = [
  "tree-sitter-odin",
  "tree-sitter-perl-next",
  "tree-sitter-python",
+ "tree-sitter-qmldir",
+ "tree-sitter-qmljs",
  "tree-sitter-quickfix",
  "tree-sitter-ruby",
  "tree-sitter-rust",
@@ -3048,6 +3050,25 @@ name = "tree-sitter-python"
 version = "0.23.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d065aaa27f3aaceaf60c1f0e0ac09e1cb9eb8ed28e7bcdaa52129cffc7f4b04"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-qmldir"
+version = "0.1.0"
+source = "git+https://github.com/tree-sitter-grammars/tree-sitter-qmldir?rev=1fa9200#1fa9200b3e57f728291f7a85b0a6990fc98387ac"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-qmljs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67445ea937cd7eadaf2f628e2e7dd234374586cc31b4d1d63dbb5f5e7f9d9b62"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/docs/static/app_config_json_schema.json
+++ b/docs/static/app_config_json_schema.json
@@ -86,6 +86,8 @@
                 "Graphql",
                 "Gnuplot",
                 "Javascript",
+                "QmlJs",
+                "QmlDir",
                 "JSX",
                 "Svelte",
                 "JSON",

--- a/nvim-treesitter-highlight-queries/build.rs
+++ b/nvim-treesitter-highlight-queries/build.rs
@@ -34,6 +34,8 @@ const INCLUDED_NVIM_TREESITTER_LANGUAGES: &[&str] = &[
     "html_tags",
     "idris",
     "javascript",
+    "qmljs",
+    "qmldir",
     "json",
     "jsx",
     "julia",
@@ -72,8 +74,14 @@ const INCLUDED_NVIM_TREESITTER_LANGUAGES: &[&str] = &[
     "jj description",
 ];
 
-const MISSING_NVIM_HIGHLIGHTS: &[&str] =
-    &["dune", "ki_quickfix", "tsq", "jj description", "gnuplot"];
+const MISSING_NVIM_HIGHLIGHTS: &[&str] = &[
+    "dune",
+    "ki_quickfix",
+    "tsq",
+    "jj description",
+    "gnuplot",
+    "qml",
+];
 
 fn main() {
     let compiled_highlight_query_path = std::path::PathBuf::from(

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -69,6 +69,8 @@ tree-sitter-zsh = "0.63.3"
 tree-sitter-jjdescription = { git = "https://github.com/irevoire/tree-sitter-jjdescription/", rev = "671e0d6" }
 tree-sitter-kdl = { git = "https://github.com/tree-sitter-grammars/tree-sitter-kdl", rev = "7dbf219" }
 tree-sitter-gnuplot = { git = "https://github.com/dpezto/tree-sitter-gnuplot", rev = "29586d4" }
+tree-sitter-qmljs = "0.3.0"
+tree-sitter-qmldir = { git = "https://github.com/tree-sitter-grammars/tree-sitter-qmldir", rev = "1fa9200" }
 
 [dev-dependencies]
 quickcheck.workspace = true

--- a/shared/src/language.rs
+++ b/shared/src/language.rs
@@ -77,6 +77,8 @@ pub enum CargoLinkedTreesitterLanguage {
     Graphql,
     Gnuplot,
     Javascript,
+    QmlJs,
+    QmlDir,
     JSX,
     Svelte,
     JSON,
@@ -136,6 +138,8 @@ impl CargoLinkedTreesitterLanguage {
             CargoLinkedTreesitterLanguage::Graphql => tree_sitter_graphql::LANGUAGE.into(),
             CargoLinkedTreesitterLanguage::Gnuplot => tree_sitter_gnuplot::LANGUAGE.into(),
             CargoLinkedTreesitterLanguage::Javascript => tree_sitter_javascript::LANGUAGE.into(),
+            CargoLinkedTreesitterLanguage::QmlJs => tree_sitter_qmljs::LANGUAGE.into(),
+            CargoLinkedTreesitterLanguage::QmlDir => tree_sitter_qmldir::LANGUAGE.into(),
             CargoLinkedTreesitterLanguage::JSX => tree_sitter_javascript::LANGUAGE.into(),
             CargoLinkedTreesitterLanguage::Svelte => tree_sitter_svelte_ng::LANGUAGE.into(),
             CargoLinkedTreesitterLanguage::JSON => tree_sitter_json::LANGUAGE.into(),
@@ -199,6 +203,8 @@ impl CargoLinkedTreesitterLanguage {
             CargoLinkedTreesitterLanguage::Javascript => {
                 Some(tree_sitter_javascript::HIGHLIGHT_QUERY)
             }
+            CargoLinkedTreesitterLanguage::QmlJs => Some(tree_sitter_qmljs::HIGHLIGHTS_QUERY),
+            CargoLinkedTreesitterLanguage::QmlDir => Some(tree_sitter_qmldir::HIGHLIGHTS_QUERY),
             CargoLinkedTreesitterLanguage::JSX => Some(tree_sitter_javascript::HIGHLIGHT_QUERY),
             CargoLinkedTreesitterLanguage::Svelte => Some(tree_sitter_svelte_ng::HIGHLIGHTS_QUERY),
             CargoLinkedTreesitterLanguage::JSON => Some(tree_sitter_json::HIGHLIGHTS_QUERY),

--- a/shared/src/languages.rs
+++ b/shared/src/languages.rs
@@ -48,6 +48,8 @@ pub fn languages() -> HashMap<String, Language> {
         ("idris", idris()),
         ("haskell", haskell()),
         ("javascript", javascript()),
+        ("qml", qml()),
+        ("qmldir", qmldir()),
         ("javascriptreact", javascriptreact()),
         ("svelte", svelte()),
         ("json", json()),
@@ -686,6 +688,39 @@ fn javascript() -> Language {
     }
 }
 
+fn qml() -> Language {
+    Language {
+        extensions: to_vec(&["qml"]),
+        formatter: None,
+        lsp_command: Some(LspCommand {
+            command: Command::new("qmlls6", &[]),
+            ..LspCommand::default()
+        }),
+        lsp_language_id: Some(LanguageId::new("qmljs")),
+        tree_sitter_grammar_config: Some(GrammarConfig {
+            id: "qmljs".to_string(),
+            kind: GrammarConfigKind::CargoLinked(CargoLinkedTreesitterLanguage::QmlJs),
+        }),
+        line_comment_prefix: Some("//".to_string()),
+        block_comment_affixes: Some(("/*".to_string(), "*/".to_string())),
+        ..Language::new()
+    }
+}
+
+fn qmldir() -> Language {
+    Language {
+        file_names: to_vec(&["qmldir"]),
+        formatter: None,
+        tree_sitter_grammar_config: Some(GrammarConfig {
+            id: "qmldir".to_string(),
+            kind: GrammarConfigKind::CargoLinked(CargoLinkedTreesitterLanguage::QmlDir),
+        }),
+        line_comment_prefix: Some("//".to_string()),
+        block_comment_affixes: Some(("/*".to_string(), "*/".to_string())),
+        ..Language::new()
+    }
+}
+
 fn javascriptreact() -> Language {
     Language {
         extensions: to_vec(&["jsx"]),
@@ -1270,7 +1305,8 @@ fn scala() -> Language {
 mod test {
     #[test]
     fn test_languages_match_nvim_treesitter_languages() {
-        const MISSING_NVIM_HIGHLIGHTS: &[&str] = &["dune", "ki_quickfix", "tsq", "jj description"];
+        const MISSING_NVIM_HIGHLIGHTS: &[&str] =
+            &["dune", "ki_quickfix", "tsq", "jj description", "qml"];
 
         // This test is a major consistency check.
         // First, we check that all builtin languages were searched for in nvim-treesitter.

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -14,6 +14,7 @@ pub struct Edit {
     pub new: Rope,
     pub old: Rope,
 }
+
 impl Edit {
     pub fn new(rope: &Rope, range: CharIndexRange, new: Rope) -> Self {
         Self {


### PR DESCRIPTION
Hey!

I've been editing a bunch of QML files and struggling, so I added support for it in Ki.
The lsp works really well from what I saw.
The tree-sitter implementation is not that good, though, but it seems like the repo is active and it's still being worked on, so I  guess we can still add it as-is and hope it improves over releases :thinking: 

<img width="1252" height="998" alt="image" src="https://github.com/user-attachments/assets/8b4699ad-c154-4435-ac67-e7ed0f0206a3" />

