### PR TITLE
fix(lsp/roc): use new formatter command

### DIFF
--- a/shared/src/languages.rs
+++ b/shared/src/languages.rs
@@ -1037,7 +1037,7 @@ fn ruby() -> Language {
 fn roc() -> Language {
     Language {
         extensions: to_vec(&["roc"]),
-        formatter: Some(Command::new("roc", &["format", "--stdin", "--stdout"])),
+        formatter: Some(Command::new("roc", &["fmt", "--stdin"])),
         lsp_command: None,
         lsp_language_id: Some(LanguageId::new("roc")),
         tree_sitter_grammar_config: Some(GrammarConfig {


### PR DESCRIPTION
The Roc language is going through some changes. Among them the invocation of the formatter has changed. This fixes the language configuration to use the new invocation.