### PR TITLE
refactor(app): replace Movement with HistoryNavigationMovement

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -3063,13 +3063,19 @@ impl<T: Frontend> App<T> {
         Ok(())
     }
 
-    fn movement_history_navigation(&mut self, movement: Movement) -> anyhow::Result<()> {
+    fn movement_history_navigation(
+        &mut self,
+        movement: HistoryNavigationMovement,
+    ) -> anyhow::Result<()> {
         match movement {
-            Movement::Left => self.navigate_back(),
-            Movement::Right => self.navigate_forward(),
-            Movement::Previous => self.handle_dispatch_editor(DispatchEditor::GoBack),
-            Movement::Next => self.handle_dispatch_editor(DispatchEditor::GoForward),
-            _ => Ok(()),
+            HistoryNavigationMovement::CoarseBack => self.navigate_back(),
+            HistoryNavigationMovement::CoarseForward => self.navigate_forward(),
+            HistoryNavigationMovement::FineBack => {
+                self.handle_dispatch_editor(DispatchEditor::GoBack)
+            }
+            HistoryNavigationMovement::FineForward => {
+                self.handle_dispatch_editor(DispatchEditor::GoForward)
+            }
         }
     }
 
@@ -3823,6 +3829,18 @@ impl Dispatches {
     }
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub enum HistoryNavigationMovement {
+    /// Navigate back across files (coarse)
+    CoarseBack,
+    /// Navigate forward across files (coarse)
+    CoarseForward,
+    /// Navigate back within a file (fine)
+    FineBack,
+    /// Navigate forward within a file (fine)
+    FineForward,
+}
+
 #[must_use]
 #[derive(Clone, Debug, PartialEq, NamedVariant)]
 /// Dispatch are for child component to request action from the root node
@@ -4002,7 +4020,7 @@ pub enum Dispatch {
     SelectCompletionItem,
     SetKeyboardLayout(KeyboardLayout),
     OpenKeyboardLayoutPrompt,
-    MovementHistoryNavigation(Movement),
+    MovementHistoryNavigation(HistoryNavigationMovement),
     ToggleSelectionMark,
     ToggleFileMark,
     SetFileDirtyStatus {

--- a/src/components/test_editor.rs
+++ b/src/components/test_editor.rs
@@ -1,4 +1,4 @@
-use crate::app::{Dimension, LocalSearchConfigUpdate, Scope};
+use crate::app::{Dimension, HistoryNavigationMovement, LocalSearchConfigUpdate, Scope};
 use crate::buffer::{BufferOwner, EditHistoryKind};
 use crate::char_index_range::CharIndexRange;
 use crate::clipboard::Texts;
@@ -4860,13 +4860,13 @@ fn main() {
             Editor(MoveSelection(Left)),
             Editor(MoveSelection(Left)),
             Expect(CurrentSelectedTexts(&["fn main() {"])),
-            App(MovementHistoryNavigation(Previous)),
+            App(MovementHistoryNavigation(HistoryNavigationMovement::FineBack)),
             Expect(CurrentSelectedTexts(&["foo();"])),
-            App(MovementHistoryNavigation(Previous)),
+            App(MovementHistoryNavigation(HistoryNavigationMovement::FineBack)),
             Expect(CurrentSelectedTexts(&["bar();"])),
-            App(MovementHistoryNavigation(Next)),
+            App(MovementHistoryNavigation(HistoryNavigationMovement::FineForward)),
             Expect(CurrentSelectedTexts(&["foo();"])),
-            App(MovementHistoryNavigation(Next)),
+            App(MovementHistoryNavigation(HistoryNavigationMovement::FineForward)),
             Expect(CurrentSelectedTexts(&["fn main() {"])),
         ])
     })

