### PR TITLE
feat(languages): link sql, dockerfile, gitattributes, gitcommit, rescript, typst grammars as crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,10 +106,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "arborium-dockerfile"
+version = "2.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "168968cacf937c51bb8ed785780467547a5158141d2c53c0d8f6fb64a60d86c9"
+dependencies = [
+ "arborium-sysroot",
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "arborium-gitattributes"
+version = "2.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6232795395bf1256555d3d04ac7fb87dd723076983fd27c4a7d0274bf28ea41e"
+dependencies = [
+ "arborium-sysroot",
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "arborium-idris"
 version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59975ace9d4045a3f73bccd3bc8ab71072655afd89c24c95c50254bc926700a3"
+dependencies = [
+ "arborium-sysroot",
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "arborium-rescript"
+version = "2.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f208a704e5197213f623202527f4986be44a8b3ff453eb90b6457bf8a508dcb0"
+dependencies = [
+ "arborium-sysroot",
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "arborium-sql"
+version = "2.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8f790fcca922217312f9e4c03d7423d74e37d4c5eec41a0b774019debd73be8"
 dependencies = [
  "arborium-sysroot",
  "cc",
@@ -124,6 +168,17 @@ checksum = "59d99d80550b726f9dec7ee6d07118c31e08b10e729ac488eabd4c10603dc841"
 dependencies = [
  "cc",
  "dlmalloc",
+]
+
+[[package]]
+name = "arborium-typst"
+version = "2.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f38b5836c08e6ce5432de2d721b4eef7d217961d03d0e6815179fa6fb0d514b"
+dependencies = [
+ "arborium-sysroot",
+ "cc",
+ "tree-sitter-language",
 ]
 
 [[package]]
@@ -591,7 +646,7 @@ checksum = "ad5208a115eaba24916f7456929832e310a81518c641f93fee4f89aa93aa3675"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -674,7 +729,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1467,7 +1522,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -2105,7 +2160,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2336,7 +2391,12 @@ name = "shared"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arborium-dockerfile",
+ "arborium-gitattributes",
  "arborium-idris",
+ "arborium-rescript",
+ "arborium-sql",
+ "arborium-typst",
  "codebook-tree-sitter-latex",
  "etcetera",
  "grammar",
@@ -2362,6 +2422,7 @@ dependencies = [
  "tree-sitter-elixir",
  "tree-sitter-fish",
  "tree-sitter-fsharp",
+ "tree-sitter-gitcommit",
  "tree-sitter-gleam",
  "tree-sitter-glsl",
  "tree-sitter-gnuplot",
@@ -2848,6 +2909,16 @@ name = "tree-sitter-fsharp"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd296b6559884f6c7e78458632337a18b41e19c1c9daa04407ea5b8478372774"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-gitcommit"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b051221607cfde94e2d0132ad99ef50a9f78a990c068380717ea0a4ce61899"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "arborium-idris"
+version = "2.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59975ace9d4045a3f73bccd3bc8ab71072655afd89c24c95c50254bc926700a3"
+dependencies = [
+ "arborium-sysroot",
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "arborium-sysroot"
+version = "2.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59d99d80550b726f9dec7ee6d07118c31e08b10e729ac488eabd4c10603dc841"
+dependencies = [
+ "cc",
+ "dlmalloc",
+]
+
+[[package]]
 name = "ast-grep-core"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -563,6 +584,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlmalloc"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad5208a115eaba24916f7456929832e310a81518c641f93fee4f89aa93aa3675"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -642,7 +674,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1435,7 +1467,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.3",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -2073,7 +2105,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2304,6 +2336,7 @@ name = "shared"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arborium-idris",
  "codebook-tree-sitter-latex",
  "etcetera",
  "grammar",

--- a/docs/static/app_config_json_schema.json
+++ b/docs/static/app_config_json_schema.json
@@ -128,7 +128,13 @@
                 "Devicetree",
                 "Just",
                 "Roc",
-                "Idris"
+                "Idris",
+                "Sql",
+                "Dockerfile",
+                "Gitattributes",
+                "Gitcommit",
+                "Rescript",
+                "Typst"
             ]
         },
         "Command": {

--- a/docs/static/app_config_json_schema.json
+++ b/docs/static/app_config_json_schema.json
@@ -127,7 +127,8 @@
                 "Glsl",
                 "Devicetree",
                 "Just",
-                "Roc"
+                "Roc",
+                "Idris"
             ]
         },
         "Command": {

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -74,6 +74,12 @@ tree-sitter-qmldir = { git = "https://github.com/tree-sitter-grammars/tree-sitte
 tree-sitter-glsl = "0.2.0"
 tree-sitter-roc = { git = "https://github.com/faldor20/tree-sitter-roc", rev = "68f4054" }
 arborium-idris = "2.18.1"
+arborium-sql = "2.18.1"
+arborium-dockerfile = "2.18.1"
+arborium-gitattributes = "2.18.1"
+arborium-rescript = "2.18.1"
+arborium-typst = "2.18.1"
+tree-sitter-gitcommit = "0.5.0"
 
 [dev-dependencies]
 quickcheck.workspace = true

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -73,6 +73,7 @@ tree-sitter-qmljs = "0.3.0"
 tree-sitter-qmldir = { git = "https://github.com/tree-sitter-grammars/tree-sitter-qmldir", rev = "1fa9200" }
 tree-sitter-glsl = "0.2.0"
 tree-sitter-roc = { git = "https://github.com/faldor20/tree-sitter-roc", rev = "68f4054" }
+arborium-idris = "2.18.1"
 
 [dev-dependencies]
 quickcheck.workspace = true

--- a/shared/src/language.rs
+++ b/shared/src/language.rs
@@ -120,6 +120,12 @@ pub enum CargoLinkedTreesitterLanguage {
     Just,
     Roc,
     Idris,
+    Sql,
+    Dockerfile,
+    Gitattributes,
+    Gitcommit,
+    Rescript,
+    Typst,
 }
 
 impl CargoLinkedTreesitterLanguage {
@@ -186,6 +192,14 @@ impl CargoLinkedTreesitterLanguage {
             CargoLinkedTreesitterLanguage::Glsl => tree_sitter_glsl::LANGUAGE_GLSL.into(),
             CargoLinkedTreesitterLanguage::Roc => tree_sitter_roc::LANGUAGE.into(),
             CargoLinkedTreesitterLanguage::Idris => arborium_idris::language().into(),
+            CargoLinkedTreesitterLanguage::Sql => arborium_sql::language().into(),
+            CargoLinkedTreesitterLanguage::Dockerfile => arborium_dockerfile::language().into(),
+            CargoLinkedTreesitterLanguage::Gitattributes => {
+                arborium_gitattributes::language().into()
+            }
+            CargoLinkedTreesitterLanguage::Gitcommit => tree_sitter_gitcommit::LANGUAGE.into(),
+            CargoLinkedTreesitterLanguage::Rescript => arborium_rescript::language().into(),
+            CargoLinkedTreesitterLanguage::Typst => arborium_typst::language().into(),
         }
     }
 
@@ -256,6 +270,18 @@ impl CargoLinkedTreesitterLanguage {
             CargoLinkedTreesitterLanguage::Glsl => Some(tree_sitter_glsl::HIGHLIGHTS_QUERY),
             CargoLinkedTreesitterLanguage::Roc => None,
             CargoLinkedTreesitterLanguage::Idris => Some(arborium_idris::HIGHLIGHTS_QUERY),
+            CargoLinkedTreesitterLanguage::Sql => Some(arborium_sql::HIGHLIGHTS_QUERY),
+            CargoLinkedTreesitterLanguage::Dockerfile => {
+                Some(arborium_dockerfile::HIGHLIGHTS_QUERY)
+            }
+            CargoLinkedTreesitterLanguage::Gitattributes => {
+                Some(arborium_gitattributes::HIGHLIGHTS_QUERY)
+            }
+            CargoLinkedTreesitterLanguage::Gitcommit => {
+                Some(tree_sitter_gitcommit::HIGHLIGHTS_QUERY)
+            }
+            CargoLinkedTreesitterLanguage::Rescript => Some(arborium_rescript::HIGHLIGHTS_QUERY),
+            CargoLinkedTreesitterLanguage::Typst => Some(arborium_typst::HIGHLIGHTS_QUERY),
         }
     }
 }

--- a/shared/src/language.rs
+++ b/shared/src/language.rs
@@ -119,6 +119,7 @@ pub enum CargoLinkedTreesitterLanguage {
     Devicetree,
     Just,
     Roc,
+    Idris,
 }
 
 impl CargoLinkedTreesitterLanguage {
@@ -184,6 +185,7 @@ impl CargoLinkedTreesitterLanguage {
             }
             CargoLinkedTreesitterLanguage::Glsl => tree_sitter_glsl::LANGUAGE_GLSL.into(),
             CargoLinkedTreesitterLanguage::Roc => tree_sitter_roc::LANGUAGE.into(),
+            CargoLinkedTreesitterLanguage::Idris => arborium_idris::language().into(),
         }
     }
 
@@ -253,6 +255,7 @@ impl CargoLinkedTreesitterLanguage {
             }
             CargoLinkedTreesitterLanguage::Glsl => Some(tree_sitter_glsl::HIGHLIGHTS_QUERY),
             CargoLinkedTreesitterLanguage::Roc => None,
+            CargoLinkedTreesitterLanguage::Idris => Some(arborium_idris::HIGHLIGHTS_QUERY),
         }
     }
 }

