### PR TITLE
fix: handle unknown/invalid path gracefully instead of panicking

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -159,45 +159,61 @@ fn read_stdin() -> anyhow::Result<PathBuf> {
     Ok(path)
 }
 
-fn run_edit_command(args: EditArgs) -> anyhow::Result<()> {
-    let config = process_edit_args(args)?;
-    crate::run(config)
+pub(crate) enum EditAction {
+    Open(AbsolutePath),
+    MissingParentDirectory { parent: PathBuf },
+    Launch,
 }
 
-fn process_edit_args(args: EditArgs) -> anyhow::Result<RunConfig> {
-    match args.path {
-        Some(path) => {
-            let tmp_path = std::path::PathBuf::from(path.clone());
-            if !tmp_path.exists() {
-                std::fs::write(tmp_path, "")?;
+pub(crate) fn parse_path_arg(path: String) -> anyhow::Result<EditAction> {
+    let tmp_path = PathBuf::from(&path);
+    if !tmp_path.exists() {
+        let parent = tmp_path
+            .parent()
+            .filter(|p| !p.as_os_str().is_empty())
+            .unwrap_or(std::path::Path::new("."));
+        if !parent.is_dir() {
+            return Ok(EditAction::MissingParentDirectory {
+                parent: parent.to_path_buf(),
+            });
+        }
+        std::fs::write(&tmp_path, "")?;
+    }
+    Ok(EditAction::Open(path.try_into()?))
+}
+
+fn run_edit_command(args: EditArgs) -> anyhow::Result<()> {
+    let action = match args.path {
+        Some(path) => parse_path_arg(path)?,
+        None => {
+            if !io::stdin().is_terminal() {
+                let path = read_stdin()?;
+                EditAction::Open(path.to_string_lossy().to_string().try_into()?)
+            } else {
+                EditAction::Launch
             }
+        }
+    };
 
-            let path: Option<AbsolutePath> = Some(path.try_into()?);
-            let working_directory = match path.clone() {
-                Some(value) if value.is_dir() => Some(value),
-                _ => None,
+    match action {
+        EditAction::Open(path) => {
+            let working_directory = if path.is_dir() {
+                Some(path.clone())
+            } else {
+                None
             };
-
-            Ok(crate::RunConfig {
-                entry_path: path,
+            crate::run(RunConfig {
+                entry_path: Some(path),
                 working_directory,
             })
         }
-        None => {
-            // If no path is provided and stdin is not a terminal, read from stdin
-            if !io::stdin().is_terminal() {
-                let path = read_stdin()?;
-                let canonicalized_path: Option<AbsolutePath> =
-                    Some(path.to_string_lossy().to_string().try_into()?);
-
-                Ok(crate::RunConfig {
-                    entry_path: canonicalized_path,
-                    working_directory: None,
-                })
-            } else {
-                Ok(RunConfig::default())
-            }
+        EditAction::MissingParentDirectory { parent } => {
+            eprintln!("Error: directory '{}' does not exist", parent.display());
+            eprintln!("Press Enter to continue...");
+            let _ = io::stdin().read_line(&mut String::new());
+            crate::run(RunConfig::default())
         }
+        EditAction::Launch => crate::run(RunConfig::default()),
     }
 }
 
@@ -268,54 +284,4 @@ pub fn build_grammars() {
 
 pub fn fetch_grammars() {
     grammar::grammar::fetch_grammars(grammar_configs()).unwrap();
-}
-#[cfg(test)]
-mod test_process_edit_args {
-    use shared::absolute_path::AbsolutePath;
-
-    use super::{process_edit_args, EditArgs};
-
-    #[test]
-    /// Cwd should not change
-    fn no_edit_args() -> anyhow::Result<()> {
-        let actual = process_edit_args(EditArgs { path: None })?;
-        assert_eq!(actual.working_directory, None);
-
-        // Delete the temporary file that will be created
-
-        for entry in std::fs::read_dir(".")? {
-            let entry = entry?;
-            let path = entry.path();
-            if path.to_string_lossy().contains("from-stdin-")
-                && path.to_string_lossy().ends_with("txt")
-            {
-                std::fs::remove_file(path)?;
-            }
-        }
-
-        Ok(())
-    }
-
-    #[test]
-    /// Cwd should not change
-    fn args_is_nested_file() -> anyhow::Result<()> {
-        let actual = process_edit_args(EditArgs {
-            path: Some("docs/package.json".to_string()),
-        })?;
-        assert_eq!(actual.working_directory, None);
-        Ok(())
-    }
-
-    #[test]
-    /// Cwd should change to the provided directory
-    fn args_is_directory() -> anyhow::Result<()> {
-        let actual = process_edit_args(EditArgs {
-            path: Some("./docs".to_string()),
-        })?;
-        assert_eq!(
-            actual.working_directory,
-            Some(AbsolutePath::try_from("./docs")?)
-        );
-        Ok(())
-    }
 }

--- a/src/embed/app.rs
+++ b/src/embed/app.rs
@@ -45,7 +45,7 @@ impl EmbeddedApp {
             log::set_max_level(log_level);
         }
 
-        let frontend = std::rc::Rc::new(std::sync::Mutex::new(Crossterm::new()?));
+        let frontend = std::rc::Rc::new(std::sync::Mutex::new(Crossterm::new()));
 
         let status_line_components = vec![];
 

--- a/src/frontend/crossterm.rs
+++ b/src/frontend/crossterm.rs
@@ -16,6 +16,12 @@ impl MyWriter for std::io::Stdout {
     }
 }
 
+impl Default for Crossterm {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Crossterm {
     pub fn new() -> Crossterm {
         Crossterm {

--- a/src/frontend/crossterm.rs
+++ b/src/frontend/crossterm.rs
@@ -17,11 +17,11 @@ impl MyWriter for std::io::Stdout {
 }
 
 impl Crossterm {
-    pub fn new() -> anyhow::Result<Crossterm> {
-        Ok(Crossterm {
+    pub fn new() -> Crossterm {
+        Crossterm {
             stdout: Box::new(io::stdout()),
             previous_screen: Screen::default(),
-        })
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,8 @@ pub mod syntax_highlight;
 #[cfg(test)]
 mod test_app;
 #[cfg(test)]
+mod test_cli;
+#[cfg(test)]
 mod test_lsp;
 #[cfg(test)]
 mod test_search;
@@ -131,7 +133,7 @@ pub fn run(config: RunConfig) -> anyhow::Result<()> {
     let syntax_highlighter_sender = syntax_highlight::start_thread(sender.clone());
 
     let app = App::from_channel(
-        Rc::new(Mutex::new(Crossterm::new()?)),
+        Rc::new(Mutex::new(Crossterm::new())),
         config.working_directory.unwrap_or(".".try_into()?),
         sender,
         receiver,

--- a/src/test_cli.rs
+++ b/src/test_cli.rs
@@ -1,0 +1,34 @@
+use uuid::Uuid;
+
+use crate::cli::{parse_path_arg, EditAction};
+
+fn unique_name() -> String {
+    Uuid::new_v4().to_string()
+}
+
+#[test]
+fn nonexistent_path_with_existing_parent_creates_file() -> anyhow::Result<()> {
+    let file_path = std::env::temp_dir().join(unique_name());
+
+    let action = parse_path_arg(file_path.to_string_lossy().to_string())?;
+
+    assert!(matches!(action, EditAction::Open(_)));
+    assert!(file_path.exists());
+
+    std::fs::remove_file(&file_path)?;
+    Ok(())
+}
+
+#[test]
+fn nonexistent_path_with_nonexistent_parent_returns_missing_parent() -> anyhow::Result<()> {
+    let parent = std::env::temp_dir().join(unique_name());
+    let file_path = parent.join(unique_name());
+
+    let action = parse_path_arg(file_path.to_string_lossy().to_string())?;
+
+    assert!(matches!(
+        action,
+        EditAction::MissingParentDirectory { parent: ref p } if p == &parent
+    ));
+    Ok(())
+}


### PR DESCRIPTION
Fixes #1610

## Problem

When Ki was launched with a path whose parent directory doesn't exist (e.g. after renaming a directory), it panicked with `called Result::unwrap() on an Err value: No such file or directory`. Same panic occurred when the parent path existed as a file rather than a directory (e.g. `ki che/lal` where `che` is a file).

## Solution

- Introduces `EditAction` enum (`Open`, `MissingParentDirectory`, `Launch`) as a clean boundary between the CLI parsing layer and the launch layer
- Extracts `parse_path_arg` — a pure, testable function that handles path resolution and file creation, returning the appropriate `EditAction`
- `run_edit_command` now only handles side effects: printing errors, the "Press Enter to continue" prompt, and launching Ki
- Uses `parent.is_dir()` instead of `parent.exists()` to correctly reject paths where the parent is a file

## Test plan

- [x] `ki /nonexistent/dir/file.txt` — prints error, prompts Enter, launches Ki normally
- [x] `ki newfile.txt` — creates the file and opens it
- [x] `ki existing/nonexistent_file.txt` — opens normally


