### PR TITLE
fix(deps): pin tree-sitter-scss to upstream commit with MSVC build fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3252,8 +3252,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter-scss"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33909a9ca86390ebbf3461e9949c4bbe2767d2d024b486306d27616641d4ba24"
+source = "git+https://github.com/tree-sitter-grammars/tree-sitter-scss?rev=2ef6d42e3ad7a8208900f9346f4529806ae0f9f9#2ef6d42e3ad7a8208900f9346f4529806ae0f9f9"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,6 +135,13 @@ nvim-treesitter-highlight-queries = { path = "nvim-treesitter-highlight-queries"
 tempfile.workspace = true
 
 
+[patch.crates-io]
+# tree-sitter-scss 1.0.0 passes a GCC-only flag ("-Wno-unused-parameter") to
+# the MSVC compiler, breaking the Windows build. Pin to the upstream commit
+# that guards the flag per-compiler, until a new version is published.
+# See: https://github.com/tree-sitter-grammars/tree-sitter-scss/commit/9ab738d
+tree-sitter-scss = { git = "https://github.com/tree-sitter-grammars/tree-sitter-scss", rev = "2ef6d42e3ad7a8208900f9346f4529806ae0f9f9" }
+
 [profile.release]
 debug = false # Set this to true when using `sudo cargo flamegraph`
 


### PR DESCRIPTION
## Summary
- The `release` workflow's `build (windows-latest)` job has been failing every night since #1672 added the SCSS grammar.
- `tree-sitter-scss` 1.0.0's build script unconditionally passes the GCC-only flag `-Wno-unused-parameter`, which `cl.exe` rejects (`D8021: invalid numeric argument`), aborting the Windows build.
- Upstream already fixed this on their default branch (guarding the flag per-compiler) but hasn't cut a new crates.io release, so this pins the dependency via `[patch.crates-io]` to that fix commit until a new version ships.

## Test plan
- [ ] Confirm the `release` workflow's `build (windows-latest)` and `build (windows-11-arm)` jobs pass on this branch.