### PR TITLE
Revert "feat(copy): disable selection extension after copying"

### DIFF
--- a/REVERT_PLACEHOLDER.txt
+++ b/REVERT_PLACEHOLDER.txt
@@ -1,0 +1,3 @@
+This file is a placeholder to create the revert commit.
+Revert of: feat(copy): disable selection extension after copying
+See: https://ki-editor.zulipchat.com/#narrow/channel/551672-.F0.9F.8C.B1-Feature/topic/Copy.20disable.20extension.20selection/near/611100364

--- a/REVERT_PLACEHOLDER.txt
+++ b/REVERT_PLACEHOLDER.txt
@@ -1,3 +1,0 @@
-This file is a placeholder to create the revert commit.
-Revert of: feat(copy): disable selection extension after copying
-See: https://ki-editor.zulipchat.com/#narrow/channel/551672-.F0.9F.8C.B1-Feature/topic/Copy.20disable.20extension.20selection/near/611100364

--- a/src/components/editor/mod.rs
+++ b/src/components/editor/mod.rs
@@ -818,7 +818,7 @@ impl Editor {
 
     #[cfg(test)]
     pub fn reset(&mut self) {
-        self.selection_set.escape_extended_selection();
+        self.selection_set.escape_highlight_mode();
     }
 
     pub fn update_selection_set(
@@ -1267,11 +1267,9 @@ impl Editor {
     }
 
     pub fn copy(&mut self) -> Dispatches {
-        let dispatches = Dispatches::one(Dispatch::SetClipboardContent {
+        Dispatches::one(Dispatch::SetClipboardContent {
             copied_texts: self.get_current_texts(),
-        });
-        self.disable_selection_extension();
-        dispatches
+        })
     }
 
     fn get_current_texts(&self) -> Texts {
@@ -1828,10 +1826,7 @@ impl Editor {
     }
 
     pub fn change_cut(&mut self, context: &Context) -> anyhow::Result<Dispatches> {
-        Ok(Dispatches::one(Dispatch::SetClipboardContent {
-            copied_texts: self.get_current_texts(),
-        })
-        .chain(self.change(context)?))
+        Ok(self.copy().chain(self.change(context)?))
     }
 
     pub fn insert(

--- a/src/components/test_editor.rs
+++ b/src/components/test_editor.rs
@@ -429,26 +429,6 @@ fn test_delete_extended_selection_whole_file() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_copy_disables_selection_extension() -> anyhow::Result<()> {
-    execute_test(move |s| {
-        Box::new([
-            App(OpenFile {
-                path: s.main_rs(),
-                owner: BufferOwner::User,
-                focus: true,
-            }),
-            Editor(SetContent("who lives in a pineapple".to_string())),
-            Editor(SetSelectionMode(IfCurrentNotFound::LookForward, Word)),
-            Editor(EnableSelectionExtension),
-            Editor(MoveSelection(Right)),
-            Expect(CurrentSelectedTexts(&["who lives"])),
-            Editor(Copy),
-            Expect(SelectionExtensionEnabled(false)),
-        ])
-    })
-}
-
-#[test]
 fn test_delete_word_short_backward_from_middle_of_file() -> anyhow::Result<()> {
     execute_test(|s| {
         Box::new([

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -259,7 +259,7 @@ impl SelectionSet {
         Ok(())
     }
     #[cfg(test)]
-    pub fn escape_extended_selection(&mut self) {
+    pub fn escape_highlight_mode(&mut self) {
         self.apply_mut(|selection| selection.disable_extension());
     }
 

--- a/src/test_app.rs
+++ b/src/test_app.rs
@@ -1166,7 +1166,7 @@ fn cut_replace() -> anyhow::Result<()> {
 
 #[serial]
 #[test]
-fn cut_extended_selection() -> anyhow::Result<()> {
+fn highlight_mode_cut() -> anyhow::Result<()> {
     execute_test(|s| {
         Box::new([
             App(OpenFile {
@@ -1195,7 +1195,7 @@ fn cut_extended_selection() -> anyhow::Result<()> {
 
 #[serial]
 #[test]
-fn copy_extended_selection() -> anyhow::Result<()> {
+fn highlight_mode_copy() -> anyhow::Result<()> {
     execute_test(|s| {
         Box::new([
             App(OpenFile {
@@ -1226,7 +1226,7 @@ fn copy_extended_selection() -> anyhow::Result<()> {
 
 #[serial]
 #[test]
-fn replace_extended_selection() -> anyhow::Result<()> {
+fn highlight_mode_replace() -> anyhow::Result<()> {
     execute_test(|s| {
         Box::new([
             App(OpenFile {


### PR DESCRIPTION
This reverts commit c4cc0c3122c31d1b59b07889ef19aa8aa0cbe400.

Reference: https://ki-editor.zulipchat.com/#narrow/channel/551672-.F0.9F.8C.B1-Feature/topic/Copy.20disable.20extension.20selection/near/611100364