### PR TITLE
Use a fake filename for rubocop

### DIFF
--- a/shared/src/languages.rs
+++ b/shared/src/languages.rs
@@ -1018,7 +1018,7 @@ fn ruby() -> Language {
         file_names: to_vec(&["Gemfile", "Rakefile", "Podfile", "Fastfile", "config.ru"]),
         formatter: Some(Command::new(
             "rubocop",
-            &["--fix-layout", "--stdin", "/dev/null", "--stderr"],
+            &["--fix-layout", "--stdin", "file.rb", "--stderr"],
         )),
         lsp_command: Some(LspCommand {
             command: Command::new("ruby-lsp", &[]),


### PR DESCRIPTION
If passed /dev/null as an input, rubocop ignores the config file