### PR TITLE
fix(config): include the source file path in lenient-parse error messages

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -463,6 +463,7 @@ mod test_config {
         std::env::set_current_dir(original_dir).unwrap();
 
         assert_eq!(config.load_errors().len(), 1);
+        assert!(config.load_errors()[0].contains(".ki/config.json"));
         assert_eq!(
             config.indent_width(),
             super::AppConfig::default().indent_width()
@@ -493,6 +494,10 @@ mod test_config {
             super::AppConfig::default().indent_width()
         );
         assert!(!config.languages().is_empty());
+        assert!(config
+            .load_errors()
+            .iter()
+            .all(|error| error.contains(".ki/config.json")));
     }
 
     /// A malformed field *within* a language override (e.g. `formatter`)
@@ -517,6 +522,7 @@ mod test_config {
 
         assert_eq!(config.load_errors().len(), 1);
         assert!(config.load_errors()[0].contains("languages.javascript.formatter.arguments"));
+        assert!(config.load_errors()[0].contains(".ki/config.json"));
 
         let javascript = config.languages().get("javascript").unwrap();
         // `line_comment_prefix` was valid and should still be applied...
@@ -549,6 +555,7 @@ mod test_config {
 
         assert_eq!(config.load_errors().len(), 1);
         assert!(config.load_errors()[0].contains("status_lines.1"));
+        assert!(config.load_errors()[0].contains(".ki/config.json"));
         assert_eq!(config.status_lines().len(), 1);
     }
 
@@ -573,6 +580,7 @@ mod test_config {
 
         assert_eq!(config.load_errors().len(), 1);
         assert!(config.load_errors()[0].contains("leader_keymap.0.0"));
+        assert!(config.load_errors()[0].contains(".ki/config.json"));
         assert!(config.leader_keymap().keybindings()[0][0].is_none());
     }
 
@@ -595,5 +603,6 @@ mod test_config {
 
         assert_eq!(config.load_errors().len(), 1);
         assert!(config.load_errors()[0].contains("custom_keyboard_layouts.bad"));
+        assert!(config.load_errors()[0].contains(".ki/config.json"));
     }
 }

--- a/src/config/lenient.rs
+++ b/src/config/lenient.rs
@@ -47,12 +47,12 @@ pub(super) fn extract_lenient(figment: &figment::Figment) -> Extracted<RawConfig
         ($field:ident, $key:literal) => {
             match figment.find_value($key) {
                 Ok(value) => match serde_path_to_error::deserialize(&value) {
-                    Ok(value) => (value, None),
+                    Ok(deserialized) => (deserialized, None),
                     Err(error) => (
                         default.$field,
                         Some(format!(
                             "{}, using default value",
-                            describe_path_error($key, error)
+                            describe_path_error(figment, value.tag(), $key, error)
                         )),
                     ),
                 },
@@ -115,18 +115,40 @@ pub(super) fn extract_lenient(figment: &figment::Figment) -> Extracted<RawConfig
     (config, errors).into()
 }
 
+/// Ki merges config from up to 6 possible files (global/workspace ×
+/// json/yaml/toml), so a per-field error message alone doesn't say which
+/// file the bad value came from. This resolves the `Tag` of the offending
+/// value back to its source file via figment's metadata, formatted as a
+/// suffix like " (in .ki/config.json)".
+fn location_suffix(figment: &figment::Figment, tag: figment::value::Tag) -> String {
+    figment
+        .get_metadata(tag)
+        .and_then(|metadata| metadata.source.as_ref())
+        .map(|source| format!(" (in {source})"))
+        .unwrap_or_default()
+}
+
 /// Formats a `serde_path_to_error` error as a fully-qualified, dotted config
 /// path (e.g. "`languages.javascript.formatter.arguments`: invalid type: ...")
 /// instead of just the leaf error message, so the user knows exactly which
 /// value in the config file is wrong.
-fn describe_path_error(prefix: &str, error: serde_path_to_error::Error<figment::Error>) -> String {
+fn describe_path_error(
+    figment: &figment::Figment,
+    tag: figment::value::Tag,
+    prefix: &str,
+    error: serde_path_to_error::Error<figment::Error>,
+) -> String {
     let path = error.path().to_string();
     let full_path = if path == "." {
         prefix.to_string()
     } else {
         format!("{prefix}.{path}")
     };
-    format!("`{full_path}` {}", error.into_inner())
+    format!(
+        "`{full_path}` {}{}",
+        error.into_inner(),
+        location_suffix(figment, tag)
+    )
 }
 
 /// Parses the `languages` map entry-by-entry, and within each entry,
@@ -141,12 +163,14 @@ fn extract_languages(figment: &figment::Figment) -> Extracted<HashMap<String, La
                 dict.into_iter().fold(
                     (languages, Vec::new()),
                     |(mut languages, mut errors), (name, entry)| {
+                        let entry_tag = entry.tag();
                         match serde_path_to_error::deserialize::<_, serde_json::Value>(&entry) {
                             Ok(entry_json) => {
                                 let default_language =
                                     languages.get(&name).cloned().unwrap_or_default();
                                 let (language, field_errors) =
                                     Language::extract_lenient(&entry_json, &default_language);
+                                let location = location_suffix(figment, entry_tag);
                                 errors.extend(field_errors.into_iter().map(
                                     |(field_path, message)| {
                                         let full_path = if field_path.is_empty() {
@@ -154,7 +178,9 @@ fn extract_languages(figment: &figment::Figment) -> Extracted<HashMap<String, La
                                         } else {
                                             format!("languages.{name}.{field_path}")
                                         };
-                                        format!("`{full_path}` {message}, using default value")
+                                        format!(
+                                            "`{full_path}` {message}, using default value{location}"
+                                        )
                                     },
                                 ));
                                 languages.insert(name, language);
@@ -162,7 +188,12 @@ fn extract_languages(figment: &figment::Figment) -> Extracted<HashMap<String, La
                             Err(error) => {
                                 errors.push(format!(
                                     "{}, ignoring language `{name}`",
-                                    describe_path_error(&format!("languages.{name}"), error)
+                                    describe_path_error(
+                                        figment,
+                                        entry_tag,
+                                        &format!("languages.{name}"),
+                                        error
+                                    )
                                 ));
                             }
                         }
@@ -196,6 +227,7 @@ fn extract_custom_keyboard_layouts(
                 dict.into_iter().fold(
                     (HashMap::new(), Vec::new()),
                     |(mut layouts, mut errors), (name, entry)| {
+                        let entry_tag = entry.tag();
                         match serde_path_to_error::deserialize(&entry) {
                             Ok(keys) => {
                                 layouts.insert(name, keys);
@@ -204,6 +236,8 @@ fn extract_custom_keyboard_layouts(
                                 errors.push(format!(
                                     "{}, ignoring custom keyboard layout `{name}`",
                                     describe_path_error(
+                                        figment,
+                                        entry_tag,
                                         &format!("custom_keyboard_layouts.{name}"),
                                         error
                                     )
@@ -239,18 +273,24 @@ fn extract_status_lines(
                 let (status_lines, errors): (Vec<_>, Vec<_>) = array
                     .into_iter()
                     .enumerate()
-                    .map(
-                        |(index, entry)| match serde_path_to_error::deserialize(&entry) {
+                    .map(|(index, entry)| {
+                        let entry_tag = entry.tag();
+                        match serde_path_to_error::deserialize(&entry) {
                             Ok(status_line) => (Some(status_line), None),
                             Err(error) => (
                                 None,
                                 Some(format!(
                                     "{}, ignoring this status line",
-                                    describe_path_error(&format!("status_lines.{index}"), error)
+                                    describe_path_error(
+                                        figment,
+                                        entry_tag,
+                                        &format!("status_lines.{index}"),
+                                        error
+                                    )
                                 )),
                             ),
-                        },
-                    )
+                        }
+                    })
                     .unzip();
                 (
                     status_lines.into_iter().flatten().collect(),
@@ -296,12 +336,15 @@ fn extract_leader_keymap(
                         return (grid, errors);
                     };
                     for (col_index, cell) in cells.into_iter().enumerate().take(10) {
+                        let cell_tag = cell.tag();
                         match serde_path_to_error::deserialize(&cell) {
                             Ok(keybinding) => grid[row_index][col_index] = keybinding,
                             Err(error) => {
                                 errors.push(format!(
                                     "{}, clearing this keybinding",
                                     describe_path_error(
+                                        figment,
+                                        cell_tag,
                                         &format!("leader_keymap.{row_index}.{col_index}"),
                                         error
                                     )


### PR DESCRIPTION
## Summary
- Ki merges config from up to 6 possible files (global/workspace x json/yaml/toml), so a per-field lenient-parse error message alone didn't say which file the bad value actually came from.
- Each malformed value's `figment::value::Tag` is now resolved back to its `Metadata::source` and appended to the error message, e.g. `` `indent_width` invalid type: ..., using default value (in .ki/config.json) ``.
- Line numbers are not included: figment discards source spans when merging into its generic `Value` tree, and recovering them would require bypassing that abstraction — left as a possible future follow-up.

## Test plan
- [ ] Create a workspace with a malformed `.ki/config.json` (e.g. `{"indent_width": "two"}`) and confirm the startup warning includes `(in .ki/config.json)`.
- [ ] With both `.ki/config.json` and `.ki/config.toml` present, put the bad value in only one of them and confirm the reported path matches the file that actually contains it, not whichever file was merged last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)