### PR TITLE
fix(lsp): handle LSP open_file errors gracefully to prevent Global Reveal/Multicursor toggle failures

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1692,7 +1692,9 @@ impl<T: Frontend> App<T> {
             self.request_syntax_highlight(component_id, batch_id, language, content)?;
         }
         if self.enable_lsp {
-            self.lsp_manager().open_file(path.clone())?;
+            if let Err(err) = self.lsp_manager().open_file(path.clone()) {
+                log::error!("Failed to notify/initialize LSP for {path:?} due to {err:?}")
+            }
         }
 
         self.send_file_watcher_input(FileWatcherInput::SyncOpenedPaths(

--- a/src/app.rs
+++ b/src/app.rs
@@ -1693,7 +1693,7 @@ impl<T: Frontend> App<T> {
         }
         if self.enable_lsp {
             if let Err(err) = self.lsp_manager().open_file(path.clone()) {
-                log::error!("Failed to notify/initialize LSP for {path:?} due to {err:?}")
+                log::error!("Failed to notify/initialize LSP for {path:?} due to {err:?}");
             }
         }
 

--- a/src/multibuffer/global_reveal.rs
+++ b/src/multibuffer/global_reveal.rs
@@ -79,13 +79,13 @@ impl<T: Frontend> App<T> {
             self.multibuffer = None;
             Ok(())
         } else if self.context.mode() == Some(GlobalMode::QuickfixListItem) {
-            self.active_global_reveal_selections()
+            self.activate_global_reveal_selections()
         } else {
             self.handle_dispatch_editor(DispatchEditor::ToggleReveal(Reveal::CurrentSelectionMode))
         }
     }
 
-    fn active_global_reveal_selections(&mut self) -> anyhow::Result<()> {
+    fn activate_global_reveal_selections(&mut self) -> anyhow::Result<()> {
         let grouped_ranges = self
             .quickfix_list()
             .items()


### PR DESCRIPTION
Previously, LSP `open_file` errors (e.g. command not found for unsupported file types) were propagated
as fatal errors, causing Global Reveal and Global Multicursor toggles to fail. Now they are logged instead.
Also fixes a typo: `active_global_reveal_selections` → `activate_global_reveal_selections`.