### PR TITLE
fix(config): don't let a broken config file discard other valid config sources

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -224,12 +224,17 @@ impl figment::Provider for ConfigFile {
 /// only takes down its own contents rather than every other config source
 /// (e.g. a broken workspace config no longer discards an otherwise-valid
 /// global config, and vice versa).
-fn merge_valid(
+struct MergeValid {
     figment: figment::Figment,
-    provider: ConfigFile,
-) -> (figment::Figment, Option<String>) {
+    error: Option<String>,
+}
+
+fn merge_valid(figment: figment::Figment, provider: ConfigFile) -> MergeValid {
     match provider.data() {
-        Ok(_) => (figment.merge(provider), None),
+        Ok(_) => MergeValid {
+            figment: figment.merge(provider),
+            error: None,
+        },
         Err(error) => {
             let metadata = provider.metadata();
             let source = metadata
@@ -237,28 +242,37 @@ fn merge_valid(
                 .as_ref()
                 .map(|source| source.to_string())
                 .unwrap_or_else(|| metadata.name.to_string());
-            (
+            MergeValid {
                 figment,
-                Some(format!(
+                error: Some(format!(
                     "{source} could not be parsed (invalid syntax), skipping this file: {error}"
                 )),
-            )
+            }
         }
     }
 }
 
+struct MergeAllValid {
+    figment: figment::Figment,
+    errors: Vec<String>,
+}
+
 /// Folds [`merge_valid`] over `providers`, collecting the resulting figment
 /// alongside every error message produced along the way.
-fn merge_all_valid(
-    figment: figment::Figment,
-    providers: Vec<ConfigFile>,
-) -> (figment::Figment, Vec<String>) {
-    providers
-        .into_iter()
-        .fold((figment, Vec::new()), |(figment, errors), provider| {
-            let (figment, error) = merge_valid(figment, provider);
-            (figment, errors.into_iter().chain(error).collect())
-        })
+fn merge_all_valid(figment: figment::Figment, providers: Vec<ConfigFile>) -> MergeAllValid {
+    providers.into_iter().fold(
+        MergeAllValid {
+            figment,
+            errors: Vec::new(),
+        },
+        |acc, provider| {
+            let result = merge_valid(acc.figment, provider);
+            MergeAllValid {
+                figment: result.figment,
+                errors: acc.errors.into_iter().chain(result.error).collect(),
+            }
+        },
+    )
 }
 
 pub fn load_script(script_name: &str) -> anyhow::Result<Script> {
@@ -320,14 +334,15 @@ impl AppConfig {
         let (figment, global_errors) = {
             let global_config =
                 |extension: &str| ki_global_directory().join(format!("config.{extension}"));
-            merge_all_valid(
+            let result = merge_all_valid(
                 figment,
                 vec![
                     ConfigFile::Json5(Json5::file(global_config("json"))),
                     ConfigFile::Yaml(providers::Yaml::file(global_config("yaml"))),
                     ConfigFile::Toml(providers::Toml::file(global_config("toml"))),
                 ],
-            )
+            );
+            (result.figment, result.errors)
         };
         #[cfg(test)]
         let global_errors: Vec<String> = Vec::new();
@@ -335,14 +350,15 @@ impl AppConfig {
         let (figment, workspace_errors) = if let Some(workspace_dir) = &workspace_dir {
             let workspace_config =
                 |extension: &str| workspace_dir.join(format!("config.{extension}"));
-            merge_all_valid(
+            let result = merge_all_valid(
                 figment,
                 vec![
                     ConfigFile::Json5(Json5::file(workspace_config("json"))),
                     ConfigFile::Yaml(providers::Yaml::file(workspace_config("yaml"))),
                     ConfigFile::Toml(providers::Toml::file(workspace_config("toml"))),
                 ],
-            )
+            );
+            (result.figment, result.errors)
         } else {
             (figment, Vec::new())
         };

--- a/src/config.rs
+++ b/src/config.rs
@@ -640,12 +640,10 @@ mod test_config {
             super::AppConfig::default().indent_width()
         );
         assert!(!config.languages().is_empty());
-        assert!(
-            config
-                .load_errors()
-                .iter()
-                .all(|error| error.contains(".ki/config.json"))
-        );
+        assert!(config
+            .load_errors()
+            .iter()
+            .all(|error| error.contains(".ki/config.json")));
     }
 
     /// `config.json` is allowed to contain `//` and `/* */` comments (JSONC),

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,7 @@ use crate::scripting::{Keybinding, Script};
 use crate::themes::Theme;
 use figment::providers;
 use figment::providers::Format;
+use figment::Provider;
 use once_cell::sync::OnceCell;
 use schemars::{JsonSchema, Schema, SchemaGenerator};
 use serde::{Deserialize, Serialize};
@@ -187,19 +188,48 @@ pub fn ki_global_directory() -> PathBuf {
     ::grammar::config_dir()
 }
 
-/// Merges `provider` into `figment` only if it parses cleanly. A file with a
-/// syntax error (invalid JSON/YAML/TOML) is excluded from the merge instead
-/// of being included and later poisoning the whole merged figment, so that a
-/// broken config file only takes down its own contents rather than every
-/// other config source (e.g. a broken workspace config no longer discards an
-/// otherwise-valid global config, and vice versa).
-fn merge_valid<T: figment::Provider>(
+/// A config file, in one of the formats Ki understands. Unifies the three
+/// concrete `figment` provider types into one so a directory's providers can
+/// be folded over as a homogeneous list.
+enum ConfigFile {
+    Json5(figment::providers::Data<Json5>),
+    Yaml(figment::providers::Data<providers::Yaml>),
+    Toml(figment::providers::Data<providers::Toml>),
+}
+
+impl figment::Provider for ConfigFile {
+    fn metadata(&self) -> figment::Metadata {
+        match self {
+            ConfigFile::Json5(provider) => provider.metadata(),
+            ConfigFile::Yaml(provider) => provider.metadata(),
+            ConfigFile::Toml(provider) => provider.metadata(),
+        }
+    }
+
+    fn data(
+        &self,
+    ) -> Result<figment::value::Map<figment::Profile, figment::value::Dict>, figment::Error> {
+        match self {
+            ConfigFile::Json5(provider) => provider.data(),
+            ConfigFile::Yaml(provider) => provider.data(),
+            ConfigFile::Toml(provider) => provider.data(),
+        }
+    }
+}
+
+/// Merges `provider` into `figment` only if it parses cleanly, returning an
+/// error message instead if it doesn't. A file with a syntax error (invalid
+/// JSON/YAML/TOML) is excluded from the merge instead of being included and
+/// later poisoning the whole merged figment, so that a broken config file
+/// only takes down its own contents rather than every other config source
+/// (e.g. a broken workspace config no longer discards an otherwise-valid
+/// global config, and vice versa).
+fn merge_valid(
     figment: figment::Figment,
-    provider: T,
-    errors: &mut Vec<String>,
-) -> figment::Figment {
+    provider: ConfigFile,
+) -> (figment::Figment, Option<String>) {
     match provider.data() {
-        Ok(_) => figment.merge(provider),
+        Ok(_) => (figment.merge(provider), None),
         Err(error) => {
             let metadata = provider.metadata();
             let source = metadata
@@ -207,12 +237,28 @@ fn merge_valid<T: figment::Provider>(
                 .as_ref()
                 .map(|source| source.to_string())
                 .unwrap_or_else(|| metadata.name.to_string());
-            errors.push(format!(
-                "{source} could not be parsed (invalid syntax), skipping this file: {error}"
-            ));
-            figment
+            (
+                figment,
+                Some(format!(
+                    "{source} could not be parsed (invalid syntax), skipping this file: {error}"
+                )),
+            )
         }
     }
+}
+
+/// Folds [`merge_valid`] over `providers`, collecting the resulting figment
+/// alongside every error message produced along the way.
+fn merge_all_valid(
+    figment: figment::Figment,
+    providers: Vec<ConfigFile>,
+) -> (figment::Figment, Vec<String>) {
+    providers
+        .into_iter()
+        .fold((figment, Vec::new()), |(figment, errors), provider| {
+            let (figment, error) = merge_valid(figment, provider);
+            (figment, errors.into_iter().chain(error).collect())
+        })
 }
 
 pub fn load_script(script_name: &str) -> anyhow::Result<Script> {
@@ -270,49 +316,35 @@ impl AppConfig {
         let figment =
             figment::Figment::from(providers::Serialized::defaults(&RawConfig::default()));
 
-        let mut file_errors = Vec::new();
-
         #[cfg(not(test))]
-        let figment = {
+        let (figment, global_errors) = {
             let global_config =
                 |extension: &str| ki_global_directory().join(format!("config.{extension}"));
-            let figment = merge_valid(
+            merge_all_valid(
                 figment,
-                Json5::file(global_config("json")),
-                &mut file_errors,
-            );
-            let figment = merge_valid(
-                figment,
-                providers::Yaml::file(global_config("yaml")),
-                &mut file_errors,
-            );
-            merge_valid(
-                figment,
-                providers::Toml::file(global_config("toml")),
-                &mut file_errors,
+                vec![
+                    ConfigFile::Json5(Json5::file(global_config("json"))),
+                    ConfigFile::Yaml(providers::Yaml::file(global_config("yaml"))),
+                    ConfigFile::Toml(providers::Toml::file(global_config("toml"))),
+                ],
             )
         };
+        #[cfg(test)]
+        let global_errors: Vec<String> = Vec::new();
 
-        let figment = if let Some(workspace_dir) = &workspace_dir {
+        let (figment, workspace_errors) = if let Some(workspace_dir) = &workspace_dir {
             let workspace_config =
                 |extension: &str| workspace_dir.join(format!("config.{extension}"));
-            let figment = merge_valid(
+            merge_all_valid(
                 figment,
-                Json5::file(workspace_config("json")),
-                &mut file_errors,
-            );
-            let figment = merge_valid(
-                figment,
-                providers::Yaml::file(workspace_config("yaml")),
-                &mut file_errors,
-            );
-            merge_valid(
-                figment,
-                providers::Toml::file(workspace_config("toml")),
-                &mut file_errors,
+                vec![
+                    ConfigFile::Json5(Json5::file(workspace_config("json"))),
+                    ConfigFile::Yaml(providers::Yaml::file(workspace_config("yaml"))),
+                    ConfigFile::Toml(providers::Toml::file(workspace_config("toml"))),
+                ],
             )
         } else {
-            figment
+            (figment, Vec::new())
         };
 
         let Extracted {
@@ -330,7 +362,8 @@ impl AppConfig {
 
         let load_errors = workspace_dir_error
             .into_iter()
-            .chain(file_errors)
+            .chain(global_errors)
+            .chain(workspace_errors)
             .chain(field_errors)
             .chain(apply_error)
             .collect();

--- a/src/config.rs
+++ b/src/config.rs
@@ -187,6 +187,34 @@ pub fn ki_global_directory() -> PathBuf {
     ::grammar::config_dir()
 }
 
+/// Merges `provider` into `figment` only if it parses cleanly. A file with a
+/// syntax error (invalid JSON/YAML/TOML) is excluded from the merge instead
+/// of being included and later poisoning the whole merged figment, so that a
+/// broken config file only takes down its own contents rather than every
+/// other config source (e.g. a broken workspace config no longer discards an
+/// otherwise-valid global config, and vice versa).
+fn merge_valid<T: figment::Provider>(
+    figment: figment::Figment,
+    provider: T,
+    errors: &mut Vec<String>,
+) -> figment::Figment {
+    match provider.data() {
+        Ok(_) => figment.merge(provider),
+        Err(error) => {
+            let metadata = provider.metadata();
+            let source = metadata
+                .source
+                .as_ref()
+                .map(|source| source.to_string())
+                .unwrap_or_else(|| metadata.name.to_string());
+            errors.push(format!(
+                "{source} could not be parsed (invalid syntax), skipping this file: {error}"
+            ));
+            figment
+        }
+    }
+}
+
 pub fn load_script(script_name: &str) -> anyhow::Result<Script> {
     // Trying reading from workspace directory first
     let workspace_path = ki_workspace_directory()?.join("scripts").join(script_name);
@@ -224,6 +252,12 @@ impl AppConfig {
     /// instead of failing the entire config, so that Ki always starts up.
     /// Anything that couldn't be parsed is recorded in [`AppConfig::load_errors`];
     /// [`AppConfig::singleton`] is responsible for surfacing it to the user.
+    ///
+    /// Global and workspace config files are each validated for syntax
+    /// independently before being merged in: a syntax error in one file (e.g.
+    /// the workspace config) only drops that file, so the other (e.g. the
+    /// global config) still applies instead of the whole config collapsing
+    /// to hardcoded defaults.
     pub fn load_from_current_directory() -> Self {
         let (workspace_dir, workspace_dir_error) = match ki_workspace_directory() {
             Ok(dir) => (Some(dir), None),
@@ -236,23 +270,47 @@ impl AppConfig {
         let figment =
             figment::Figment::from(providers::Serialized::defaults(&RawConfig::default()));
 
+        let mut file_errors = Vec::new();
+
         #[cfg(not(test))]
         let figment = {
             let global_config =
                 |extension: &str| ki_global_directory().join(format!("config.{extension}"));
-            figment
-                .merge(Json5::file(global_config("json")))
-                .merge(providers::Yaml::file(global_config("yaml")))
-                .merge(providers::Toml::file(global_config("toml")))
+            let figment = merge_valid(
+                figment,
+                Json5::file(global_config("json")),
+                &mut file_errors,
+            );
+            let figment = merge_valid(
+                figment,
+                providers::Yaml::file(global_config("yaml")),
+                &mut file_errors,
+            );
+            merge_valid(
+                figment,
+                providers::Toml::file(global_config("toml")),
+                &mut file_errors,
+            )
         };
 
         let figment = if let Some(workspace_dir) = &workspace_dir {
             let workspace_config =
                 |extension: &str| workspace_dir.join(format!("config.{extension}"));
-            figment
-                .merge(Json5::file(workspace_config("json")))
-                .merge(providers::Yaml::file(workspace_config("yaml")))
-                .merge(providers::Toml::file(workspace_config("toml")))
+            let figment = merge_valid(
+                figment,
+                Json5::file(workspace_config("json")),
+                &mut file_errors,
+            );
+            let figment = merge_valid(
+                figment,
+                providers::Yaml::file(workspace_config("yaml")),
+                &mut file_errors,
+            );
+            merge_valid(
+                figment,
+                providers::Toml::file(workspace_config("toml")),
+                &mut file_errors,
+            )
         } else {
             figment
         };
@@ -272,6 +330,7 @@ impl AppConfig {
 
         let load_errors = workspace_dir_error
             .into_iter()
+            .chain(file_errors)
             .chain(field_errors)
             .chain(apply_error)
             .collect();
@@ -485,6 +544,29 @@ mod test_config {
         );
     }
 
+    /// Regression test: a syntax error in one config file (here, a broken
+    /// workspace `config.json`) must not discard the values contributed by
+    /// another, syntactically valid config file (here, `config.toml`) merged
+    /// into the same figment. This is the same mechanism that lets a broken
+    /// workspace config fall back to an otherwise-valid global config instead
+    /// of collapsing the whole config to hardcoded defaults.
+    #[test]
+    fn broken_file_does_not_discard_another_valid_files_values() {
+        let tempdir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tempdir.path().join(".ki")).unwrap();
+        std::fs::write(tempdir.path().join(".ki/config.json"), "{ not valid json").unwrap();
+        std::fs::write(tempdir.path().join(".ki/config.toml"), "indent_width = 7").unwrap();
+
+        let original_dir = std::env::current_dir().unwrap();
+        std::env::set_current_dir(tempdir.path()).unwrap();
+        let config = super::AppConfig::load_from_current_directory();
+        std::env::set_current_dir(original_dir).unwrap();
+
+        assert_eq!(config.load_errors().len(), 1);
+        assert!(config.load_errors()[0].contains(".ki/config.json"));
+        assert_eq!(config.indent_width(), 7);
+    }
+
     /// A malformed field and a malformed language entry should each fall back
     /// to their own default independently, instead of the whole config (or
     /// even the whole `languages` map) failing.
@@ -509,10 +591,12 @@ mod test_config {
             super::AppConfig::default().indent_width()
         );
         assert!(!config.languages().is_empty());
-        assert!(config
-            .load_errors()
-            .iter()
-            .all(|error| error.contains(".ki/config.json")));
+        assert!(
+            config
+                .load_errors()
+                .iter()
+                .all(|error| error.contains(".ki/config.json"))
+        );
     }
 
     /// `config.json` is allowed to contain `//` and `/* */` comments (JSONC),


### PR DESCRIPTION
## Summary
- Global and workspace config files (`.json`/`.yaml`/`.toml`, up to 6 files) were merged into a single `figment::Figment` before validating syntax. A syntax error in *any one* file caused the whole merge to fail, discarding values from every other file too — e.g. a broken local `.ki/config.json` would silently wipe out an otherwise-valid global config, falling back entirely to hardcoded defaults.
- Each config file is now validated independently before being merged in (`merge_valid`); a file that fails to parse is skipped (with an error naming it) instead of poisoning the whole merge, so a broken local config no longer takes down a valid global config, and vice versa.

## Test plan

1. Create a global config (`~/.config/ki/config.json` or platform equivalent) with a valid setting (e.g. `indent_width`).
2. Create a workspace `.ki/config.json` with a JSON syntax error (e.g. a stray comma or missing brace).
3. Launch Ki in that workspace and confirm the global config's setting still applies, with a warning naming only the broken workspace file (not a full fallback to built-in defaults).