### PR TITLE
feat(languages/roc) link grammar as crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2355,6 +2355,7 @@ dependencies = [
  "tree-sitter-qmldir",
  "tree-sitter-qmljs",
  "tree-sitter-quickfix",
+ "tree-sitter-roc",
  "tree-sitter-ruby",
  "tree-sitter-rust",
  "tree-sitter-scala",
@@ -3090,6 +3091,15 @@ version = "0.0.1"
 dependencies = [
  "cc",
  "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-roc"
+version = "1.0.0"
+source = "git+https://github.com/faldor20/tree-sitter-roc?rev=68f4054#68f405426d030a7625392aabf41836c1aad05d33"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
 ]
 
 [[package]]

--- a/docs/static/app_config_json_schema.json
+++ b/docs/static/app_config_json_schema.json
@@ -126,7 +126,8 @@
                 "Scala",
                 "Glsl",
                 "Devicetree",
-                "Just"
+                "Just",
+                "Roc"
             ]
         },
         "Command": {

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -72,6 +72,7 @@ tree-sitter-gnuplot = { git = "https://github.com/dpezto/tree-sitter-gnuplot", r
 tree-sitter-qmljs = "0.3.0"
 tree-sitter-qmldir = { git = "https://github.com/tree-sitter-grammars/tree-sitter-qmldir", rev = "1fa9200" }
 tree-sitter-glsl = "0.2.0"
+tree-sitter-roc = { git = "https://github.com/faldor20/tree-sitter-roc", rev = "68f4054" }
 
 [dev-dependencies]
 quickcheck.workspace = true

--- a/shared/src/language.rs
+++ b/shared/src/language.rs
@@ -118,6 +118,7 @@ pub enum CargoLinkedTreesitterLanguage {
     Glsl,
     Devicetree,
     Just,
+    Roc,
 }
 
 impl CargoLinkedTreesitterLanguage {
@@ -182,6 +183,7 @@ impl CargoLinkedTreesitterLanguage {
                 tree_sitter_jjdescription::LANGUAGE.into()
             }
             CargoLinkedTreesitterLanguage::Glsl => tree_sitter_glsl::LANGUAGE_GLSL.into(),
+            CargoLinkedTreesitterLanguage::Roc => tree_sitter_roc::LANGUAGE.into(),
         }
     }
 
@@ -250,6 +252,7 @@ impl CargoLinkedTreesitterLanguage {
                 Some(tree_sitter_jjdescription::HIGHLIGHTS_QUERY)
             }
             CargoLinkedTreesitterLanguage::Glsl => Some(tree_sitter_glsl::HIGHLIGHTS_QUERY),
+            CargoLinkedTreesitterLanguage::Roc => None,
         }
     }
 }

--- a/shared/src/languages.rs
+++ b/shared/src/languages.rs
@@ -1042,11 +1042,7 @@ fn roc() -> Language {
         lsp_language_id: Some(LanguageId::new("roc")),
         tree_sitter_grammar_config: Some(GrammarConfig {
             id: "roc".to_string(),
-            kind: GrammarConfigKind::FromSource {
-                url: "https://github.com/faldor20/tree-sitter-roc".to_string(),
-                commit: "master".to_string(),
-                subpath: None,
-            },
+            kind: GrammarConfigKind::CargoLinked(CargoLinkedTreesitterLanguage::Roc),
         }),
         line_comment_prefix: Some("#".to_string()),
         ..Language::new()


### PR DESCRIPTION
This pulls in the roc tree-sitter grammar as a cargo-linked-source, following a bit of work in upstream (https://github.com/faldor20/tree-sitter-roc/pull/41). No highlight-query yet, this requires some additional work upstream which I'm hoping to look into soon and make another PR for.