### PR TITLE
fix(cut): use extended selection range when cutting with selection extension

### DIFF
--- a/src/components/editor/mod.rs
+++ b/src/components/editor/mod.rs
@@ -1091,13 +1091,18 @@ impl Editor {
         movement: Movement,
         cut: bool,
     ) -> anyhow::Result<Dispatches> {
+        // Capture texts before building the edit transaction, so that the extended
+        // selection range is used for both the clipboard and the kill ring.
+        let current_texts = self.get_current_texts();
         let initial_dispatches: Dispatches = if cut {
-            self.copy()
+            Dispatches::one(Dispatch::SetClipboardContent {
+                copied_texts: current_texts.clone(),
+            })
         } else {
             Dispatches::default()
         }
         .append(Dispatch::AddKillRingEntry {
-            texts: self.get_current_texts(),
+            texts: current_texts,
         });
         let edit_transaction = EditTransaction::from_action_groups({
             let buffer = self.buffer();
@@ -1737,13 +1742,20 @@ impl Editor {
     }
 
     pub fn delete_one(&mut self, context: &Context, cut: bool) -> anyhow::Result<Dispatches> {
+        // Capture texts before building the edit transaction, so that the extended
+        // selection range is used for both the clipboard and the kill ring.
+        // (Calling `self.copy()` has a side effect of disabling selection extension,
+        // which would cause the subsequent edit transaction to use the wrong range.)
+        let current_texts = self.get_current_texts();
         let initial_dispatches: Dispatches = if cut {
-            self.copy()
+            Dispatches::one(Dispatch::SetClipboardContent {
+                copied_texts: current_texts.clone(),
+            })
         } else {
             Dispatches::default()
         }
         .append(Dispatch::AddKillRingEntry {
-            texts: self.get_current_texts(),
+            texts: current_texts,
         });
 
         let edit_transaction = EditTransaction::from_action_groups(

--- a/src/components/test_editor.rs
+++ b/src/components/test_editor.rs
@@ -6238,6 +6238,32 @@ fn delete_one_extended_selection() -> anyhow::Result<()> {
 }
 
 #[test]
+fn cut_one_extended_selection() -> anyhow::Result<()> {
+    // Regression test for https://github.com/ki-editor/ki-editor/issues/1597
+    // Cut One with an extended selection should copy AND delete the entire extended selection.
+    execute_test(|s| {
+        Box::new([
+            App(OpenFile {
+                path: s.main_rs(),
+                owner: BufferOwner::User,
+                focus: true,
+            }),
+            Editor(SetContent("abc\ndef".to_string())),
+            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Line)),
+            Editor(EnableSelectionExtension),
+            Editor(MoveSelection(Down)),
+            Expect(CurrentSelectedTexts(&["abc\ndef"])),
+            Editor(CutOne),
+            // Both lines should be deleted, not just the last one
+            Expect(CurrentComponentContent("")),
+            // The clipboard should contain the full extended selection
+            Editor(ReplaceWithCopiedText { cut: false }),
+            Expect(CurrentComponentContent("abc\ndef")),
+        ])
+    })
+}
+
+#[test]
 fn handle_repeated_arrow_keys_in_insert_mode() -> anyhow::Result<()> {
     execute_test(|s| {
         Box::new([


### PR DESCRIPTION
## Summary

- Fixes `CutOne` and `CutWithMovement` incorrectly only deleting the base selection range when a selection extension was active
- Root cause: `copy()` had a side-effect of calling `disable_selection_extension()`, which cleared `initial_range` before the edit transaction was built, causing `extended_range()` to return the non-extended range
- Fix: capture texts upfront and dispatch `SetClipboardContent` directly, avoiding the early side-effect

Closes #1597

## Test plan

- [x] Added `cut_one_extended_selection` regression test: extend a line selection across two lines, cut, verify both lines are deleted and both are in clipboard
- [x] Existing `delete_one_extended_selection` test still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)