### PR TITLE
fix(lsp): send selection range in code action requests

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -4170,6 +4170,7 @@ impl FilePickerKind {
 pub struct RequestParams {
     pub path: AbsolutePath,
     pub position: Position,
+    pub selection_end: Position,
     pub context: ResponseContext,
 }
 impl RequestParams {

--- a/src/components/editor/mod.rs
+++ b/src/components/editor/mod.rs
@@ -1879,9 +1879,15 @@ impl Editor {
 
     pub fn get_request_params(&self) -> Option<RequestParams> {
         let position = self.get_cursor_position().ok()?;
+        let selection_end = self
+            .buffer
+            .borrow()
+            .char_to_position(self.selection_set.primary_selection().extended_range().end)
+            .unwrap_or(position);
         self.path().map(|path| RequestParams {
             path,
             position,
+            selection_end,
             context: ResponseContext {
                 scope: None,
                 description: None,

--- a/src/lsp/process.rs
+++ b/src/lsp/process.rs
@@ -1344,6 +1344,7 @@ impl LspServerProcess {
             path,
             position,
             context,
+            ..
         }: RequestParams,
     ) -> anyhow::Result<()> {
         if !self.has_capability(|c| c.definition_provider.is_some()) {
@@ -1369,6 +1370,7 @@ impl LspServerProcess {
             path,
             position,
             context,
+            ..
         }: RequestParams,
         include_declaration: bool,
     ) -> anyhow::Result<()> {
@@ -1505,7 +1507,7 @@ impl LspServerProcess {
                 partial_result_params: PartialResultParams::default(),
                 range: Range {
                     start: params.position.into(),
-                    end: params.position.into(),
+                    end: params.selection_end.into(),
                 },
                 text_document: path_buf_to_text_document_identifier(params.path)?,
                 work_done_progress_params: WorkDoneProgressParams::default(),

--- a/src/test_app.rs
+++ b/src/test_app.rs
@@ -3018,6 +3018,7 @@ fn request_signature_help() -> anyhow::Result<()> {
                 FromEditor::TextDocumentSignatureHelp(RequestParams {
                     path: s.main_rs(),
                     position: Position::new(0, 3),
+                    selection_end: Position::new(0, 3),
                     context: ResponseContext::default(),
                 }),
             )),
@@ -3026,6 +3027,7 @@ fn request_signature_help() -> anyhow::Result<()> {
                 FromEditor::TextDocumentSignatureHelp(RequestParams {
                     path: s.main_rs(),
                     position: Position::new(0, 2),
+                    selection_end: Position::new(0, 2),
                     context: ResponseContext::default(),
                 }),
             )),


### PR DESCRIPTION
## Summary

- `textDocument/codeAction` was sending a zero-width range (cursor position for both start and end), so LSP servers never saw a selection
- Range-based refactors like "extract into function" require the server to receive the selected range to know they're applicable
- Now `get_request_params` includes the primary selection's `extended_range().end` as `selection_end`, which is used as the range end in code action requests
- When the selection is collapsed, `selection_end == position`, so existing behaviour is unchanged

Fixes #1636

## Test plan

- Open a Rust file in ki with rust-analyzer running
- Select a block of code using ki's selection mode
- Trigger the code action menu
- Verify that "Extract into function" (and similar range-based refactors) now appear in the list

## Proof of Fix

<img width="3580" height="1988" alt="image" src="https://github.com/user-attachments/assets/52669fb7-40b5-488d-9d91-c4549a839ef6" />
