### PR TITLE
chore: remove unused pub functions (fixes #1650)

### DIFF
--- a/shared/src/formatter.rs
+++ b/shared/src/formatter.rs
@@ -15,9 +15,6 @@ impl From<ProcessCommand> for Formatter {
 }
 
 impl Formatter {
-    pub fn command_string(&self) -> String {
-        self.process_command.to_string()
-    }
     pub fn format(&self, content: &str) -> anyhow::Result<String> {
         // Run the command with the args,
         // pass in the content using stdin,

--- a/shared/src/language.rs
+++ b/shared/src/language.rs
@@ -326,13 +326,6 @@ impl Language {
     pub fn block_comment_affixes(&self) -> Option<(String, String)> {
         self.block_comment_affixes.clone()
     }
-
-    pub fn lsp_environment(&self) -> HashMap<String, String> {
-        self.lsp_command
-            .as_ref()
-            .map(|c| c.environment.clone())
-            .unwrap_or_default()
-    }
 }
 
 impl Default for Language {

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -323,25 +323,6 @@ impl Buffer {
         (rope, tree)
     }
 
-    pub fn given_range_is_node(&self, range: &CharIndexRange) -> bool {
-        let Some(start) = self.char_to_byte(range.start).ok() else {
-            return false;
-        };
-        let Some(end) = self.char_to_byte(range.end).ok() else {
-            return false;
-        };
-        let byte_range = start..end;
-        self.tree
-            .as_ref()
-            .map(|tree| {
-                tree.root_node()
-                    .descendant_for_byte_range(byte_range.start, byte_range.end)
-                    .map(|node| node.byte_range() == byte_range)
-                    .unwrap_or(false)
-            })
-            .unwrap_or(false)
-    }
-
     pub fn update_highlighted_spans(
         &mut self,
         batch_id: SyntaxHighlightRequestBatchId,

--- a/src/components/editor/mod.rs
+++ b/src/components/editor/mod.rs
@@ -534,13 +534,6 @@ impl Direction {
         Direction::Start
     }
 
-    pub fn format_action(&self, action: &str) -> String {
-        match self {
-            Direction::Start => format!("← {action}"),
-            Direction::End => format!("{action} →"),
-        }
-    }
-
     pub fn to_if_current_not_found(&self) -> IfCurrentNotFound {
         match self {
             Direction::Start => IfCurrentNotFound::LookBackward,

--- a/src/components/editor_keymap.rs
+++ b/src/components/editor_keymap.rs
@@ -212,20 +212,6 @@ impl KeyboardLayout {
             .unwrap_or(char_to_translate)
     }
 
-    pub fn translate_char_from_qwerty(&self, qwerty_char: char) -> char {
-        let zipped_chars = || {
-            self.get_keyboard_layout()
-                .iter()
-                .flatten()
-                .zip(QWERTY.iter().flatten())
-                .map(|(char, qwerty)| (*char, *qwerty))
-        };
-        zipped_chars()
-            .chain(zipped_chars().map(|(this, qwerty)| (shifted_char(this), shifted_char(qwerty))))
-            .find_map(|(this, qwerty)| (qwerty == qwerty_char).then_some(this))
-            .unwrap_or(qwerty_char)
-    }
-
     pub fn make_combined_key_event(&self, event: KeyEvent) -> CombinedKeyEvent {
         let qwerty = match event.code {
             KeyCode::Char(pressed_char) => {


### PR DESCRIPTION
## Summary
- Fixes #1650 by removing the flagged `pub` functions that have zero call sites anywhere in the workspace: `Formatter::command_string`, `Language::lsp_environment`, `Buffer::given_range_is_node`, `Direction::format_action`, and `KeyboardLayout::translate_char_from_qwerty`.
- Two items from the same report were intentionally left untouched: `Editor::set_cursor_position` already carries `#[allow(dead_code)]` with a TODO for a future mouse-click feature, and `doc_assets_generate_recipes` is itself a `#[test]` function, so it being "unused" is a false positive of the unused-pub check.

## Test plan
- [ ] `cargo build --workspace` compiles with no new warnings
- [ ] `cargo clippy --workspace --all-targets` is clean