### PR TITLE
fix(multibuffer): focus retained file after delete cursor removes focused file

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 # PR Guidelines
 
+Always create a new branch before committing and creating a PR.
+
 ## Test plan
 
 Only include manual testing steps. Do not list automated tests (unit tests, integration tests, etc.) — those are verified by CI.

--- a/src/multibuffer/global_multicursor.rs
+++ b/src/multibuffer/global_multicursor.rs
@@ -326,6 +326,8 @@ impl<T: Frontend> App<T> {
         {
             let focused_file_removed = global_multicursor.delete_cursor()?;
             if focused_file_removed {
+                let new_focused_path = global_multicursor.focused_file()?.path.clone();
+                self.open_file(&new_focused_path, BufferOwner::User, false, true)?;
                 return Ok(());
             }
         }

--- a/src/multibuffer/test_global_multicursor.rs
+++ b/src/multibuffer/test_global_multicursor.rs
@@ -289,6 +289,41 @@ fn global_multicursor_marks() -> Result<(), anyhow::Error> {
     })
 }
 
+// Test after delete cursor, should be able to use normal mode actions, such as `a`
+#[test]
+fn should_be_able_to_use_normal_mode_actions_after_delete_cursor() -> Result<(), anyhow::Error> {
+    execute_test(|s| {
+        Box::new([
+            App(TerminalDimensionChanged(Dimension {
+                width: 100,
+                height: 10,
+            })),
+            App(OpenFile {
+                path: s.gitignore(),
+                owner: BufferOwner::User,
+                focus: true,
+            }),
+            App(ToggleFileMark),
+            App(SetFileContent(s.foo_rs(), "foo1".to_string())),
+            App(SetFileContent(s.main_rs(), "foo2".to_string())),
+            App(OpenSearchPrompt {
+                scope: Scope::Global,
+                if_current_not_found: IfCurrentNotFound::LookForward,
+            }),
+            App(HandleKeyEvents(keys!("r / f o o . enter").to_vec())),
+            WaitForAppMessage(regex!("GlobalSearchFinished")),
+            App(AddCursorToAllSelections),
+            Expect(CurrentSelectedTexts(&["foo1", "foo2"])),
+            // Delete a cursor
+            App(HandleKeyEvents(keys!("b n release-b").to_vec())),
+            Expect(CurrentSelectedTexts(&["foo2"])),
+            // Change to Char selection mode
+            App(HandleKeyEvents(keys!("W").to_vec())),
+            Expect(CurrentSelectedTexts(&["f"])),
+        ])
+    })
+}
+
 #[test]
 fn delete_cursor_should_remove_file_if_the_selection_is_the_only_selection_of_the_file(
 ) -> Result<(), anyhow::Error> {


### PR DESCRIPTION
## Summary

- When `delete_cursor` removes the focused file from global multicursor, the app now calls `open_file` to focus the retained file in the layout
- Without this fix, the layout still pointed to the old (removed) editor, causing subsequent normal mode actions (e.g. `W`, `a`) to malfunction

## Test plan

1. Activate Global Multicursor across multiple files
2. Cycle to a non-first file and delete its cursor (so the file is removed)
3. Verify the remaining file is focused and normal mode actions work correctly