### PR TITLE
feat(keymap): tab and shift+tab indent and dedent in insert mode

### DIFF
--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -1220,10 +1220,11 @@ pub fn insert_mode_keymap_legend_config(include_universal_keymap: bool) -> Keyma
                     "Enter new line",
                     Dispatch::ToEditor(EnterNewline),
                 ),
+                Keybinding::new_undocumented(key!("tab"), "Indent", Dispatch::ToEditor(Indent)),
                 Keybinding::new_undocumented(
-                    key!("tab"),
-                    "Enter tab",
-                    Dispatch::ToEditor(Insert("\t".to_string())),
+                    key!("shift+backtab"),
+                    "Dedent",
+                    Dispatch::ToEditor(Dedent),
                 ),
                 Keybinding::new_undocumented(
                     key!("home"),


### PR DESCRIPTION
This PR rebinds tab and shift+tab to indent and dedent in insert mode, matching the expectation commit from helix and possibly other edits.

Note that due to https://github.com/ki-editor/ki-editor/issues/1638, the behaviour on empty lines when in LINE selection mode is _weird_.