### PR TITLE
Add support for glsl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2331,6 +2331,7 @@ dependencies = [
  "tree-sitter-fish",
  "tree-sitter-fsharp",
  "tree-sitter-gleam",
+ "tree-sitter-glsl",
  "tree-sitter-gnuplot",
  "tree-sitter-go",
  "tree-sitter-graphql",
@@ -2824,6 +2825,16 @@ name = "tree-sitter-gleam"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0175c53793bda5d444360dd5add25463d18d66afb7f521d6791e2fc61bf2fb3"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-glsl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df0ee57cbf4c2b35d3a7f17a01bf33c0ef2e85987cb85e516ac8c6904c4e62ac"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/docs/static/app_config_json_schema.json
+++ b/docs/static/app_config_json_schema.json
@@ -124,6 +124,7 @@
                 "Clojure",
                 "FSharp",
                 "Scala",
+                "Glsl",
                 "Devicetree",
                 "Just"
             ]

--- a/nvim-treesitter-highlight-queries/build.rs
+++ b/nvim-treesitter-highlight-queries/build.rs
@@ -72,6 +72,7 @@ const INCLUDED_NVIM_TREESITTER_LANGUAGES: &[&str] = &[
     "kdl",
     "zig",
     "jj description",
+    "glsl",
 ];
 
 const MISSING_NVIM_HIGHLIGHTS: &[&str] = &[

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -71,6 +71,7 @@ tree-sitter-kdl = { git = "https://github.com/tree-sitter-grammars/tree-sitter-k
 tree-sitter-gnuplot = { git = "https://github.com/dpezto/tree-sitter-gnuplot", rev = "29586d4" }
 tree-sitter-qmljs = "0.3.0"
 tree-sitter-qmldir = { git = "https://github.com/tree-sitter-grammars/tree-sitter-qmldir", rev = "1fa9200" }
+tree-sitter-glsl = "0.2.0"
 
 [dev-dependencies]
 quickcheck.workspace = true

--- a/shared/src/language.rs
+++ b/shared/src/language.rs
@@ -115,6 +115,7 @@ pub enum CargoLinkedTreesitterLanguage {
     Clojure,
     FSharp,
     Scala,
+    Glsl,
     Devicetree,
     Just,
 }
@@ -180,6 +181,7 @@ impl CargoLinkedTreesitterLanguage {
             CargoLinkedTreesitterLanguage::JjDescription => {
                 tree_sitter_jjdescription::LANGUAGE.into()
             }
+            CargoLinkedTreesitterLanguage::Glsl => tree_sitter_glsl::LANGUAGE_GLSL.into(),
         }
     }
 
@@ -247,6 +249,7 @@ impl CargoLinkedTreesitterLanguage {
             CargoLinkedTreesitterLanguage::JjDescription => {
                 Some(tree_sitter_jjdescription::HIGHLIGHTS_QUERY)
             }
+            CargoLinkedTreesitterLanguage::Glsl => Some(tree_sitter_glsl::HIGHLIGHTS_QUERY),
         }
     }
 }

--- a/shared/src/languages.rs
+++ b/shared/src/languages.rs
@@ -82,6 +82,7 @@ pub fn languages() -> HashMap<String, Language> {
         ("zig", zig()),
         ("clojure", clojure()),
         ("scala", scala()),
+        ("glsl", glsl()),
     ]
     .into_iter()
     .map(|(str, language)| (str.to_string(), language))
@@ -1294,6 +1295,25 @@ fn scala() -> Language {
         tree_sitter_grammar_config: Some(GrammarConfig {
             id: "scala".to_string(),
             kind: GrammarConfigKind::CargoLinked(CargoLinkedTreesitterLanguage::Scala),
+        }),
+        line_comment_prefix: Some("//".to_string()),
+        block_comment_affixes: Some(("/*".to_string(), "*/".to_string())),
+        ..Language::new()
+    }
+}
+
+fn glsl() -> Language {
+    Language {
+        extensions: to_vec(&["glsl"]),
+        formatter: Some(Command::new("clang-format", &[])),
+        lsp_command: Some(LspCommand {
+            command: Command::new("glsl_analyzer", &[]),
+            ..LspCommand::default()
+        }),
+        lsp_language_id: Some(LanguageId::new("glsl")),
+        tree_sitter_grammar_config: Some(GrammarConfig {
+            id: "glsl".to_string(),
+            kind: GrammarConfigKind::CargoLinked(CargoLinkedTreesitterLanguage::Glsl),
         }),
         line_comment_prefix: Some("//".to_string()),
         block_comment_affixes: Some(("/*".to_string(), "*/".to_string())),


### PR DESCRIPTION
Hey!

This PR adds support for glsl, I used `clang format` for the formatter and from what I see it works pretty well.
I'm not using a C lsp or C tree-sitter because there is some custom one made for glsl specifically.
 
<img width="2539" height="1440" alt="image" src="https://github.com/user-attachments/assets/4a0a9669-324a-46ff-baa9-876a19300d06" />
