### PR TITLE
refactor: replace key handling with CombinedKeyEvent

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -446,14 +446,20 @@ impl<T: Frontend> App<T> {
             }
             event => {
                 let dispatches = match (event, &mut self.keymap_override) {
-                    (Event::Key(key_event), Some(keymap_override)) => match key_event.kind {
-                        KeyEventKind::Press => {
-                            keymap_override.handle_press(&self.context, key_event)
+                    (Event::Key(key_event), Some(keymap_override)) => {
+                        let combined_key_event = self
+                            .context
+                            .keyboard_layout()
+                            .make_combined_key_event(key_event);
+                        match key_event.kind {
+                            KeyEventKind::Press => {
+                                keymap_override.handle_press(&self.context, combined_key_event)
+                            }
+                            KeyEventKind::Release => {
+                                keymap_override.handle_release(&self.context, combined_key_event)
+                            }
                         }
-                        KeyEventKind::Release => {
-                            keymap_override.handle_release(&self.context, key_event)
-                        }
-                    },
+                    }
                     (event, _) => component.borrow_mut().handle_event(&self.context, event),
                 };
 

--- a/src/components/editor/mod.rs
+++ b/src/components/editor/mod.rs
@@ -1709,23 +1709,24 @@ impl Editor {
         context: &Context,
         key_event: KeyEvent,
     ) -> anyhow::Result<Dispatches> {
-        let translated_key_event = context
-            .keyboard_layout()
-            .translate_key_event_to_qwerty(key_event);
-        match self.handle_universal_key(&translated_key_event)? {
+        let combined_key_event = context.keyboard_layout().make_combined_key_event(key_event);
+        match self.handle_universal_key(&combined_key_event)? {
             Some(dispatches) => Ok(dispatches),
             None => match &mut self.keymap_override {
                 Some(keymap_override) => match key_event.kind {
-                    KeyEventKind::Press => keymap_override.handle_press(context, key_event),
-                    KeyEventKind::Release => keymap_override.handle_release(context, key_event),
+                    KeyEventKind::Press => {
+                        keymap_override.handle_press(context, combined_key_event)
+                    }
+                    KeyEventKind::Release => {
+                        keymap_override.handle_release(context, combined_key_event)
+                    }
                 },
                 None => {
                     if let Mode::Insert = self.mode {
-                        self.handle_insert_mode(context, key_event)
+                        self.handle_insert_mode(combined_key_event)
                     } else {
-                        let translated_key_event = context
-                            .keyboard_layout()
-                            .translate_key_event_to_qwerty(key_event);
+                        let translated_key_event =
+                            context.keyboard_layout().make_combined_key_event(key_event);
                         let keymap_legend_config = self.get_current_keymap_legend_config();
 
                         if let Some(keybinding) =
@@ -1733,7 +1734,7 @@ impl Editor {
                         {
                             return Ok(keybinding.get_dispatches());
                         }
-                        log::info!("unhandled event: {translated_key_event:?}");
+                        log::info!("unhandled event: {combined_key_event:?}");
                         Ok(vec![].into())
                     }
                 }

--- a/src/components/editor_keymap.rs
+++ b/src/components/editor_keymap.rs
@@ -165,6 +165,12 @@ pub fn builtin_layout_map() -> HashMap<String, KeyboardLayout> {
         .collect()
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct CombinedKeyEvent {
+    pub original: KeyEvent,
+    pub translated: KeyEvent,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct KeyboardLayout {
     name: String,
@@ -211,8 +217,8 @@ impl KeyboardLayout {
             .unwrap_or(qwerty_char)
     }
 
-    pub fn translate_key_event_to_qwerty(&self, event: KeyEvent) -> KeyEvent {
-        match event.code {
+    pub fn make_combined_key_event(&self, event: KeyEvent) -> CombinedKeyEvent {
+        let qwerty = match event.code {
             KeyCode::Char(pressed_char) => {
                 let translated_char = self.translate_char_to_qwerty(pressed_char);
                 let shift = translated_char.is_uppercase();
@@ -223,6 +229,10 @@ impl KeyboardLayout {
                 }
             }
             _ => event,
+        };
+        CombinedKeyEvent {
+            original: event,
+            translated: qwerty,
         }
     }
 }

--- a/src/components/editor_keymap_legend.rs
+++ b/src/components/editor_keymap_legend.rs
@@ -1,32 +1,27 @@
 use crossterm::event::KeyCode;
 
-use event::{KeyEvent, KeyEventKind};
+use event::KeyEventKind;
 
 use crate::{
     app::{Dispatch, Dispatches},
-    context::Context,
+    components::editor_keymap::CombinedKeyEvent,
     keymap::keymap_universal,
 };
 
 use super::{editor::Editor, keymap_legend::Keymap};
 
 impl Editor {
-    pub fn handle_insert_mode(
-        &self,
-        context: &Context,
-        event: KeyEvent,
-    ) -> anyhow::Result<Dispatches> {
-        let translated_event = context
-            .keyboard_layout()
-            .translate_key_event_to_qwerty(event);
+    pub fn handle_insert_mode(&self, event: CombinedKeyEvent) -> anyhow::Result<Dispatches> {
         if let Some(dispatches) = self
             .insert_mode_keymap(true)
             .iter()
-            .find(|keymap| keymap.event() == &translated_event)
+            .find(|keymap| keymap.event() == &event.translated)
             .map(|keymap| keymap.get_dispatches())
         {
             Ok(dispatches)
-        } else if let (KeyCode::Char(c), KeyEventKind::Press) = (event.code, event.kind) {
+        } else if let (KeyCode::Char(c), KeyEventKind::Press) =
+            (event.original.code, event.original.kind)
+        {
             Ok(Dispatches::one(Dispatch::ToEditor(
                 super::editor::DispatchEditor::InsertChar(c),
             )))
@@ -35,7 +30,10 @@ impl Editor {
         }
     }
 
-    pub fn handle_universal_key(&self, event: &KeyEvent) -> anyhow::Result<Option<Dispatches>> {
+    pub fn handle_universal_key(
+        &self,
+        event: &CombinedKeyEvent,
+    ) -> anyhow::Result<Option<Dispatches>> {
         if let Some(keymap) = Keymap::new(&keymap_universal()).get(event) {
             Ok(Some(keymap.get_dispatches()))
         } else {

--- a/src/components/keymap_legend.rs
+++ b/src/components/keymap_legend.rs
@@ -5,7 +5,10 @@ use std::borrow::Cow;
 
 use crate::{
     app::{Dispatch, Dispatches},
-    components::{editor_keymap::KeyboardLayout, editor_keymap_printer::KeymapDisplayOption},
+    components::{
+        editor_keymap::{CombinedKeyEvent, KeyboardLayout},
+        editor_keymap_printer::KeymapDisplayOption,
+    },
     config::AppConfig,
     context::Context,
     rectangle::Rectangle,
@@ -101,8 +104,8 @@ impl Keymap {
         Self(keybindings.to_vec())
     }
 
-    pub fn get(&self, event: &KeyEvent) -> std::option::Option<&Keybinding> {
-        self.0.iter().find(|key| &key.event == event)
+    pub fn get(&self, event: &CombinedKeyEvent) -> std::option::Option<&Keybinding> {
+        self.0.iter().find(|key| key.event == event.translated)
     }
 
     pub fn iter(&self) -> std::slice::Iter<'_, Keybinding> {

--- a/src/components/suggestive_editor.rs
+++ b/src/components/suggestive_editor.rs
@@ -3,7 +3,7 @@ use crate::context::{Context, GlobalMode};
 use crate::grid::StyleKey;
 use crate::selection::SelectionMode;
 use crate::thread::Callback;
-use event::KeyEventKind;
+use event::{KeyEvent, KeyEventKind};
 use DispatchEditor::*;
 
 use crate::selection_range::SelectionRange;
@@ -77,17 +77,15 @@ impl Component for SuggestiveEditor {
     fn handle_key_event(
         &mut self,
         context: &Context,
-        event: event::KeyEvent,
+        event: KeyEvent,
     ) -> anyhow::Result<Dispatches> {
+        let combined_key_event = context.keyboard_layout().make_combined_key_event(event);
         if self.editor.mode == Mode::Insert && self.completion_dropdown_opened() {
-            let translated_event = context
-                .keyboard_layout()
-                .translate_key_event_to_qwerty(event);
-            if let Some(keymap) = completion_item_keymap().get(&translated_event) {
+            if let Some(keymap) = completion_item_keymap().get(&combined_key_event) {
                 log::info!("dispatches = {:?}", keymap.get_dispatches());
                 return Ok(keymap.get_dispatches());
             };
-            match translated_event {
+            match combined_key_event.translated {
                 key!("down") => return self.next_completion_item(),
                 key!("up") => return self.previous_completion_item(),
                 key!("tab") => return self.select_completion_item(),

--- a/src/keymap_override/find_one.rs
+++ b/src/keymap_override/find_one.rs
@@ -1,14 +1,15 @@
-use crossterm::event::KeyCode;
-use event::KeyEvent;
-
 use crate::{
     app::{Dispatch, Dispatches},
-    components::editor::{DispatchEditor, IfCurrentNotFound},
+    components::{
+        editor::{DispatchEditor, IfCurrentNotFound},
+        editor_keymap::CombinedKeyEvent,
+    },
     context::{Context, LocalSearchConfigMode, Search},
     keymap_override::KeymapOverrideTrait,
     list::grep::RegexConfig,
     selection::SelectionMode,
 };
+use crossterm::event::KeyCode;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FindOneCharKeymapOverride {
@@ -19,9 +20,9 @@ impl KeymapOverrideTrait for FindOneCharKeymapOverride {
     fn handle_press(
         &mut self,
         _context: &Context,
-        key_event: KeyEvent,
+        key_event: CombinedKeyEvent,
     ) -> anyhow::Result<Dispatches> {
-        match key_event.code {
+        match key_event.original.code {
             KeyCode::Esc => Ok(Dispatches::one(Dispatch::ToEditor(
                 DispatchEditor::SetKeymapOverride(None),
             ))),

--- a/src/keymap_override/jump.rs
+++ b/src/keymap_override/jump.rs
@@ -3,7 +3,10 @@ use itertools::Itertools as _;
 
 use crate::{
     app::{Dispatch, Dispatches},
-    components::editor::{DispatchEditor, Editor, Jump, Movement},
+    components::{
+        editor::{DispatchEditor, Editor, Jump, Movement},
+        editor_keymap::CombinedKeyEvent,
+    },
     context::Context,
     keymap_override::KeymapOverrideTrait,
 };
@@ -17,9 +20,9 @@ impl KeymapOverrideTrait for JumpKeymapOverride {
     fn handle_press(
         &mut self,
         context: &Context,
-        key_event: event::KeyEvent,
+        key_event: CombinedKeyEvent,
     ) -> anyhow::Result<Dispatches> {
-        let c = match key_event.code {
+        let c = match key_event.original.code {
             KeyCode::Char(c) => c,
             KeyCode::Esc => {
                 return Ok(Dispatches::one(Dispatch::ToEditor(

--- a/src/keymap_override/menu.rs
+++ b/src/keymap_override/menu.rs
@@ -1,9 +1,10 @@
-use event::KeyEvent;
 use my_proc_macros::key;
 
 use crate::{
     app::{Dispatch, Dispatches},
-    components::{editor::DispatchEditor, keymap_legend::KeymapLegendConfig},
+    components::{
+        editor::DispatchEditor, editor_keymap::CombinedKeyEvent, keymap_legend::KeymapLegendConfig,
+    },
     context::Context,
     keymap_override::KeymapOverrideTrait,
 };
@@ -16,20 +17,17 @@ pub struct MenuKeymapOverride {
 impl KeymapOverrideTrait for MenuKeymapOverride {
     fn handle_press(
         &mut self,
-        context: &Context,
-        key_event: KeyEvent,
+        _context: &Context,
+        key_event: CombinedKeyEvent,
     ) -> anyhow::Result<Dispatches> {
         let close_dispatches = Dispatches::from(vec![
             Dispatch::CloseKeymapLegend,
             Dispatch::ToEditor(DispatchEditor::SetKeymapOverride(None)),
         ]);
-        if key_event == key!("esc") {
+        if key_event.original == key!("esc") {
             return Ok(close_dispatches);
         }
 
-        let key_event = context
-            .keyboard_layout()
-            .translate_key_event_to_qwerty(key_event);
         Ok(match self.config.keymap.get(&key_event) {
             Some(binding) => close_dispatches.chain(binding.get_dispatches()),
             None => Dispatches::default(),

--- a/src/keymap_override/mod.rs
+++ b/src/keymap_override/mod.rs
@@ -1,7 +1,6 @@
-use event::KeyEvent;
-
 use crate::{
     app::Dispatches,
+    components::editor_keymap::CombinedKeyEvent,
     context::Context,
     keymap_override::{
         find_one::FindOneCharKeymapOverride, jump::JumpKeymapOverride, menu::MenuKeymapOverride,
@@ -37,13 +36,13 @@ pub trait KeymapOverrideTrait {
     fn handle_press(
         &mut self,
         context: &Context,
-        key_event: KeyEvent,
+        key_event: CombinedKeyEvent,
     ) -> anyhow::Result<Dispatches>;
 
     fn handle_release(
         &mut self,
         context: &Context,
-        key_event: KeyEvent,
+        key_event: CombinedKeyEvent,
     ) -> anyhow::Result<Dispatches> {
         let _ = (context, key_event);
         Ok(Dispatches::default())
@@ -64,7 +63,7 @@ impl KeymapOverrideTrait for AppKeymapOverride {
     fn handle_press(
         &mut self,
         context: &Context,
-        key_event: KeyEvent,
+        key_event: CombinedKeyEvent,
     ) -> anyhow::Result<Dispatches> {
         self.inner().handle_press(context, key_event)
     }
@@ -72,7 +71,7 @@ impl KeymapOverrideTrait for AppKeymapOverride {
     fn handle_release(
         &mut self,
         context: &Context,
-        key_event: KeyEvent,
+        key_event: CombinedKeyEvent,
     ) -> anyhow::Result<Dispatches> {
         self.inner().handle_release(context, key_event)
     }
@@ -95,7 +94,7 @@ impl KeymapOverrideTrait for EditorKeymapOverride {
     fn handle_press(
         &mut self,
         context: &Context,
-        key_event: KeyEvent,
+        key_event: CombinedKeyEvent,
     ) -> anyhow::Result<Dispatches> {
         self.inner().handle_press(context, key_event)
     }
@@ -103,7 +102,7 @@ impl KeymapOverrideTrait for EditorKeymapOverride {
     fn handle_release(
         &mut self,
         context: &Context,
-        key_event: KeyEvent,
+        key_event: CombinedKeyEvent,
     ) -> anyhow::Result<Dispatches> {
         self.inner().handle_release(context, key_event)
     }

--- a/src/keymap_override/momentary_layer/joint.rs
+++ b/src/keymap_override/momentary_layer/joint.rs
@@ -2,7 +2,7 @@ use event::KeyEvent;
 
 use crate::{
     app::{Dispatch, Dispatches},
-    components::keymap_legend::ReleaseKey,
+    components::{editor_keymap::CombinedKeyEvent, keymap_legend::ReleaseKey},
 };
 
 use super::{simple::SimpleMomentaryLayer, MomentaryLayerBaseTrait};
@@ -16,8 +16,8 @@ pub(super) struct JointMomentaryLayer {
 }
 
 impl MomentaryLayerBaseTrait for JointMomentaryLayer {
-    fn handle_press(&mut self, key_event: KeyEvent) -> anyhow::Result<(bool, Dispatches)> {
-        if key_event == self.swap_key {
+    fn handle_press(&mut self, key_event: CombinedKeyEvent) -> anyhow::Result<(bool, Dispatches)> {
+        if key_event.translated == self.swap_key {
             std::mem::swap(&mut self.active, &mut self.inactive);
             Ok((
                 false,

--- a/src/keymap_override/momentary_layer/mod.rs
+++ b/src/keymap_override/momentary_layer/mod.rs
@@ -3,7 +3,10 @@ use my_proc_macros::key;
 
 use crate::{
     app::{Dispatch, Dispatches},
-    components::keymap_legend::{KeymapLegendConfig, OnTap, ReleaseKey},
+    components::{
+        editor_keymap::CombinedKeyEvent,
+        keymap_legend::{KeymapLegendConfig, OnTap, ReleaseKey},
+    },
     context::Context,
     keymap_override::{
         momentary_layer::{joint::JointMomentaryLayer, simple::SimpleMomentaryLayer},
@@ -15,7 +18,7 @@ mod joint;
 mod simple;
 
 trait MomentaryLayerBaseTrait {
-    fn handle_press(&mut self, key_event: KeyEvent) -> anyhow::Result<(bool, Dispatches)>;
+    fn handle_press(&mut self, key_event: CombinedKeyEvent) -> anyhow::Result<(bool, Dispatches)>;
     fn tap(&mut self) -> anyhow::Result<Dispatches>;
 }
 
@@ -45,15 +48,12 @@ pub struct MomentaryLayerKeymapOverride {
 impl KeymapOverrideTrait for MomentaryLayerKeymapOverride {
     fn handle_press(
         &mut self,
-        context: &Context,
-        key_event: KeyEvent,
+        _context: &Context,
+        key_event: CombinedKeyEvent,
     ) -> anyhow::Result<Dispatches> {
-        if key_event == key!("esc") {
+        if key_event.original == key!("esc") {
             return Ok(self.close_dispatches());
         }
-        let key_event = context
-            .keyboard_layout()
-            .translate_key_event_to_qwerty(key_event);
         let (key_press, dispatches) = self.base.inner().handle_press(key_event)?;
         self.other_keys_pressed |= key_press;
         Ok(dispatches)
@@ -61,14 +61,10 @@ impl KeymapOverrideTrait for MomentaryLayerKeymapOverride {
 
     fn handle_release(
         &mut self,
-        context: &Context,
-        key_event: KeyEvent,
+        _context: &Context,
+        key_event: CombinedKeyEvent,
     ) -> anyhow::Result<Dispatches> {
-        let key_event = context
-            .keyboard_layout()
-            .translate_key_event_to_qwerty(key_event);
-
-        Ok(if self.release_key == key_event {
+        Ok(if self.release_key == key_event.translated {
             let dispatches = self.close_dispatches();
 
             if !self.other_keys_pressed {

--- a/src/keymap_override/momentary_layer/simple.rs
+++ b/src/keymap_override/momentary_layer/simple.rs
@@ -1,8 +1,9 @@
-use event::KeyEvent;
-
 use crate::{
     app::Dispatches,
-    components::keymap_legend::{Keybinding, KeymapLegendConfig, OnTap},
+    components::{
+        editor_keymap::CombinedKeyEvent,
+        keymap_legend::{Keybinding, KeymapLegendConfig, OnTap},
+    },
     keymap_override::momentary_layer::MomentaryLayerBaseTrait,
 };
 
@@ -13,7 +14,7 @@ pub(super) struct SimpleMomentaryLayer {
 }
 
 impl MomentaryLayerBaseTrait for SimpleMomentaryLayer {
-    fn handle_press(&mut self, key_event: KeyEvent) -> anyhow::Result<(bool, Dispatches)> {
+    fn handle_press(&mut self, key_event: CombinedKeyEvent) -> anyhow::Result<(bool, Dispatches)> {
         Ok(
             match self
                 .config


### PR DESCRIPTION
Instead of translating everything everywhere, which gets very tangly, we can pass around a combined object with both the translated and original event.