### PR TITLE
feat(languages/roc) switch to different tree-sitter grammar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3214,7 +3214,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter-roc"
 version = "1.0.0"
-source = "git+https://github.com/faldor20/tree-sitter-roc?rev=68f4054#68f405426d030a7625392aabf41836c1aad05d33"
+source = "git+https://git.sr.ht/~jwoudenberg/tree-sitter-roc?rev=5758e4bc#5758e4bc103b1fde8ecdcd985ae214dd478490cf"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -74,7 +74,7 @@ tree-sitter-gnuplot = { git = "https://github.com/dpezto/tree-sitter-gnuplot", r
 tree-sitter-qmljs = "0.3.0"
 tree-sitter-qmldir = { git = "https://github.com/tree-sitter-grammars/tree-sitter-qmldir", rev = "1fa9200" }
 tree-sitter-glsl = "0.2.0"
-tree-sitter-roc = { git = "https://github.com/faldor20/tree-sitter-roc", rev = "68f4054" }
+tree-sitter-roc = { git = "https://git.sr.ht/~jwoudenberg/tree-sitter-roc", rev = "5758e4bc" }
 arborium-idris = "2.18.1"
 arborium-sql = "2.18.1"
 arborium-dockerfile = "2.18.1"

--- a/shared/src/language.rs
+++ b/shared/src/language.rs
@@ -273,7 +273,7 @@ impl CargoLinkedTreesitterLanguage {
                 Some(tree_sitter_jjdescription::HIGHLIGHTS_QUERY)
             }
             CargoLinkedTreesitterLanguage::Glsl => Some(tree_sitter_glsl::HIGHLIGHTS_QUERY),
-            CargoLinkedTreesitterLanguage::Roc => None,
+            CargoLinkedTreesitterLanguage::Roc => Some(tree_sitter_roc::HIGHLIGHTS_QUERY),
             CargoLinkedTreesitterLanguage::Idris => Some(arborium_idris::HIGHLIGHTS_QUERY),
             CargoLinkedTreesitterLanguage::Sql => Some(arborium_sql::HIGHLIGHTS_QUERY),
             CargoLinkedTreesitterLanguage::Dockerfile => {


### PR DESCRIPTION
I wrote a tree-sitter grammar for roc specifically intended to provide a good experience writing Roc with Ki. It has a flatter syntax tree which I think suits Ki's tree-based editing commands better. It also includes syntax highlighting.