--- a/src/components/test_editor.rs
+++ b/src/components/test_editor.rs
@@ -4860,13 +4860,21 @@ fn main() {
             Editor(MoveSelection(Left)),
             Editor(MoveSelection(Left)),
             Expect(CurrentSelectedTexts(&["fn main() {"])),
-            App(MovementHistoryNavigation(HistoryNavigationMovement::FineBack)),
+            App(MovementHistoryNavigation(
+                HistoryNavigationMovement::FineBack,
+            )),
             Expect(CurrentSelectedTexts(&["foo();"])),
-            App(MovementHistoryNavigation(HistoryNavigationMovement::FineBack)),
+            App(MovementHistoryNavigation(
+                HistoryNavigationMovement::FineBack,
+            )),
             Expect(CurrentSelectedTexts(&["bar();"])),
-            App(MovementHistoryNavigation(HistoryNavigationMovement::FineForward)),
+            App(MovementHistoryNavigation(
+                HistoryNavigationMovement::FineForward,
+            )),
             Expect(CurrentSelectedTexts(&["foo();"])),
-            App(MovementHistoryNavigation(HistoryNavigationMovement::FineForward)),
+            App(MovementHistoryNavigation(
+                HistoryNavigationMovement::FineForward,
+            )),
             Expect(CurrentSelectedTexts(&["fn main() {"])),
         ])
     })

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -1,5 +1,5 @@
 use crate::{
-    app::{Dispatch, FilePickerKind, Scope},
+    app::{Dispatch, FilePickerKind, HistoryNavigationMovement, Scope},
     components::{
         editor::{
             Direction, DispatchEditor, Editor, IfCurrentNotFound, Movement, PriorChange, Reveal,
@@ -1778,22 +1778,22 @@ pub fn movement_history_keymap() -> Keymap {
         Keybinding::new_undocumented(
             "j",
             "<< Move Hist",
-            Dispatch::MovementHistoryNavigation(Movement::Left),
+            Dispatch::MovementHistoryNavigation(HistoryNavigationMovement::CoarseBack),
         ),
         Keybinding::new_undocumented(
             "l",
             "Move Hist >>",
-            Dispatch::MovementHistoryNavigation(Movement::Right),
+            Dispatch::MovementHistoryNavigation(HistoryNavigationMovement::CoarseForward),
         ),
         Keybinding::new_undocumented(
             "u",
             "< Move Hist",
-            Dispatch::MovementHistoryNavigation(Movement::Previous),
+            Dispatch::MovementHistoryNavigation(HistoryNavigationMovement::FineBack),
         ),
         Keybinding::new_undocumented(
             "o",
             "Move Hist >",
-            Dispatch::MovementHistoryNavigation(Movement::Next),
+            Dispatch::MovementHistoryNavigation(HistoryNavigationMovement::FineForward),
         ),
     ])
 }

--- a/src/test_app.rs
+++ b/src/test_app.rs
@@ -43,8 +43,8 @@ use crate::layout::BufferContentsMap;
 
 use crate::{
     app::{
-        App, Dimension, Dispatch, LocalSearchConfigUpdate, RequestParams, Scope,
-        StatusLineComponent,
+        App, Dimension, Dispatch, HistoryNavigationMovement, LocalSearchConfigUpdate, RequestParams,
+        Scope, StatusLineComponent,
     },
     buffer::{Buffer, BufferOwner},
     char_index_range::CharIndexRange,
@@ -3268,18 +3268,18 @@ fn test_navigate_back_from_open_file() -> anyhow::Result<()> {
                 focus: true,
             }),
             Expect(CurrentComponentPath(Some(s.foo_rs()))),
-            App(MovementHistoryNavigation(Movement::Left)),
+            App(MovementHistoryNavigation(HistoryNavigationMovement::CoarseBack)),
             Expect(CurrentComponentPath(Some(s.main_rs()))),
-            App(MovementHistoryNavigation(Movement::Right)),
+            App(MovementHistoryNavigation(HistoryNavigationMovement::CoarseForward)),
             Expect(CurrentComponentPath(Some(s.foo_rs()))),
-            App(MovementHistoryNavigation(Movement::Left)),
+            App(MovementHistoryNavigation(HistoryNavigationMovement::CoarseBack)),
             Expect(CurrentComponentPath(Some(s.main_rs()))),
             App(OpenFile {
                 path: s.gitignore(),
                 owner: BufferOwner::User,
                 focus: true,
             }),
-            App(MovementHistoryNavigation(Movement::Left)),
+            App(MovementHistoryNavigation(HistoryNavigationMovement::CoarseBack)),
             Expect(CurrentComponentPath(Some(s.main_rs()))),
         ])
     })
