### PR TITLE
fix(dev): config schema generation shouldn't be affected user-defined configs

### DIFF
--- a/src/themes/theme_descriptor.rs
+++ b/src/themes/theme_descriptor.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, sync::LazyLock};
 
 use super::{from_zed_theme, very_dark, vscode_dark, vscode_light, Theme};
-use zed_theme::{get_custom_themes, get_zed_themes};
+use zed_theme::get_zed_themes;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct ThemeDescriptor(String);
@@ -39,34 +39,38 @@ static THEMES: LazyLock<HashMap<String, Theme>> = LazyLock::new(|| {
         themes.insert(name, from_zed_theme::from_theme_content(theme));
     }
 
-    // Zed ~/.config/themes/ directory loaded themes
-    let global_glob_os_string = crate::config::ki_global_directory()
-        .join("themes/*.json")
-        .into_os_string();
-    let global_glob = global_glob_os_string
-        .to_str()
-        .expect("Not able to convert global glob os string to str");
-
-    get_custom_themes(global_glob)
-        .into_iter()
-        .for_each(|(name, theme)| {
-            themes.insert(name, from_zed_theme::from_theme_content(theme));
-        });
-
-    // Zed .ki/themes/ directory loaded themes
-    let workspace_glob_os_string = crate::config::ki_workspace_directory()
-        .map(|path| path.join("themes/*.json").into_os_string());
-
-    if let Ok(workspace_glob_os_string) = workspace_glob_os_string {
-        let workspace_glob = workspace_glob_os_string
+    // while running the tests we don't want to load the custom user config
+    #[cfg(not(test))]
+    {
+        // Zed ~/.config/themes/ directory loaded themes
+        let global_glob_os_string = crate::config::ki_global_directory()
+            .join("themes/*.json")
+            .into_os_string();
+        let global_glob = global_glob_os_string
             .to_str()
-            .expect("Not able to convert workspace glob os string to str");
-        get_custom_themes(workspace_glob)
+            .expect("Not able to convert global glob os string to str");
+
+        zed_theme::get_custom_themes(global_glob)
             .into_iter()
             .for_each(|(name, theme)| {
                 themes.insert(name, from_zed_theme::from_theme_content(theme));
             });
-    };
+
+        // Zed .ki/themes/ directory loaded themes
+        let workspace_glob_os_string = crate::config::ki_workspace_directory()
+            .map(|path| path.join("themes/*.json").into_os_string());
+
+        if let Ok(workspace_glob_os_string) = workspace_glob_os_string {
+            let workspace_glob = workspace_glob_os_string
+                .to_str()
+                .expect("Not able to convert workspace glob os string to str");
+            zed_theme::get_custom_themes(workspace_glob)
+                .into_iter()
+                .for_each(|(name, theme)| {
+                    themes.insert(name, from_zed_theme::from_theme_content(theme));
+                });
+        };
+    }
 
     themes
 });


### PR DESCRIPTION
Hey,

Currently, when updating the configuration ki is mixing up my configuration with the default configuration.
This is because we load the user themes when creating the `RawConfig::default`.
This PR fixes this issue and allows me to run `just check-config-schema` even with a custom theme 😁 