### PR TITLE
fix(grammar): store runtime grammars in xdg cache

### DIFF
--- a/grammar/src/lib.rs
+++ b/grammar/src/lib.rs
@@ -28,8 +28,8 @@ pub fn current_working_dir() -> PathBuf {
 fn get_runtime_dir() -> PathBuf {
     use directories::ProjectDirs;
     let project_dirs = ProjectDirs::from("ki", "ki", "ki").unwrap();
-    std::fs::create_dir_all(project_dirs.config_dir()).unwrap();
-    project_dirs.config_dir().into()
+    std::fs::create_dir_all(project_dirs.cache_dir()).unwrap();
+    project_dirs.cache_dir().into()
 }
 
 pub fn runtime_dir() -> &'static PathBuf {


### PR DESCRIPTION
Compiled artifacts like the grammars built by Ki when you do `ki @ grammar build` are currently located in `~/.config/ki/grammars` (`$XDG_CONFIG_HOME`). Since these are not configuration files, but rather non-essential, architecture-specific compiled artifacts, they belong in `$XDG_CACHE_HOME` instead (See the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir/latest/#basics)) to prevent cluttering user configuration.

This PR patches `get_runtime_dir` which is currently only used by grammar-related code.