@@ -3302,9 +3302,9 @@ fn test_navigate_back_from_go_to_location() -> anyhow::Result<()> {
                 range: CharIndexRange::default(),
             })),
             Expect(CurrentComponentPath(Some(s.gitignore()))),
-            App(MovementHistoryNavigation(Movement::Left)),
+            App(MovementHistoryNavigation(HistoryNavigationMovement::CoarseBack)),
             Expect(CurrentComponentPath(Some(s.foo_rs()))),
-            App(MovementHistoryNavigation(Movement::Left)),
+            App(MovementHistoryNavigation(HistoryNavigationMovement::CoarseBack)),
             Expect(CurrentComponentPath(Some(s.main_rs()))),
         ])
     })
@@ -3336,7 +3336,7 @@ fn test_navigate_back_from_quickfix_list() -> anyhow::Result<()> {
                 ),
             ))),
             Expect(CurrentComponentPath(Some(s.foo_rs()))),
-            App(MovementHistoryNavigation(Movement::Left)),
+            App(MovementHistoryNavigation(HistoryNavigationMovement::CoarseBack)),
             Expect(CurrentComponentPath(Some(s.main_rs()))),
         ])
     })
@@ -3853,7 +3853,7 @@ fn navigate_back_should_skip_files_that_were_renamed_or_deleted() -> anyhow::Res
                 focus: true,
             }),
             App(DeletePaths(NonEmpty::new(s.main_rs()))),
-            App(MovementHistoryNavigation(Movement::Left)),
+            App(MovementHistoryNavigation(HistoryNavigationMovement::CoarseBack)),
             Expect(NoError),
         ])
     })
@@ -3873,10 +3873,10 @@ fn navigate_forward_should_skip_files_that_were_renamed_or_deleted() -> anyhow::
                 owner: BufferOwner::User,
                 focus: true,
             }),
-            App(MovementHistoryNavigation(Movement::Left)),
+            App(MovementHistoryNavigation(HistoryNavigationMovement::CoarseBack)),
             Expect(CurrentPath(s.main_rs())),
             App(DeletePaths(NonEmpty::new(s.hello_ts()))),
-            App(MovementHistoryNavigation(Movement::Right)),
+            App(MovementHistoryNavigation(HistoryNavigationMovement::CoarseForward)),
             Expect(NoError),
         ])
     })

--- a/src/test_app.rs
+++ b/src/test_app.rs
@@ -43,8 +43,8 @@ use crate::layout::BufferContentsMap;
 
 use crate::{
     app::{
-        App, Dimension, Dispatch, HistoryNavigationMovement, LocalSearchConfigUpdate, RequestParams,
-        Scope, StatusLineComponent,
+        App, Dimension, Dispatch, HistoryNavigationMovement, LocalSearchConfigUpdate,
+        RequestParams, Scope, StatusLineComponent,
     },
     buffer::{Buffer, BufferOwner},
     char_index_range::CharIndexRange,
@@ -3268,18 +3268,26 @@ fn test_navigate_back_from_open_file() -> anyhow::Result<()> {
                 focus: true,
             }),
             Expect(CurrentComponentPath(Some(s.foo_rs()))),
-            App(MovementHistoryNavigation(HistoryNavigationMovement::CoarseBack)),
+            App(MovementHistoryNavigation(
+                HistoryNavigationMovement::CoarseBack,
+            )),
             Expect(CurrentComponentPath(Some(s.main_rs()))),
