### PR TITLE
refactor(clipboard): use OSC52 exclusively for copying

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,29 +463,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cssparser"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e901edd733a1472f944a45116df3f846f54d37e67e68640ac8bb69689aca2aa"
-dependencies = [
- "cssparser-macros",
- "dtoa-short",
- "itoa",
- "phf",
- "smallvec",
-]
-
-[[package]]
-name = "cssparser-macros"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
 name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -601,21 +578,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
-name = "dtoa"
-version = "1.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6add3b8cff394282be81f3fc1a0605db594ed69890078ca6e2cab1c408bcf04"
-
-[[package]]
-name = "dtoa-short"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
-dependencies = [
- "dtoa",
-]
-
-[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -626,12 +588,6 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
-
-[[package]]
-name = "ego-tree"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2972feb8dffe7bc8c5463b1dacda1b0dfbed3710e50f977d965429692d74cd8"
 
 [[package]]
 name = "either"
@@ -807,16 +763,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futf"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
-dependencies = [
- "mac",
- "new_debug_unreachable",
-]
-
-[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -894,15 +840,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -920,15 +857,6 @@ checksum = "0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818"
 dependencies = [
  "libc",
  "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "getopts"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -1070,17 +998,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "html5ever"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55d958c2f74b664487a2035fe1dadb032c48718a03b63f3ab0b8537db8549ed4"
-dependencies = [
- "log",
- "markup5ever",
- "match_token",
 ]
 
 [[package]]
@@ -1405,7 +1322,6 @@ dependencies = [
  "regex",
  "ropey",
  "schemars",
- "scraper",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -1606,34 +1522,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
-
-[[package]]
-name = "markup5ever"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "311fe69c934650f8f19652b3946075f0fc41ad8757dbb68f1ca14e7900ecc1c3"
-dependencies = [
- "log",
- "tendril",
- "web_atoms",
-]
-
-[[package]]
-name = "match_token"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac84fd3f360fcc43dc5f5d186f02a94192761a080e8bc58621ad4d12296a58cf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1703,12 +1591,6 @@ dependencies = [
  "slab",
  "snowflake",
 ]
-
-[[package]]
-name = "new_debug_unreachable"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nom"
@@ -1947,58 +1829,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_macros",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
-dependencies = [
- "phf_generator",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared",
- "rand",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator",
- "phf_shared",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2033,12 +1863,6 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
-
-[[package]]
-name = "precomputed-hash"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "pretty_assertions"
@@ -2322,44 +2146,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "scraper"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5f3a24d916e78954af99281a455168d4a9515d65eca99a18da1b813689c4ad9"
-dependencies = [
- "cssparser",
- "ego-tree",
- "getopts",
- "html5ever",
- "precomputed-hash",
- "selectors",
- "tendril",
-]
-
-[[package]]
 name = "sdd"
 version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
-
-[[package]]
-name = "selectors"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5685b6ae43bfcf7d2e7dfcfb5d8e8f61b46442c902531e41a32a9a8bf0ee0fb6"
-dependencies = [
- "bitflags 2.9.1",
- "cssparser",
- "derive_more",
- "fxhash",
- "log",
- "new_debug_unreachable",
- "phf",
- "phf_codegen",
- "precomputed-hash",
- "servo_arc",
- "smallvec",
-]
 
 [[package]]
 name = "serde"
@@ -2498,15 +2288,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "servo_arc"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "204ea332803bd95a0b60388590d59cf6468ec9becf626e2451f1d26a1d972de4"
-dependencies = [
- "stable_deref_trait",
-]
-
-[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2638,12 +2419,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "siphasher"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
-
-[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2687,31 +2462,6 @@ name = "streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
-
-[[package]]
-name = "string_cache"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
-dependencies = [
- "new_debug_unreachable",
- "parking_lot",
- "phf_shared",
- "precomputed-hash",
- "serde",
-]
-
-[[package]]
-name = "string_cache_codegen"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
-dependencies = [
- "phf_generator",
- "phf_shared",
- "proc-macro2",
- "quote",
-]
 
 [[package]]
 name = "strsim"
@@ -2771,17 +2521,6 @@ dependencies = [
  "once_cell",
  "rustix 1.0.8",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "tendril"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
-dependencies = [
- "futf",
- "mac",
- "utf-8",
 ]
 
 [[package]]
@@ -3739,18 +3478,6 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
  "wasm-bindgen-futures",
-]
-
-[[package]]
-name = "web_atoms"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ffde1dc01240bdf9992e3205668b235e59421fd085e8a317ed98da0178d414"
-dependencies = [
- "phf",
- "phf_codegen",
- "string_cache",
- "string_cache_codegen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,6 @@ figment = { version = "0.10.19", features = ["json", "toml", "yaml"] }
 tungstenite = "0.21"
 libc = "0.2.174"
 crc32fast = "1.4.2"
-scraper = "0.24.0"
 imara-diff = "0.2.0"
 nucleo = "0.5.0"
 notify = "8.2.0"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1132,12 +1132,11 @@ impl<T: Frontend> App<T> {
             Dispatch::SetClipboardContent {
                 copied_texts: contents,
             } => {
-                self.context
-                    .set_clipboard_content(contents.clone())
-                    .or_else(|_| {
-                        let mut frontend = self.frontend.lock().unwrap();
-                        frontend.set_clipboard_with_osc52(&contents.to_text())
-                    })?;
+                self.context.set_clipboard_content(contents.clone());
+                self.frontend
+                    .lock()
+                    .unwrap()
+                    .set_clipboard_with_osc52(&contents.to_text())?;
             }
             Dispatch::AddKillRingEntry { texts } => self.context.add_kill_ring_entry(texts),
             Dispatch::SetGlobalMode(mode) => self.set_global_mode(mode)?,
@@ -1268,8 +1267,8 @@ impl<T: Frontend> App<T> {
             } => self.open_search_prompt_with_current_selection(scope, prior_change)?,
             Dispatch::ShowGlobalInfo(info) => self.show_global_info(info),
             #[cfg(test)]
-            Dispatch::SetSystemClipboardHtml { html, alt_text } => {
-                self.set_system_clipboard_html(html, alt_text)?;
+            Dispatch::SetSystemClipboardContent { content } => {
+                self.set_system_clipboard_content(content)?;
             }
             Dispatch::AddQuickfixListEntries(locations) => {
                 self.add_quickfix_list_entries(locations)?;
@@ -3308,8 +3307,8 @@ impl<T: Frontend> App<T> {
     }
 
     #[cfg(test)]
-    fn set_system_clipboard_html(&self, html: &str, alt_text: &str) -> anyhow::Result<()> {
-        Ok(arboard::Clipboard::new()?.set_html(html, Some(alt_text))?)
+    fn set_system_clipboard_content(&self, content: &str) -> anyhow::Result<()> {
+        Ok(arboard::Clipboard::new()?.set_text(content)?)
     }
 
     fn restore_session(&mut self) {
@@ -4014,9 +4013,8 @@ pub enum Dispatch {
     },
     ShowGlobalInfo(Info),
     #[cfg(test)]
-    SetSystemClipboardHtml {
-        html: &'static str,
-        alt_text: &'static str,
+    SetSystemClipboardContent {
+        content: &'static str,
     },
     AddQuickfixListEntries(Vec<Match>),
     AppliedEdits {

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -1,8 +1,6 @@
-use anyhow::Context;
 use indexmap::IndexSet;
 use itertools::Itertools;
 use nonempty::NonEmpty;
-use scraper::{Html, Selector};
 
 #[derive(Clone)]
 pub struct Clipboard {
@@ -10,7 +8,7 @@ pub struct Clipboard {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-/// Why is it a vector?  
+/// Why is it a vector?
 /// Because it needs to support multiple cursors.
 /// The first entry represent the copied text of the first cursor,
 /// and so forth.
@@ -42,102 +40,6 @@ impl Texts {
     pub fn to_text(&self) -> String {
         self.join("\n")
     }
-
-    pub fn to_html(&self) -> String {
-        // Multiple elements (multi-cursor), wrap in HTML format
-        let html = Xml::Node {
-            tag: "div",
-            attributes: vec![XmlAttribute {
-                key: "source",
-                value: "ki-editor".to_string(),
-            }],
-            children: self
-                .texts
-                .iter()
-                .map(|text| Xml::Node {
-                    tag: "div",
-                    attributes: vec![],
-                    children: vec![Xml::Text(text.clone())],
-                })
-                .collect(),
-        };
-        html.stringify()
-    }
-}
-
-enum Xml {
-    Node {
-        tag: &'static str,
-        attributes: Vec<XmlAttribute>,
-        children: Vec<Xml>,
-    },
-    Text(String),
-}
-impl Xml {
-    fn stringify(&self) -> String {
-        match self {
-            Xml::Node {
-                tag,
-                attributes,
-                children,
-            } => {
-                let attributes = attributes
-                    .iter()
-                    .map(|attribute| attribute.stringify())
-                    .join(" ");
-                let children = children.iter().map(|child| child.stringify()).join("\n");
-                format!("<{tag} {attributes}>{children}</{tag}>",)
-            }
-            Xml::Text(text) => escape_xml_text(text),
-        }
-    }
-}
-
-struct XmlAttribute {
-    key: &'static str,
-    value: String,
-}
-impl XmlAttribute {
-    fn stringify(&self) -> String {
-        format!("{}=\"{}\"", self.key, escape_xml_attr(&self.value))
-    }
-}
-
-fn escape_xml_text(s: &str) -> String {
-    s.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-}
-
-fn escape_xml_attr(s: &str) -> String {
-    s.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-}
-
-impl Texts {
-    fn from_html(html: &str) -> anyhow::Result<Self> {
-        let html_doc = Html::parse_document(html);
-        let ki_selector = Selector::parse("div[source='ki-editor'] div")
-            .map_err(|err| anyhow::anyhow!("{err}"))?;
-
-        let texts: Vec<String> = html_doc
-            .select(&ki_selector)
-            .filter_map(|element| {
-                let text = element.text().collect::<String>();
-                if text.is_empty() {
-                    None
-                } else {
-                    Some(text.to_string())
-                }
-            })
-            .collect();
-
-        Ok(Texts::new(NonEmpty::from_vec(texts).ok_or(
-            anyhow::anyhow!("CopiedTexts::from_html: texts is empty"),
-        )?))
-    }
 }
 
 impl Clipboard {
@@ -152,26 +54,30 @@ impl Clipboard {
     }
 
     pub fn get_from_system_clipboard(&self) -> anyhow::Result<Texts> {
-        // Try to parse the HTML as a Ki-injected HTML
-        let mut clipboard = arboard::Clipboard::new()?;
-        clipboard
-            .get()
-            .html()
-            .map_err(|err| anyhow::anyhow!("{err}"))
-            .and_then(|html| Texts::from_html(html.as_str()))
-            .or_else(|_| {
-                Ok(Texts::new(NonEmpty::new(
-                    clipboard.get().text().context("arboard::Get::text")?,
-                )))
-            })
+        let arboard_result = arboard::Clipboard::new()
+            .and_then(|mut clipboard| clipboard.get().text())
+            .ok();
+
+        let latest_ki_entry = self.history.get(0);
+
+        match (arboard_result, latest_ki_entry) {
+            // arboard failed: fall back to ki's history
+            (None, Some(ki_entry)) => Ok(ki_entry),
+            // arboard failed and ki history is empty: error
+            (None, None) => Err(anyhow::anyhow!("system clipboard is inaccessible")),
+            // Content matches ki's entry — use ki's entry to preserve multi-cursor
+            (Some(arboard_text), Some(ki_entry)) if arboard_text == ki_entry.to_text() => {
+                Ok(ki_entry)
+            }
+            // External content or no ki history: return as single-text Texts
+            (Some(arboard_text), _) => Ok(Texts::new(NonEmpty::singleton(arboard_text))),
+        }
     }
 
-    pub fn set(&mut self, copied_texts: Texts) -> anyhow::Result<()> {
-        self.history.add(copied_texts.clone());
-        arboard::Clipboard::new().and_then(|mut clipboard| {
-            clipboard.set_html(copied_texts.to_html(), Some(copied_texts.to_text()))
-        })?;
-        Ok(())
+    /// Adds the copied texts to ki's internal clipboard history.
+    /// The caller is responsible for writing to the system clipboard (e.g. via OSC52).
+    pub fn set(&mut self, copied_texts: Texts) {
+        self.history.add(copied_texts);
     }
 }
 
@@ -180,9 +86,9 @@ pub struct RingHistory<T: Clone> {
     items: IndexSet<T>,
 }
 impl<T: Clone + PartialEq + Eq + std::hash::Hash> RingHistory<T> {
-    /// 0 means latest.  
-    /// -1 means previous.  
-    /// +1 means next.  
+    /// 0 means latest.
+    /// -1 means previous.
+    /// +1 means next.
     pub fn get(&self, history_offset: isize) -> Option<T> {
         let len = self.items.len();
         if len == 0 {

--- a/src/context.rs
+++ b/src/context.rs
@@ -391,9 +391,9 @@ impl Context {
         self.clipboard.get(history_offset)
     }
 
-    pub fn set_clipboard_content(&mut self, contents: Texts) -> anyhow::Result<()> {
+    pub fn set_clipboard_content(&mut self, contents: Texts) {
         self.kill_ring.add(contents.clone());
-        self.clipboard.set(contents)
+        self.clipboard.set(contents);
     }
 
     pub fn mode(&self) -> Option<GlobalMode> {

--- a/src/frontend/mock.rs
+++ b/src/frontend/mock.rs
@@ -75,7 +75,10 @@ impl super::Frontend for MockFrontend {
         self.previous_screen = previous_screen;
     }
 
-    fn set_clipboard_with_osc52(&mut self, _content: &str) -> anyhow::Result<()> {
+    fn set_clipboard_with_osc52(&mut self, content: &str) -> anyhow::Result<()> {
+        // In tests there is no real terminal to receive OSC52, so write to arboard
+        // directly so that get_from_system_clipboard() returns the same content.
+        let _ = arboard::Clipboard::new().and_then(|mut c| c.set_text(content));
         Ok(())
     }
 

--- a/src/test_app.rs
+++ b/src/test_app.rs
@@ -3195,9 +3195,7 @@ fn pasting_when_clipboard_html_is_set_by_other_app() -> Result<(), anyhow::Error
                     owner: BufferOwner::User,
                     focus: true,
                 }),
-                App(Dispatch::SetSystemClipboardContent {
-                    content: "hello",
-                }),
+                App(Dispatch::SetSystemClipboardContent { content: "hello" }),
                 Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Character)),
                 Editor(SetContent("".to_string())),
                 Editor(PasteWithMovement(GetGapMovement::Right)),

--- a/src/test_app.rs
+++ b/src/test_app.rs
@@ -3195,9 +3195,8 @@ fn pasting_when_clipboard_html_is_set_by_other_app() -> Result<(), anyhow::Error
                     owner: BufferOwner::User,
                     focus: true,
                 }),
-                App(Dispatch::SetSystemClipboardHtml {
-                    html: "<div source=\"from Microsoft Word\">hello</div>",
-                    alt_text: "hello",
+                App(Dispatch::SetSystemClipboardContent {
+                    content: "hello",
                 }),
                 Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Character)),
                 Editor(SetContent("".to_string())),


### PR DESCRIPTION
## Background

Two separate user reports pointed to the same root cause.

### Report 1 — clipboard broken on X11 (https://ki-editor.zulipchat.com/#narrow/channel/538719/topic/Copy.20to.20clipboard.3F/with/592372905)

**Descending Nerdliness** reported that copying in Ki didn't put anything on the system clipboard (Debian/X11 with CopyQ). Checking the logs revealed:

```
WARN arboard::platform::linux::x11: Could not hand the clipboard contents over to the clipboard manager. The request timed out.
```

arboard was silently failing to hand off clipboard contents to the X11 clipboard manager — no error surfaced to the user, copy just silently did nothing.

### Report 2 — clipboard broken when Ki is suspended (https://ki-editor.zulipchat.com/#narrow/channel/538719/topic/copy.20paste.20while.20ki.20is.20suspended/with/592178096)

@irevoire reported that copied content was unavailable after suspending Ki with `ctrl+z`. Their workflow:

> edit stuff in ki → ctrl+z, do stuff in my terminal → fg to put back ki in foreground

Copying in Ki and then trying to paste after suspending it would freeze the terminal for ~2 seconds. A clipboard history manager could eventually show the content, but direct paste was broken.

@Riolku diagnosed the root cause: Ki uses arboard, which uses the Wayland/X11 clipboard APIs directly. Under these protocols, the *application* (Ki) is responsible for serving clipboard data when another client requests it. When Ki is suspended, it can't respond to those requests — hence the freeze and timeout.

> Helix and vim and friends aren't using wayland to send data, they're using OSC52 probably, which makes the terminal responsible for sending data. However we use the wayland APIs via a crate. Therefore Ki is responsible for sending data when another client requests it.

## Solution

**Riolku's proposal:**

> - on copy, use OSC52 and update ki's clipboard history
> - on paste, use arboard. If it fails, or the content matches ki's most recent entry, use that. Otherwise, use what arboard said
>
> this also lets us stop including an HTML parser in ki

With OSC52, the *terminal* owns the clipboard data, so it's available regardless of whether Ki is running or suspended.

The multi-cursor copy-paste behaviour is preserved: since OSC52 only carries plain text, on paste we compare arboard's text against ki's latest history entry (joined with newlines). If they match, we use ki's "enriched" entry which carries per-cursor text.

## Changes

- **Copy path**: removed arboard + HTML encode/decode; `clipboard.set()` now only updates ki's internal history, and the `SetClipboardContent` dispatch always writes via `crossterm`'s `CopyToClipboard` (OSC52)
- **Paste path**: arboard still used for reading plain text, with smart fallback:
  - If arboard text matches ki's latest history entry → return ki's entry (preserves multi-cursor structure)
  - If arboard fails → fall back to ki's internal history
  - Otherwise → wrap arboard text as a single-cursor `Texts`
- **Removed `scraper`** dependency entirely (no more HTML parser needed)
- Simplified test-only `SetSystemClipboardHtml` → `SetSystemClipboardContent` (plain text only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)