### PR TITLE
fix(language): shfmt usage

### DIFF
--- a/shared/src/languages.rs
+++ b/shared/src/languages.rs
@@ -86,7 +86,7 @@ fn bash() -> Language {
     Language {
         extensions: to_vec(&["sh", "bash"]),
         file_names: to_vec(&[".bashrc", ".bash_profile", "bashrc", "bash_profile"]),
-        formatter: Some(Command::new("shfmt", &[".sh", ".bash"])),
+        formatter: Some(Command::new("shfmt", &[])),
         lsp_command: Some(LspCommand {
             command: Command::new("bash-language-server", &["start"]),
             ..LspCommand::default()


### PR DESCRIPTION
```shell
$ cat $(ki @ log)
...
2026-05-04T19:40:21.687319Z  INFO shared::process_command: 58: ProcessCommand::spawn "shfmt" [".sh", ".bash"]
2026-05-04T19:40:21.692754Z  INFO ki::buffer: 749: Error formatting: [[STDERR]]:
lstat .sh: no such file or directory
lstat .bash: no such file or directory


[[STDOUT]]:
```