--- a/shared/src/languages.rs
+++ b/shared/src/languages.rs
@@ -642,11 +642,7 @@ fn idris() -> Language {
         lsp_language_id: Some(LanguageId::new("idris")),
         tree_sitter_grammar_config: Some(GrammarConfig {
             id: "idris".to_string(),
-            kind: GrammarConfigKind::FromSource {
-                url: "https://github.com/kayhide/tree-sitter-idris".to_string(),
-                commit: "main".to_string(),
-                subpath: None,
-            },
+            kind: GrammarConfigKind::CargoLinked(CargoLinkedTreesitterLanguage::Idris),
         }),
         ..Language::new()
     }

--- a/shared/src/languages.rs
+++ b/shared/src/languages.rs
@@ -333,11 +333,7 @@ fn dockerfile() -> Language {
         file_names: to_vec(&["Dockerfile"]),
         tree_sitter_grammar_config: Some(GrammarConfig {
             id: "dockerfile".to_string(),
-            kind: GrammarConfigKind::FromSource {
-                url: "https://github.com/camdencheek/tree-sitter-dockerfile".to_string(),
-                commit: "main".to_string(),
-                subpath: None,
-            },
+            kind: GrammarConfigKind::CargoLinked(CargoLinkedTreesitterLanguage::Dockerfile),
         }),
         line_comment_prefix: Some("#".to_string()),
         ..Language::new()
@@ -389,12 +385,7 @@ fn gitattributes() -> Language {
         file_names: to_vec(&[".gitattributes"]),
         tree_sitter_grammar_config: Some(GrammarConfig {
             id: "gitattributes".to_string(),
-            kind: GrammarConfigKind::FromSource {
-                url: "https://github.com/tree-sitter-grammars/tree-sitter-gitattributes"
-                    .to_string(),
-                commit: "master".to_string(),
-                subpath: None,
-            },
+            kind: GrammarConfigKind::CargoLinked(CargoLinkedTreesitterLanguage::Gitattributes),
         }),
         line_comment_prefix: Some("#".to_string()),
         ..Language::new()
@@ -406,11 +397,7 @@ fn gitcommit() -> Language {
         file_names: to_vec(&["COMMIT_EDITMSG"]),
         tree_sitter_grammar_config: Some(GrammarConfig {
             id: "gitcommit".to_string(),
-            kind: GrammarConfigKind::FromSource {
-                url: "https://github.com/gbprod/tree-sitter-gitcommit".to_string(),
-                commit: "main".to_string(),
-                subpath: None,
-            },
+            kind: GrammarConfigKind::CargoLinked(CargoLinkedTreesitterLanguage::Gitcommit),
         }),
         line_comment_prefix: Some("#".to_string()),
         ..Language::new()
@@ -996,11 +983,7 @@ fn rescript() -> Language {
         lsp_language_id: Some(LanguageId::new("rescript")),
         tree_sitter_grammar_config: Some(GrammarConfig {
             id: "rescript".to_string(),
-            kind: GrammarConfigKind::FromSource {
-                url: "https://github.com/rescript-lang/tree-sitter-rescript".to_string(),
-                commit: "main".to_string(),
-                subpath: None,
-            },
+            kind: GrammarConfigKind::CargoLinked(CargoLinkedTreesitterLanguage::Rescript),
         }),
         line_comment_prefix: Some("//".to_string()),
         block_comment_affixes: Some(("/*".to_string(), "*/".to_string())),
@@ -1070,11 +1053,7 @@ fn sql() -> Language {
         formatter: Some(Command::new("sql-formatter", &["--language", "postgresql"])),
         tree_sitter_grammar_config: Some(GrammarConfig {
             id: "sql".to_string(),
-            kind: GrammarConfigKind::FromSource {
-                url: "https://github.com/DerekStride/tree-sitter-sql".to_string(),
-                commit: "25f94f998de79bae9df28add9782f9ea6ea0e2b8".to_string(),
-                subpath: None,
-            },
+            kind: GrammarConfigKind::CargoLinked(CargoLinkedTreesitterLanguage::Sql),
         }),
         line_comment_prefix: Some("--".to_string()),
         block_comment_affixes: Some(("/*".to_string(), "*/".to_string())),
@@ -1112,11 +1091,7 @@ fn typst() -> Language {
         lsp_language_id: Some(LanguageId::new("typst")),
         tree_sitter_grammar_config: Some(GrammarConfig {
             id: "typst".to_string(),
-            kind: GrammarConfigKind::FromSource {
-                url: "https://github.com/uben0/tree-sitter-typst".to_string(),
-                commit: "master".to_string(),
-                subpath: None,
-            },
+            kind: GrammarConfigKind::CargoLinked(CargoLinkedTreesitterLanguage::Typst),
         }),
         block_comment_affixes: Some(("/*".to_string(), "*/".to_string())),
         ..Language::new()


### PR DESCRIPTION
## Summary
- Switches `sql`, `dockerfile`, `gitattributes`, `gitcommit`, `rescript`, and `typst` from `GrammarConfigKind::FromSource` (git clone + build at grammar-build time) to `GrammarConfigKind::CargoLinked` (vendored as regular Cargo dependencies), mirroring the Idris/Roc change (#1654, #1651).
- `sql`, `dockerfile`, `gitattributes`, `rescript`, `typst` use `arborium-*` crates (bearcove/arborium family). `gitcommit` uses `tree-sitter-gitcommit` directly, which is the same upstream (`gbprod/tree-sitter-gitcommit`) already pinned.
- `csv`, `hare`, `tsq`, `gitconfig`, `gitignore`, `gitrebase`, and `unison` are intentionally left on `FromSource`: the only published crates for csv/hare/tsq pin `tree-sitter ~0.19`/`~0.20`, which is incompatible with this workspace's `tree-sitter 0.25.6`; no crate at all exists for gitconfig/gitignore/gitrebase/unison.

## Risk
`dockerfile`, `gitattributes`, `rescript`, and `typst` now come from a different upstream grammar repo (bearcove/arborium) than what was previously pinned, so highlighting output may differ slightly (different query file, possibly different coverage). This is the same tradeoff already accepted for the Idris and Roc switches.

## Test plan
- Open a `.sql`, `Dockerfile`, `.gitattributes`, `COMMIT_EDITMSG`, `.res`, and `.typ` file in ki-editor and confirm syntax highlighting still renders reasonably (exact token colors may shift slightly given the different upstream grammars for dockerfile/gitattributes/rescript/typst).

🤖 Generated with [Claude Code](https://claude.com/claude-code)