### PR TITLE
feat(languages/idris): link grammar as crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "arborium-idris"
+version = "2.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59975ace9d4045a3f73bccd3bc8ab71072655afd89c24c95c50254bc926700a3"
+dependencies = [
+ "arborium-sysroot",
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "arborium-sysroot"
+version = "2.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59d99d80550b726f9dec7ee6d07118c31e08b10e729ac488eabd4c10603dc841"
+dependencies = [
+ "cc",
+ "dlmalloc",
+]
+
+[[package]]
 name = "ast-grep-core"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -563,6 +584,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlmalloc"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad5208a115eaba24916f7456929832e310a81518c641f93fee4f89aa93aa3675"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -642,7 +674,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1435,7 +1467,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.3",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -2073,7 +2105,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2304,6 +2336,7 @@ name = "shared"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arborium-idris",
  "codebook-tree-sitter-latex",
  "etcetera",
  "grammar",

--- a/docs/static/app_config_json_schema.json
+++ b/docs/static/app_config_json_schema.json
@@ -127,7 +127,8 @@
                 "Glsl",
                 "Devicetree",
                 "Just",
-                "Roc"
+                "Roc",
+                "Idris"
             ]
         },
         "Command": {

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -73,6 +73,7 @@ tree-sitter-qmljs = "0.3.0"
 tree-sitter-qmldir = { git = "https://github.com/tree-sitter-grammars/tree-sitter-qmldir", rev = "1fa9200" }
 tree-sitter-glsl = "0.2.0"
 tree-sitter-roc = { git = "https://github.com/faldor20/tree-sitter-roc", rev = "68f4054" }
+arborium-idris = "2.18.1"
 
 [dev-dependencies]
 quickcheck.workspace = true

--- a/shared/src/language.rs
+++ b/shared/src/language.rs
@@ -119,6 +119,7 @@ pub enum CargoLinkedTreesitterLanguage {
     Devicetree,
     Just,
     Roc,
+    Idris,
 }
 
 impl CargoLinkedTreesitterLanguage {
@@ -184,6 +185,7 @@ impl CargoLinkedTreesitterLanguage {
             }
             CargoLinkedTreesitterLanguage::Glsl => tree_sitter_glsl::LANGUAGE_GLSL.into(),
             CargoLinkedTreesitterLanguage::Roc => tree_sitter_roc::LANGUAGE.into(),
+            CargoLinkedTreesitterLanguage::Idris => arborium_idris::language().into(),
         }
     }
 
@@ -253,6 +255,7 @@ impl CargoLinkedTreesitterLanguage {
             }
             CargoLinkedTreesitterLanguage::Glsl => Some(tree_sitter_glsl::HIGHLIGHTS_QUERY),
             CargoLinkedTreesitterLanguage::Roc => None,
+            CargoLinkedTreesitterLanguage::Idris => Some(arborium_idris::HIGHLIGHTS_QUERY),
         }
     }
 }

--- a/shared/src/languages.rs
+++ b/shared/src/languages.rs
@@ -642,11 +642,7 @@ fn idris() -> Language {
         lsp_language_id: Some(LanguageId::new("idris")),
         tree_sitter_grammar_config: Some(GrammarConfig {
             id: "idris".to_string(),
-            kind: GrammarConfigKind::FromSource {
-                url: "https://github.com/kayhide/tree-sitter-idris".to_string(),
-                commit: "main".to_string(),
-                subpath: None,
-            },
+            kind: GrammarConfigKind::CargoLinked(CargoLinkedTreesitterLanguage::Idris),
         }),
         ..Language::new()
     }


### PR DESCRIPTION
## Summary
- Switch Idris's tree-sitter grammar from a `FromSource` git build (`kayhide/tree-sitter-idris`) to the `arborium-idris` crate, linked directly via Cargo like Roc's grammar (#1651).
- Adds `arborium-idris` to `shared/Cargo.toml` and wires it into `CargoLinkedTreesitterLanguage` (language + highlight query).

## Test plan
- [x] Open an `.idr` file in ki-editor and confirm syntax highlighting works and no grammar download/build step occurs.