### PR TITLE
fix(multibuffer): prevent Esc from exiting global mode while Global Reveal is active

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# PR Guidelines
+
+## Test plan
+
+Only include manual testing steps. Do not list automated tests (unit tests, integration tests, etc.) — those are verified by CI.

--- a/src/app.rs
+++ b/src/app.rs
@@ -2397,6 +2397,11 @@ impl<T: Frontend> App<T> {
     }
 
     pub fn set_global_mode(&mut self, mode: Option<GlobalMode>) -> anyhow::Result<()> {
+        if mode.is_none() && self.multibuffer.is_some() {
+            // Don't allow unsetting the global mode when Global Reveal is active;
+            // otherwise the user won't be able to navigate between files using Left/Right.
+            return Ok(());
+        }
         self.context.set_mode(mode.clone());
         if let Some(GlobalMode::QuickfixListItem) = mode {
             self.goto_quickfix_list_item(Movement::Current(IfCurrentNotFound::LookForward))?;

--- a/src/multibuffer/global_multicursor.rs
+++ b/src/multibuffer/global_multicursor.rs
@@ -271,13 +271,13 @@ impl<T: Frontend> App<T> {
             .collect::<anyhow::Result<Vec<_>>>()?;
 
         if !files.is_empty() {
+            self.set_global_mode(None)?;
+
             self.multibuffer = Some(Multibuffer::GlobalMulticursor(GlobalMulticursor {
                 // We'll just assume the first file is the focused file, for simplicity purposes
                 files,
                 focused_file_index: 0,
             }));
-
-            self.set_global_mode(None)?;
 
             self.handle_dispatch_editor(DispatchEditor::SetSelectionMode(
                 IfCurrentNotFound::LookForward,

--- a/src/multibuffer/test_global_reveal.rs
+++ b/src/multibuffer/test_global_reveal.rs
@@ -1,9 +1,10 @@
 use lazy_regex::regex;
-use my_proc_macros::keys;
+use my_proc_macros::{key, keys};
 
 use crate::{
     app::{Dimension, Dispatch::*, Scope},
     components::editor::{DispatchEditor::*, IfCurrentNotFound, Movement},
+    context::GlobalMode,
     grid::StyleKey,
     test_app::{execute_test, ExpectKind::*, Step::*},
 };
@@ -232,6 +233,44 @@ src/foo.rs
                 .trim_matches('\n')
                 .to_string(),
             )),
+        ])
+    })
+}
+
+#[test]
+fn pressing_esc_should_not_exit_quickfix_mode_when_global_reveal_is_active(
+) -> Result<(), anyhow::Error> {
+    execute_test(|s| {
+        Box::new([
+            App(TerminalDimensionChanged(Dimension {
+                width: 100,
+                height: 5,
+            })),
+            App(SetFileContent(
+                s.foo_rs(),
+                "// x \n// qux1 qux2".to_string(),
+            )),
+            App(SetFileContent(
+                s.main_rs(),
+                "// x \n// qux3 qux4".to_string(),
+            )),
+            App(OpenSearchPrompt {
+                scope: Scope::Global,
+                if_current_not_found: IfCurrentNotFound::LookForward,
+            }),
+            App(HandleKeyEvents(keys!("r / q u x . enter").to_vec())),
+            WaitForAppMessage(regex!("GlobalSearchFinished")),
+            App(ToggleRevealSelections),
+            Expect(CurrentGlobalMode(Some(GlobalMode::QuickfixListItem))),
+            App(HandleKeyEvents(keys!("esc").to_vec())),
+            // After pressing Esc, expect the global mode to remain
+            // because Global Reveal is still active.
+            Expect(CurrentGlobalMode(Some(GlobalMode::QuickfixListItem))),
+            App(ToggleRevealSelections),
+            App(HandleKeyEvents(keys!("esc").to_vec())),
+            // After pressing Esc, expect the global mode to be None
+            // because Global Reveal is no longer active.
+            Expect(CurrentGlobalMode(None)),
         ])
     })
 }

--- a/src/multibuffer/test_global_reveal.rs
+++ b/src/multibuffer/test_global_reveal.rs
@@ -1,5 +1,5 @@
 use lazy_regex::regex;
-use my_proc_macros::{key, keys};
+use my_proc_macros::keys;
 
 use crate::{
     app::{Dimension, Dispatch::*, Scope},


### PR DESCRIPTION
## Summary

- When Global Reveal is active, pressing Esc no longer unsets the `QuickfixListItem` global mode — previously this broke Left/Right navigation between files.
- Added a guard in `set_global_mode` that blocks unsetting the mode while `self.multibuffer` is `Some`.
- Reordered the Global Multicursor toggle to call `set_global_mode(None)` *before* assigning `self.multibuffer`, so the new guard does not block the initial mode reset.
- Added a regression test in `test_global_reveal.rs` covering this exact scenario.

## Test plan

- [x] Manually activate Global Reveal, press Esc, and verify Left/Right still navigates between files.
- [x] Deactivate Global Reveal, press Esc, and verify the global mode is cleared.