### PR TITLE
feat(keymap): workaround for lack of tap-action on MoLs on non-KPP terminals

### DIFF
--- a/src/components/keymap_legend.rs
+++ b/src/components/keymap_legend.rs
@@ -707,4 +707,79 @@ Release hold: Conichihuahua
             ])
         })
     }
+
+    #[test]
+    /// On non-KKP terminals, double-tapping the MoL key (pressing it again while
+    /// the layer is open, with no other keys pressed) fires the on_tap action.
+    fn double_tap_triggers_on_tap() -> anyhow::Result<()> {
+        execute_test(|s| {
+            Box::new([
+                App(OpenFile {
+                    path: s.main_rs(),
+                    owner: BufferOwner::User,
+                    focus: true,
+                }),
+                Editor(SetContent("".to_string())),
+                App(ShowMomentaryLayer(
+                    KeymapLegendConfig {
+                        title: "LEGEND_TITLE".to_string(),
+                        keymap: Keymap::new(&[]),
+                    },
+                    ReleaseKey::new(
+                        "b",
+                        Some(OnTap::new(
+                            "",
+                            Dispatch::ToEditor(SetContent("on tapped!".to_string())),
+                        )),
+                    ),
+                )),
+                Expect(AppGridContains("LEGEND_TITLE")),
+                // Second press of the MoL key — simulates double-tap on non-KKP terminal
+                App(HandleKeyEvent(key!("b"))),
+                Expect(CurrentComponentContent("on tapped!")),
+                Expect(Not(Box::new(AppGridContains("LEGEND_TITLE")))),
+            ])
+        })
+    }
+
+    #[test]
+    /// On non-KKP terminals, pressing the MoL key again after having used the layer
+    /// (other keys were pressed) should close the layer without firing on_tap.
+    fn double_tap_after_using_layer_closes_without_tap() -> anyhow::Result<()> {
+        execute_test(|s| {
+            Box::new([
+                App(OpenFile {
+                    path: s.main_rs(),
+                    owner: BufferOwner::User,
+                    focus: true,
+                }),
+                Editor(SetContent("".to_string())),
+                App(ShowMomentaryLayer(
+                    KeymapLegendConfig {
+                        title: "LEGEND_TITLE".to_string(),
+                        keymap: Keymap::new(&[Keybinding::new_undocumented(
+                            "x",
+                            "",
+                            Dispatch::ToEditor(Insert("hello".to_string())),
+                        )]),
+                    },
+                    ReleaseKey::new(
+                        "b",
+                        Some(OnTap::new(
+                            "",
+                            Dispatch::ToEditor(SetContent("on tapped!".to_string())),
+                        )),
+                    ),
+                )),
+                // Use a layer action so other_keys_pressed becomes true
+                App(HandleKeyEvent(key!("x"))),
+                // Second press of the MoL key
+                App(HandleKeyEvent(key!("b"))),
+                // Layer should be closed
+                Expect(Not(Box::new(AppGridContains("LEGEND_TITLE")))),
+                // on_tap must NOT have fired — content is from the layer action, not the tap
+                Expect(CurrentComponentContent("hello")),
+            ])
+        })
+    }
 }

--- a/src/keymap_override/momentary_layer/mod.rs
+++ b/src/keymap_override/momentary_layer/mod.rs
@@ -54,6 +54,21 @@ impl KeymapOverrideTrait for MomentaryLayerKeymapOverride {
         let key_event = context
             .keyboard_layout()
             .translate_key_event_to_qwerty(key_event);
+
+        // Non-KKP fallback: a second press of the MoL key acts as a tap.
+        // On KKP terminals this branch is unreachable because the layer is
+        // already closed by the release event before a second press arrives.
+        if key_event.code == self.release_key.code
+            && key_event.modifiers == self.release_key.modifiers
+        {
+            let dispatches = self.close_dispatches();
+            return Ok(if !self.other_keys_pressed {
+                dispatches.chain(self.base.inner().tap()?)
+            } else {
+                dispatches
+            });
+        }
+
         let (key_press, dispatches) = self.base.inner().handle_press(key_event)?;
         self.other_keys_pressed |= key_press;
         Ok(dispatches)


### PR DESCRIPTION
Previously when using a non-KPP terminal emulator, MoLs opened up the layer and the layer needed to be manually closed (by pressing escape). However, there did not seem to be any way of actually executing the tap-action of the MoL.

This commit makes it so that double tapping a MoL key executes the tap-action and closes the MoL. E.g. double-tapping `r` will execute the delete action.

This does not affect KPP terminals, since the MoL will be closed as soon as the key is released.

Ran the testsuite, some tests showed up as flaky, but the same tests showed up as flaky without this patch as well.