-            App(MovementHistoryNavigation(HistoryNavigationMovement::CoarseForward)),
+            App(MovementHistoryNavigation(
+                HistoryNavigationMovement::CoarseForward,
+            )),
             Expect(CurrentComponentPath(Some(s.foo_rs()))),
-            App(MovementHistoryNavigation(HistoryNavigationMovement::CoarseBack)),
+            App(MovementHistoryNavigation(
+                HistoryNavigationMovement::CoarseBack,
+            )),
             Expect(CurrentComponentPath(Some(s.main_rs()))),
             App(OpenFile {
                 path: s.gitignore(),
                 owner: BufferOwner::User,
                 focus: true,
             }),
-            App(MovementHistoryNavigation(HistoryNavigationMovement::CoarseBack)),
+            App(MovementHistoryNavigation(
+                HistoryNavigationMovement::CoarseBack,
+            )),
             Expect(CurrentComponentPath(Some(s.main_rs()))),
         ])
     })
@@ -3302,9 +3310,13 @@ fn test_navigate_back_from_go_to_location() -> anyhow::Result<()> {
                 range: CharIndexRange::default(),
             })),
             Expect(CurrentComponentPath(Some(s.gitignore()))),
-            App(MovementHistoryNavigation(HistoryNavigationMovement::CoarseBack)),
+            App(MovementHistoryNavigation(
+                HistoryNavigationMovement::CoarseBack,
+            )),
             Expect(CurrentComponentPath(Some(s.foo_rs()))),
-            App(MovementHistoryNavigation(HistoryNavigationMovement::CoarseBack)),
+            App(MovementHistoryNavigation(
+                HistoryNavigationMovement::CoarseBack,
+            )),
             Expect(CurrentComponentPath(Some(s.main_rs()))),
         ])
     })
@@ -3336,7 +3348,9 @@ fn test_navigate_back_from_quickfix_list() -> anyhow::Result<()> {
                 ),
             ))),
             Expect(CurrentComponentPath(Some(s.foo_rs()))),
-            App(MovementHistoryNavigation(HistoryNavigationMovement::CoarseBack)),
+            App(MovementHistoryNavigation(
+                HistoryNavigationMovement::CoarseBack,
+            )),
             Expect(CurrentComponentPath(Some(s.main_rs()))),
         ])
     })
@@ -3853,7 +3867,9 @@ fn navigate_back_should_skip_files_that_were_renamed_or_deleted() -> anyhow::Res
                 focus: true,
             }),
             App(DeletePaths(NonEmpty::new(s.main_rs()))),
-            App(MovementHistoryNavigation(HistoryNavigationMovement::CoarseBack)),
+            App(MovementHistoryNavigation(
+                HistoryNavigationMovement::CoarseBack,
+            )),
             Expect(NoError),
         ])
     })
@@ -3873,10 +3889,14 @@ fn navigate_forward_should_skip_files_that_were_renamed_or_deleted() -> anyhow::
                 owner: BufferOwner::User,
                 focus: true,
             }),
-            App(MovementHistoryNavigation(HistoryNavigationMovement::CoarseBack)),
+            App(MovementHistoryNavigation(
+                HistoryNavigationMovement::CoarseBack,
+            )),
             Expect(CurrentPath(s.main_rs())),
             App(DeletePaths(NonEmpty::new(s.hello_ts()))),
-            App(MovementHistoryNavigation(HistoryNavigationMovement::CoarseForward)),
+            App(MovementHistoryNavigation(
+                HistoryNavigationMovement::CoarseForward,
+            )),
             Expect(NoError),
         ])
     })


### PR DESCRIPTION
## Summary

- Introduces a dedicated `HistoryNavigationMovement` enum with four explicit variants (`CoarseBack`, `CoarseForward`, `FineBack`, `FineForward`)
- Replaces reuse of the general-purpose `Movement` enum in `MovementHistoryNavigation`, making the intent of each direction explicit
- Removes the catch-all `_ => Ok(())` arm from `movement_history_navigation`

This is a prerequisite to allow combining the Buffer MoL and Historical Navigation MoL.