### PR TITLE
feat(file-explorer): add ../ entry to navigate to parent directory

### DIFF
--- a/src/components/file_explorer.rs
+++ b/src/components/file_explorer.rs
@@ -91,24 +91,28 @@ impl FileExplorer {
 
         let tree = std::mem::take(&mut self.tree);
         self.tree = tree.reveal(path)?;
-        let dispatches = self.refresh_editor(context)?;
+        self.refresh_editor(context)?;
         if let Some(index) = self.tree.find_index(path) {
             self.editor_mut().select_line_at(index, context)
         } else {
-            Ok(dispatches)
+            Ok(Dispatches::default())
         }
     }
 
-    pub fn refresh(&mut self, context: &Context) -> anyhow::Result<Dispatches> {
+    pub fn refresh(&mut self, context: &Context) -> anyhow::Result<()> {
         let tree = std::mem::take(&mut self.tree);
         self.tree = tree.refresh(context.current_working_directory())?;
-        let dispatches = self.refresh_editor(context)?;
-        Ok(dispatches)
+        self.refresh_editor(context)?;
+        Ok(())
     }
 
-    fn refresh_editor(&mut self, context: &Context) -> anyhow::Result<Dispatches> {
+    fn refresh_editor(&mut self, context: &Context) -> anyhow::Result<()> {
         let text = self.tree.render();
-        self.editor_mut().set_content(&text, context)
+
+        // We can ignore the Dispatches returned here, since they
+        // are only applicable to an editor with a buffer path.
+        let _ = self.editor_mut().set_content(&text, context)?;
+        Ok(())
     }
 
     fn get_current_node(&self) -> anyhow::Result<Option<Node>> {
@@ -142,6 +146,11 @@ impl FileExplorer {
         if nodes.len() == 1 {
             let node = nodes.first();
             match node.kind {
+                NodeKind::ParentDirectory => {
+                    self.tree = Tree::new(&node.path)?;
+                    let _ = self.refresh_editor(context)?;
+                    Ok(Vec::new().into())
+                }
                 NodeKind::File => Ok([
                     Dispatch::CloseCurrentWindow,
                     Dispatch::OpenFile {
@@ -225,7 +234,27 @@ enum ContinuationKind {
 impl Tree {
     fn new(working_directory: &AbsolutePath) -> anyhow::Result<Self> {
         let nodes = get_nodes(working_directory)?;
-        Ok(Self { nodes })
+        // Prepend a ".." entry unless we are already at the filesystem root.
+        let parent_node = working_directory
+            .parent()
+            .ok()
+            .flatten()
+            .map(|parent| Node {
+                name: "..".to_string(),
+                path: parent,
+                kind: NodeKind::ParentDirectory,
+            });
+        Ok(Self {
+            nodes: parent_node.into_iter().chain(nodes).collect(),
+        })
+    }
+
+    /// Creates a child tree (inside an open directory). Child trees do not
+    /// show the `..` entry — only the root-level tree does.
+    fn new_child(directory: &AbsolutePath) -> anyhow::Result<Self> {
+        Ok(Self {
+            nodes: get_nodes(directory)?,
+        })
     }
 
     fn map<F>(self, f: F) -> Self
@@ -243,20 +272,22 @@ impl Tree {
     {
         self.map(|node| {
             let kind = match node.kind {
-                NodeKind::File => node.kind,
+                NodeKind::File | NodeKind::ParentDirectory => node.kind,
                 NodeKind::Directory { open, children } => NodeKind::Directory {
                     open: if node.path == *path {
                         change_open(open)
                     } else {
                         open
                     },
-                    children: children.or_else(|| Tree::new(&node.path).ok()).map(|tree| {
-                        if open {
-                            tree.toggle(path, change_open.clone())
-                        } else {
-                            tree
-                        }
-                    }),
+                    children: children
+                        .or_else(|| Tree::new_child(&node.path).ok())
+                        .map(|tree| {
+                            if open {
+                                tree.toggle(path, change_open.clone())
+                            } else {
+                                tree
+                            }
+                        }),
                 },
             };
             Node { kind, ..node }
@@ -276,7 +307,7 @@ impl Tree {
                 },
                 |continuation, node| match continuation.kind {
                     ContinuationKind::Continue => match &node.kind {
-                        NodeKind::File => {
+                        NodeKind::File | NodeKind::ParentDirectory => {
                             let result = f(continuation.state, node);
                             Continuation {
                                 state: result.state,
@@ -341,6 +372,7 @@ impl Tree {
     }
 
     fn render_with_indent(&self, indent: usize) -> String {
+        let indent_str = "  ".repeat(indent);
         self.nodes
             .iter()
             .map(|node| {
@@ -354,6 +386,7 @@ impl Tree {
                 };
                 let content = match &node.kind {
                     NodeKind::File => format(node.path.icon(icon_config), &node.name),
+                    NodeKind::ParentDirectory => "../".to_string(),
                     NodeKind::Directory { open, children } => {
                         let icon = if *open {
                             icon_config.folder_expanded.as_str()
@@ -377,7 +410,7 @@ impl Tree {
                         }
                     }
                 };
-                format!("{} - {}", "  ".repeat(indent), content)
+                format!("{indent_str} - {content}")
             })
             .collect::<Vec<_>>()
             .join("\n")
@@ -416,7 +449,7 @@ impl Tree {
         let opened_paths = self.walk_visible(Vec::new(), |result, node| Continuation {
             kind: ContinuationKind::Continue,
             state: match &node.kind {
-                NodeKind::File => result,
+                NodeKind::File | NodeKind::ParentDirectory => result,
                 NodeKind::Directory { open, .. } => {
                     if *open {
                         result
@@ -446,6 +479,8 @@ struct Node {
 #[derive(Clone)]
 enum NodeKind {
     File,
+    /// The virtual "../" entry that navigates to the parent directory.
+    ParentDirectory,
     Directory {
         open: bool,
         /// Should be populated lazily
@@ -490,6 +525,7 @@ mod test_file_explorer {
                 App(RevealInExplorer(s.main_rs())),
                 Expect(FileExplorerContent(
                     "
+ - ../
  - 📁  .git/ :
  - 🙈  .gitignore
  - 🔒  Cargo.lock
@@ -539,6 +575,7 @@ mod test_file_explorer {
                 App(RevealInExplorer(s.main_rs())),
                 Expect(FileExplorerContent(
                     "
+ - ../
  - 📁  .git/ :
  - 🙈  .gitignore
  - 🔒  Cargo.lock
@@ -561,6 +598,7 @@ mod test_file_explorer {
                 // Expect the two files (Cargo.lock and Cargo.toml) are deleted
                 Expect(FileExplorerContent(
                     "
+ - ../
  - 📁  .git/ :
  - 🙈  .gitignore
  - 📂  src/ :
@@ -581,6 +619,7 @@ mod test_file_explorer {
                 App(RevealInExplorer(s.main_rs())),
                 Expect(FileExplorerContent(
                     "
+ - ../
  - 📁  .git/ :
  - 🙈  .gitignore
  - 🔒  Cargo.lock
@@ -606,6 +645,7 @@ mod test_file_explorer {
                 // Expect the two files (Cargo.lock and Cargo.toml) are deleted
                 Expect(FileExplorerContent(
                     "
+ - ../
  - 📁  .git/ :
  - 🙈  .gitignore
  - 📂  src/ :
@@ -627,6 +667,7 @@ mod test_file_explorer {
                 App(RevealInExplorer(s.main_rs())),
                 Expect(FileExplorerContent(
                     "
+ - ../
  - 📁  .git/ :
  - 🙈  .gitignore
  - 🔒  Cargo.lock
@@ -666,6 +707,7 @@ mod test_file_explorer {
                 App(RevealInExplorer(s.main_rs())),
                 Expect(FileExplorerContent(
                     "
+ - ../
  - 📁  .git/ :
  - 🙈  .gitignore
  - 🔒  Cargo.lock
@@ -705,6 +747,7 @@ mod test_file_explorer {
                 // Expect the two files paths are appended with ".x"
                 Expect(FileExplorerContent(
                     "
+ - ../
  - 📁  .git/ :
  - 🙈  .gitignore
  - 📄  Cargo.lock.x
@@ -717,6 +760,31 @@ mod test_file_explorer {
                     .trim_matches('\n')
                     .to_string(),
                 )),
+            ])
+        })
+    }
+
+    #[test]
+    fn navigate_to_parent_via_dotdot() -> anyhow::Result<()> {
+        execute_test(|s| {
+            Box::new([
+                // Change cwd to ./src so the file explorer roots there
+                App(ChangeWorkingDirectory(
+                    s.new_path("src").try_into().unwrap(),
+                )),
+                App(RevealInExplorer(s.main_rs())),
+                Expect(CurrentComponentContent(
+                    " - ../
+ - 🦀  foo.rs
+ - 📘  hello.ts
+ - 🦀  main.rs",
+                )),
+                // Press enter on the ".." line (which is line 0)
+                Editor(MatchLiteral("..".to_owned())),
+                Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Line)),
+                App(HandleKeyEvent(key!("enter"))),
+                // Expect the root has moved up one level (now shows src/ as a child)
+                Expect(CurrentComponentContentMatches(lazy_regex::regex!("src"))),
             ])
         })
     }
@@ -748,7 +816,8 @@ mod test_file_explorer {
                 // Although main.rs is deleted, expects the File Explorer
                 // still renders properly
                 Expect(CurrentComponentContent(
-                    " - 📁  .git/ :
+                    " - ../
+ - 📁  .git/ :
  - 🙈  .gitignore
  - 🔒  Cargo.lock
  - 📄  Cargo.toml
@@ -777,14 +846,16 @@ mod test_file_explorer {
                 App(RevealInExplorer(s.main_rs())),
                 // Expect the root of the file explorer is `src` now
                 Expect(CurrentComponentContent(
-                    " - 🦀  foo.rs
+                    " - ../
+ - 🦀  foo.rs
  - 📘  hello.ts
  - 🦀  main.rs",
                 )),
                 // Reveal a file which is outside of ./src
                 App(RevealInExplorer(s.gitignore())),
                 Expect(CurrentComponentContent(
-                    " - 📁  .git/ :
+                    " - ../
+ - 📁  .git/ :
  - 🙈  .gitignore
  - 🔒  Cargo.lock
  - 📄  Cargo.toml

--- a/src/components/file_explorer.rs
+++ b/src/components/file_explorer.rs
@@ -148,7 +148,7 @@ impl FileExplorer {
             match node.kind {
                 NodeKind::ParentDirectory => {
                     self.tree = Tree::new(&node.path)?;
-                    let _ = self.refresh_editor(context)?;
+                    self.refresh_editor(context)?;
                     Ok(Vec::new().into())
                 }
                 NodeKind::File => Ok([
@@ -166,7 +166,7 @@ impl FileExplorer {
                     self.tree = tree.toggle(&node.path, |open| !open);
                     // dropping dispatch as this is a buffer with no path and
                     // refresh dispatches are related to file dirty status
-                    let _ = self.refresh_editor(context)?;
+                    self.refresh_editor(context)?;
                     Ok(Vec::new().into())
                 }
             }

--- a/src/components/prompt.rs
+++ b/src/components/prompt.rs
@@ -846,6 +846,7 @@ mod test_prompt {
                 App(RevealInExplorer(s.main_rs())),
                 Expect(FileExplorerContent(
                     "
+ - ../
  - 📁  .git/ :
  - 🙈  .gitignore
  - 🔒  Cargo.lock

--- a/src/file_watcher/test.rs
+++ b/src/file_watcher/test.rs
@@ -169,7 +169,8 @@ fn path_modified_under_a_non_expanded_folder_should_not_refresh_explorer(
             App(RevealInExplorer(s.gitignore())),
             // Expect "src" folder is not expanded,
             Expect(CurrentComponentContent(
-                " - 📁  .git/ :
+                " - ../
+ - 📁  .git/ :
  - 🙈  .gitignore
  - 🔒  Cargo.lock
  - 📄  Cargo.toml

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -315,8 +315,7 @@ impl Layout {
     pub fn refresh_file_explorer(&self, context: &Context) -> Result<(), anyhow::Error> {
         // dropping dispatch as this is a buffer with no path and
         // refresh dispatches are related to file dirty status
-        let _ = self
-            .background_file_explorer
+        self.background_file_explorer
             .borrow_mut()
             .refresh(context)?;
         Ok(())

--- a/src/test_app.rs
+++ b/src/test_app.rs
@@ -4483,6 +4483,7 @@ fn saving_content_of_pathless_buffer_into_a_new_file_using_shift_enter() -> anyh
             App(OpenFileExplorer),
             Expect(CurrentComponentContent(
                 "
+ - ../
  - 📁  .git/ :
  - 🙈  .gitignore
  - 🔒  Cargo.lock
@@ -4502,6 +4503,7 @@ fn saving_content_of_pathless_buffer_into_a_new_file_using_shift_enter() -> anyh
             )),
             Expect(CurrentComponentContent(
                 "
+ - ../
  - 📁  .git/ :
  - 🙈  .gitignore
  - 🔒  Cargo.lock


### PR DESCRIPTION
## Summary

- Adds a `../` entry as the first line of the File Explorer that navigates to the parent directory when activated (Enter key)
- The entry is omitted when already at the filesystem root (handled correctly on both Unix and Windows via `AbsolutePath::parent`)
- Implemented by prepending a `ParentDirectory` node in `Tree::new()` — child trees (inside open directories) use `Tree::new_child()` which omits it, keeping the entry only at the root level

## Test plan

- [x] All existing file explorer tests updated and passing
- [x] New `navigate_to_parent_via_dotdot` test added to verify the navigation behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)