### PR TITLE
feat(config): allow comments in config.json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1349,6 +1349,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "json_comments"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dbbfed4e59ba9750e15ba154fdfd9329cee16ff3df539c2666b70f58cc32105"
+
+[[package]]
 name = "ki"
 version = "0.1.0"
 dependencies = [
@@ -1381,6 +1387,7 @@ dependencies = [
  "is_ci",
  "itertools",
  "json-rpc-types",
+ "json_comments",
  "ki-protocol-types",
  "lazy-regex",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1349,10 +1349,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "json_comments"
-version = "0.2.2"
+name = "json5"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dbbfed4e59ba9750e15ba154fdfd9329cee16ff3df539c2666b70f58cc32105"
+checksum = "733a844dbd6fef128e98cb4487b887cb55454d92cd9994b1bafe004fabbe670c"
+dependencies = [
+ "serde",
+ "ucd-trie",
+]
 
 [[package]]
 name = "ki"
@@ -1387,7 +1391,7 @@ dependencies = [
  "is_ci",
  "itertools",
  "json-rpc-types",
- "json_comments",
+ "json5",
  "ki-protocol-types",
  "lazy-regex",
  "libc",
@@ -3391,6 +3395,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uncased"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,6 @@ ki-protocol-types = { path = "ki-protocol-types" }
 uuid = { version = "1.4.1", features = ["v4", "serde"] }
 url = { version = "2.5.2" }
 figment = { version = "0.10.19", features = ["json", "toml", "yaml"] }
-json_comments = "0.2.2"
 
 # Add tungstenite for WebSocket support
 tungstenite = "0.21"
@@ -122,6 +121,7 @@ tracing-log.workspace = true
 crossbeam-channel = "0.5.15"
 const_format = "0.2.36"
 once_cell.workspace = true
+json5 = "1.3.1"
 
 [dev-dependencies]
 serial_test = "~3.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,7 @@ ki-protocol-types = { path = "ki-protocol-types" }
 uuid = { version = "1.4.1", features = ["v4", "serde"] }
 url = { version = "2.5.2" }
 figment = { version = "0.10.19", features = ["json", "toml", "yaml"] }
+json_comments = "0.2.2"
 
 # Add tungstenite for WebSocket support
 tungstenite = "0.21"

--- a/src/config.rs
+++ b/src/config.rs
@@ -61,17 +61,18 @@ enum IndentChar {
 
 const DEFAULT_CONFIG: &str = include_str!("config_default.json");
 
-/// A JSON [`providers::Format`] that first strips `//` and `/* */` comments,
-/// so user-facing `config.json` files can be written as JSONC.
+/// A JSON [`providers::Format`] backed by the [`json5`] parser, so
+/// user-facing `config.json` files can contain `//` and `/* */` comments
+/// (and other JSON5 conveniences like trailing commas).
 struct Jsonc;
 
 impl providers::Format for Jsonc {
-    type Error = serde_json::Error;
+    type Error = json5::Error;
 
     const NAME: &'static str = "JSON";
 
     fn from_str<T: serde::de::DeserializeOwned>(string: &str) -> Result<T, Self::Error> {
-        serde_json::from_reader(json_comments::StripComments::new(string.as_bytes()))
+        json5::from_str(string)
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -61,6 +61,20 @@ enum IndentChar {
 
 const DEFAULT_CONFIG: &str = include_str!("config_default.json");
 
+/// A JSON [`providers::Format`] that first strips `//` and `/* */` comments,
+/// so user-facing `config.json` files can be written as JSONC.
+struct Jsonc;
+
+impl providers::Format for Jsonc {
+    type Error = serde_json::Error;
+
+    const NAME: &'static str = "JSON";
+
+    fn from_str<T: serde::de::DeserializeOwned>(string: &str) -> Result<T, Self::Error> {
+        serde_json::from_reader(json_comments::StripComments::new(string.as_bytes()))
+    }
+}
+
 impl Default for RawConfig {
     fn default() -> Self {
         RawConfig {
@@ -226,7 +240,7 @@ impl AppConfig {
             let global_config =
                 |extension: &str| ki_global_directory().join(format!("config.{extension}"));
             figment
-                .merge(providers::Json::file(global_config("json")))
+                .merge(Jsonc::file(global_config("json")))
                 .merge(providers::Yaml::file(global_config("yaml")))
                 .merge(providers::Toml::file(global_config("toml")))
         };
@@ -235,7 +249,7 @@ impl AppConfig {
             let workspace_config =
                 |extension: &str| workspace_dir.join(format!("config.{extension}"));
             figment
-                .merge(providers::Json::file(workspace_config("json")))
+                .merge(Jsonc::file(workspace_config("json")))
                 .merge(providers::Yaml::file(workspace_config("yaml")))
                 .merge(providers::Toml::file(workspace_config("toml")))
         } else {
@@ -498,6 +512,30 @@ mod test_config {
             .load_errors()
             .iter()
             .all(|error| error.contains(".ki/config.json")));
+    }
+
+    /// `config.json` is allowed to contain `//` and `/* */` comments (JSONC),
+    /// since that's convenient for annotating settings.
+    #[test]
+    fn config_json_allows_comments() {
+        let tempdir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tempdir.path().join(".ki")).unwrap();
+        std::fs::write(
+            tempdir.path().join(".ki/config.json"),
+            r#"{
+                // line comment
+                "indent_width": 7 /* inline comment */
+            }"#,
+        )
+        .unwrap();
+
+        let original_dir = std::env::current_dir().unwrap();
+        std::env::set_current_dir(tempdir.path()).unwrap();
+        let config = super::AppConfig::load_from_current_directory();
+        std::env::set_current_dir(original_dir).unwrap();
+
+        assert!(config.load_errors().is_empty());
+        assert_eq!(config.indent_width(), 7);
     }
 
     /// A malformed field *within* a language override (e.g. `formatter`)

--- a/src/config.rs
+++ b/src/config.rs
@@ -64,9 +64,9 @@ const DEFAULT_CONFIG: &str = include_str!("config_default.json");
 /// A JSON [`providers::Format`] backed by the [`json5`] parser, so
 /// user-facing `config.json` files can contain `//` and `/* */` comments
 /// (and other JSON5 conveniences like trailing commas).
-struct Jsonc;
+struct Json5;
 
-impl providers::Format for Jsonc {
+impl providers::Format for Json5 {
     type Error = json5::Error;
 
     const NAME: &'static str = "JSON";
@@ -241,7 +241,7 @@ impl AppConfig {
             let global_config =
                 |extension: &str| ki_global_directory().join(format!("config.{extension}"));
             figment
-                .merge(Jsonc::file(global_config("json")))
+                .merge(Json5::file(global_config("json")))
                 .merge(providers::Yaml::file(global_config("yaml")))
                 .merge(providers::Toml::file(global_config("toml")))
         };
@@ -250,7 +250,7 @@ impl AppConfig {
             let workspace_config =
                 |extension: &str| workspace_dir.join(format!("config.{extension}"));
             figment
-                .merge(Jsonc::file(workspace_config("json")))
+                .merge(Json5::file(workspace_config("json")))
                 .merge(providers::Yaml::file(workspace_config("yaml")))
                 .merge(providers::Toml::file(workspace_config("toml")))
         } else {


### PR DESCRIPTION
## Summary
- `config.json` is now parsed with the `json5` crate, so it supports `//` line comments, `/* */` block comments, and other JSON5 conveniences (e.g. trailing commas).
- YAML/TOML config files are unaffected.

## Test plan
- [x] Create `.ki/config.json` with a `//` and a `/* */` comment and confirm Ki starts up without a config warning and applies the values.