### PR TITLE
Publish release channels from a dedicated branch

### DIFF
--- a/.github/scripts/sync-release-channels.sh
+++ b/.github/scripts/sync-release-channels.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo="${GITHUB_REPOSITORY:?}"
+fast="${FAST:-true}"
+expected_version="${EXPECTED_VERSION:-}"
+snapshot_keep="${SNAPSHOT_KEEP:-14}"
+stage="$RUNNER_TEMP/release-channels"
+
+rm -rf "$stage"
+mkdir -p "$stage"
+
+effective_fast="$fast"
+if git -C source fetch origin channels --depth=1 >/dev/null 2>&1 \
+  && git -C source show FETCH_HEAD:releases.jsonl \
+    > "$stage/existing-releases.jsonl" 2>/dev/null; then
+  :
+else
+  : > "$stage/existing-releases.jsonl"
+  effective_fast=false
+fi
+
+normalize_releases() {
+  jq -c '
+    .[]
+    | select(.draft == false)
+    | if (.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+$")) then
+        {
+          version: .tag_name,
+          channel: "stable",
+          created_at: .created_at,
+          commit_id: .target_commitish
+        }
+      elif (.tag_name | test("^snapshot-[0-9]{8}-[0-9]{4}-[0-9a-f]{12}$")) then
+        {
+          version: .tag_name,
+          channel: "snapshot",
+          created_at: .created_at,
+          commit_id: .target_commitish
+        }
+      else
+        empty
+      end
+  '
+}
+
+query_releases() {
+  if [ "$effective_fast" = "true" ]; then
+    gh api "repos/$repo/releases?per_page=100" | normalize_releases
+  else
+    gh api --paginate --slurp "repos/$repo/releases?per_page=100" \
+      | jq -c '.[][]' \
+      | jq -cs '.' \
+      | normalize_releases
+  fi
+}
+
+attempt=1
+while :; do
+  query_releases > "$stage/api-releases.jsonl"
+
+  if [ -z "$expected_version" ] \
+    || jq -e --arg version "$expected_version" \
+      'select(.version == $version)' "$stage/api-releases.jsonl" >/dev/null; then
+    break
+  fi
+
+  if [ "$attempt" -ge 5 ]; then
+    echo "Published release is not visible through the API: $expected_version" >&2
+    exit 1
+  fi
+
+  sleep "$((attempt * 2))"
+  attempt="$((attempt + 1))"
+done
+
+if [ "$effective_fast" = "true" ]; then
+  jq -cs '
+    reduce .[] as $release ({}; .[$release.version] = $release)
+    | [.[]]
+    | sort_by([.created_at, .version])
+    | reverse
+    | .[]
+  ' "$stage/existing-releases.jsonl" "$stage/api-releases.jsonl" \
+    > "$stage/merged-releases.jsonl"
+else
+  cp "$stage/api-releases.jsonl" "$stage/merged-releases.jsonl"
+fi
+
+jq -cs '
+  sort_by([.created_at, .version])
+  | reverse
+  | .[]
+' "$stage/merged-releases.jsonl" > "$stage/sorted-releases.jsonl"
+mv "$stage/sorted-releases.jsonl" "$stage/merged-releases.jsonl"
+
+jq -cs --argjson snapshot_keep "$snapshot_keep" '
+  [ .[] | select(.channel == "stable") ],
+  ([ .[] | select(.channel == "snapshot") ] | .[:$snapshot_keep])
+  | .[]
+' "$stage/merged-releases.jsonl" > "$stage/retained-releases.jsonl"
+
+jq -rcs --argjson snapshot_keep "$snapshot_keep" '
+  [ .[] | select(.channel == "snapshot") ][ $snapshot_keep: ]
+  | .[].version
+' "$stage/merged-releases.jsonl" > "$stage/releases-to-delete.txt"
+
+while IFS= read -r version; do
+  if lookup_error="$(gh release view "$version" --repo "$repo" 2>&1 >/dev/null)"; then
+    gh release delete "$version" --repo "$repo" --cleanup-tag --yes
+  elif printf '%s\n' "$lookup_error" | grep -Eq 'HTTP 404|release not found'; then
+    echo "Release already absent: $version"
+  else
+    printf '%s\n' "$lookup_error" >&2
+    exit 1
+  fi
+done < "$stage/releases-to-delete.txt"
+
+if git -C source ls-remote --exit-code --heads origin channels >/dev/null 2>&1; then
+  git -C source fetch origin channels
+  git -C source switch -C channels origin/channels
+else
+  git -C source switch --orphan channels
+  git -C source rm -rf . >/dev/null 2>&1 || true
+fi
+
+cp "$stage/retained-releases.jsonl" source/releases.jsonl
+
+for channel in stable snapshot; do
+  mkdir -p "source/$channel"
+  jq -r --arg channel "$channel" \
+    'select(.channel == $channel) | .version' \
+    source/releases.jsonl > "source/$channel/versions.txt"
+
+  if [ -s "source/$channel/versions.txt" ]; then
+    head -n 1 "source/$channel/versions.txt" > "source/$channel/latest.txt"
+  else
+    rm -f "source/$channel/latest.txt"
+  fi
+done
+
+if [ -z "$(git -C source status --porcelain -- releases.jsonl stable snapshot)" ]; then
+  exit 0
+fi
+
+git -C source config user.name github-actions[bot]
+git -C source config user.email github-actions[bot]@users.noreply.github.com
+git -C source add releases.jsonl stable snapshot
+git -C source commit -m "Sync release channel metadata"
+git -C source push origin HEAD:channels

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,11 +23,8 @@ on:
           - 'false'
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: release
   cancel-in-progress: false
-
-env:
-  SNAPSHOT_KEEP: 14
 
 jobs:
   prepare:
@@ -67,11 +64,10 @@ jobs:
       - name: Determine release version
         id: release
         run: |
-          load_snapshot_versions() {
-            gh api \
-              "repos/${GITHUB_REPOSITORY}/contents/channels/snapshot-versions.txt?ref=gh-pages" \
-              --jq '.content' 2>/dev/null \
-              | base64 -d 2>/dev/null || true
+          load_snapshot_commits() {
+            git fetch origin channels --depth=1 >/dev/null 2>&1 || return 0
+            git show FETCH_HEAD:releases.jsonl 2>/dev/null |
+              jq -r 'select(.channel == "snapshot") | .commit_id' || true
           }
 
           if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
@@ -84,9 +80,9 @@ jobs:
             echo "sha=$sha" >> "$GITHUB_OUTPUT"
 
             if [ "$dedupe" = "true" ]; then
-              snapshot_versions="$(load_snapshot_versions)"
+              snapshot_commits="$(load_snapshot_commits)"
 
-              if printf '%s\n' "$snapshot_versions" | grep -q -- "-${short_sha}$"; then
+              if printf '%s\n' "$snapshot_commits" | grep -qxF "$sha"; then
                 echo "skip=true" >> "$GITHUB_OUTPUT"
                 echo "version=" >> "$GITHUB_OUTPUT"
               else
@@ -100,13 +96,13 @@ jobs:
           elif [ "${GITHUB_EVENT_NAME}" = "schedule" ]; then
             sha="$(git rev-parse HEAD)"
             short_sha="${sha::12}"
-            snapshot_versions="$(load_snapshot_versions)"
+            snapshot_commits="$(load_snapshot_commits)"
 
             echo "kind=snapshot" >> "$GITHUB_OUTPUT"
             echo "ref=$sha" >> "$GITHUB_OUTPUT"
             echo "sha=$sha" >> "$GITHUB_OUTPUT"
 
-            if printf '%s\n' "$snapshot_versions" | grep -q -- "-${short_sha}$"; then
+            if printf '%s\n' "$snapshot_commits" | grep -qxF "$sha"; then
               echo "skip=true" >> "$GITHUB_OUTPUT"
               echo "version=" >> "$GITHUB_OUTPUT"
             else
@@ -144,98 +140,74 @@ jobs:
       - uses: actions/download-artifact@v7
       - name: Publish release
         run: |
-          release_flags=
-          if [ "${{ needs.prepare.outputs.kind }}" = "snapshot" ]; then
-            release_flags=--prerelease
-          fi
-
-          gh release create "${{ needs.prepare.outputs.version }}" \
-            --target "${{ needs.prepare.outputs.sha }}" \
-            --title "${{ needs.prepare.outputs.version }}" \
-            $release_flags \
-            ki-linux-x64/ki-linux-x64.tar.gz \
-            ki-linux-arm64/ki-linux-arm64.tar.gz \
-            ki-windows-x64/ki-windows-x64.zip \
-            ki-windows-arm64/ki-windows-arm64.zip \
-            ki-macos-x64/ki-macos-x64.tar.gz \
-            ki-macos-arm64/ki-macos-arm64.tar.gz
-
-  channels:
-    if: needs.prepare.outputs.skip != 'true'
-    needs: [prepare, publish]
-    runs-on: ubuntu-latest
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout gh-pages
-        uses: actions/checkout@v6
-        with:
-          ref: gh-pages
-          path: gh-pages
-
-      - name: Update channel metadata
-        working-directory: gh-pages
-        run: |
           set -eu
 
           version="${{ needs.prepare.outputs.version }}"
-          kind="${{ needs.prepare.outputs.kind }}"
+          expected_sha="${{ needs.prepare.outputs.sha }}"
+          release_info="$(
+            gh release view "$version" \
+              --json isDraft,targetCommitish \
+              --jq '[.isDraft, .targetCommitish] | @tsv' 2>/dev/null || true
+          )"
+          release_exists=false
 
-          mkdir -p channels
+          if [ -n "$release_info" ]; then
+            IFS=$'\t' read -r is_draft existing_target <<< "$release_info"
 
-          if [ "$kind" = "stable" ]; then
-            printf '%s\n' "$version" > channels/stable-latest.txt
-            touch channels/stable-versions.txt
-            grep -qxF "$version" channels/stable-versions.txt || printf '%s\n' "$version" >> channels/stable-versions.txt
-          else
-            printf '%s\n' "$version" > channels/snapshot-latest.txt
-            touch channels/snapshot-versions.txt
-            { printf '%s\n' "$version"; grep -vxF "$version" channels/snapshot-versions.txt || true; } \
-              | head -n "$SNAPSHOT_KEEP" > channels/snapshot-versions.txt.tmp
-            mv channels/snapshot-versions.txt.tmp channels/snapshot-versions.txt
+            if [ "$is_draft" = "true" ] && [ "$existing_target" = "$expected_sha" ]; then
+              echo "Removing stale draft release $version for $expected_sha"
+              gh release delete "$version" --yes
+            else
+              existing_sha="$existing_target"
+
+              if [ "$is_draft" = "false" ]; then
+                git fetch origin "refs/tags/$version" --depth=1 >/dev/null 2>&1 || true
+                existing_sha="$(git rev-parse 'FETCH_HEAD^{commit}' 2>/dev/null || printf '%s' "$existing_target")"
+              fi
+
+              if [ "$is_draft" = "false" ] && [ "$existing_sha" = "$expected_sha" ]; then
+                echo "Release already published: $version ($expected_sha)"
+                release_exists=true
+              else
+                echo "Release conflict for $version" >&2
+                echo "draft: $is_draft" >&2
+                echo "expected commit: $expected_sha" >&2
+                echo "existing commit: $existing_sha" >&2
+                echo "Resolve the existing release/tag manually, then rerun this workflow." >&2
+                exit 1
+              fi
+            fi
           fi
 
-          if [ -z "$(git status --porcelain -- channels)" ]; then
-            exit 0
+          if [ "$release_exists" = "false" ]; then
+            trap 'gh release delete "$version" --yes >/dev/null 2>&1 || true' EXIT
+
+            gh release create "$version" \
+              --target "${{ needs.prepare.outputs.sha }}" \
+              --title "$version" \
+              --draft \
+              ki-linux-x64/ki-linux-x64.tar.gz \
+              ki-linux-arm64/ki-linux-arm64.tar.gz \
+              ki-windows-x64/ki-windows-x64.zip \
+              ki-windows-arm64/ki-windows-arm64.zip \
+              ki-macos-x64/ki-macos-x64.tar.gz \
+              ki-macos-arm64/ki-macos-arm64.tar.gz
+
+            if [ "${{ needs.prepare.outputs.kind }}" = "snapshot" ]; then
+              gh release edit "$version" --draft=false --prerelease
+            else
+              gh release edit "$version" --draft=false --latest
+            fi
+
+            trap - EXIT
           fi
 
-          git config user.name github-actions[bot]
-          git config user.email github-actions[bot]@users.noreply.github.com
-          git add channels
-          git commit -m "Update release channel metadata for $version"
-          git push
-
-  gc-snapshots:
-    if: needs.prepare.outputs.kind == 'snapshot' && needs.prepare.outputs.skip != 'true'
-    needs: [prepare, channels]
-    runs-on: ubuntu-latest
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  sync-channels:
+    if: needs.prepare.outputs.skip != 'true'
+    needs: [prepare, publish]
+    uses: ./.github/workflows/sync-release-channels.yml
     permissions:
       contents: write
-    steps:
-      - name: Checkout gh-pages
-        uses: actions/checkout@v6
-        with:
-          ref: gh-pages
-          path: gh-pages
-
-      - name: Delete expired snapshot releases
-        working-directory: gh-pages
-        run: |
-          set -eu
-
-          keep_file="channels/snapshot-versions.txt"
-
-          gh release list \
-            --repo "$GITHUB_REPOSITORY" \
-            --limit 1000 \
-            --json tagName \
-            --jq '.[].tagName | select(startswith("snapshot-"))' \
-            | while IFS= read -r tag; do
-                if ! grep -qxF "$tag" "$keep_file"; then
-                  gh release delete "$tag" --repo "$GITHUB_REPOSITORY" --cleanup-tag --yes
-                fi
-              done
+    with:
+      fast: true
+      expected_version: ${{ needs.prepare.outputs.version }}

--- a/.github/workflows/sync-release-channels.yml
+++ b/.github/workflows/sync-release-channels.yml
@@ -1,0 +1,44 @@
+name: sync release channels
+
+on:
+  workflow_call:
+    inputs:
+      fast:
+        required: false
+        default: true
+        type: boolean
+      expected_version:
+        required: false
+        default: ''
+        type: string
+  workflow_dispatch:
+    inputs:
+      fast:
+        description: Only discover recent releases; do not remove missing records
+        required: true
+        default: true
+        type: boolean
+
+concurrency:
+  group: release-channels
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      SNAPSHOT_KEEP: 14
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout workflow source
+        uses: actions/checkout@v6
+        with:
+          path: source
+
+      - name: Sync release channels
+        env:
+          EXPECTED_VERSION: ${{ inputs.expected_version }}
+          FAST: ${{ inputs.fast }}
+        run: bash source/.github/scripts/sync-release-channels.sh

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -13,12 +13,14 @@ versions are tagged as `vX.Y.Z`, while snapshot builds are tagged as
 archives for Linux and macOS, and `.zip` archives for Windows. Each archive
 contains the executable under `bin/ki` or `bin/ki.exe`.
 
-Release channel metadata is published as plain text files:
+Normalized release metadata and derived channel indexes are published from the
+`channels` branch:
 
-- `https://ki-editor.github.io/ki-editor/channels/stable-latest.txt`
-- `https://ki-editor.github.io/ki-editor/channels/stable-versions.txt`
-- `https://ki-editor.github.io/ki-editor/channels/snapshot-latest.txt`
-- `https://ki-editor.github.io/ki-editor/channels/snapshot-versions.txt`
+- `https://raw.githubusercontent.com/ki-editor/ki-editor/channels/releases.jsonl`
+- `https://raw.githubusercontent.com/ki-editor/ki-editor/channels/stable/latest.txt`
+- `https://raw.githubusercontent.com/ki-editor/ki-editor/channels/stable/versions.txt`
+- `https://raw.githubusercontent.com/ki-editor/ki-editor/channels/snapshot/latest.txt`
+- `https://raw.githubusercontent.com/ki-editor/ki-editor/channels/snapshot/versions.txt`
 
 ## VS Code Extension
 


### PR DESCRIPTION
Fixes #1667

## Summary

- Publish canonical release metadata to a dedicated `channels` branch, with derived `latest.txt` and `versions.txt` files for stable and snapshot channels.
- Keep stable metadata indefinitely and retain the newest 14 snapshots.
- Use fast synchronization after publishing and support manual full reconciliation against GitHub Releases.
- Publish immutable releases through a draft/upload/publish sequence, then synchronize channel metadata.
- Deduplicate snapshots by full commit ID from `channels:releases.jsonl`.
- Update installation documentation to consume the channel metadata.

## Validation

- Snapshot publish and channel synchronization: https://github.com/hh9527/ki-editor/actions/runs/29231348943
- `dedupe=true` no-op for an already-recorded commit: https://github.com/hh9527/ki-editor/actions/runs/29235318462
- `git diff --check`

## Notes

Published releases are treated as immutable. Fast synchronization adds or updates recent API records, while manual full synchronization paginates all GitHub Releases and reconciles removals. Stable releases are never pruned; snapshots beyond the retention limit are removed.
