### PR TITLE
poc(insert): tree-sitter-based auto-indent for Python (#525)

### DIFF
--- a/shared/src/language.rs
+++ b/shared/src/language.rs
@@ -518,6 +518,17 @@ impl Language {
         })
     }
 
+    /// POC: hand-written `indents.scm` queries, authored in this repo
+    /// (see `shared/src/queries/<id>/indents.scm`), rather than vendored
+    /// from an external source. Currently only implemented for Python
+    /// to validate the approach raised in issue #525.
+    pub fn indent_query(&self) -> Option<String> {
+        match self.tree_sitter_grammar_config.as_ref()?.id.as_str() {
+            "python" => Some(include_str!("queries/python/indents.scm").to_string()),
+            _ => None,
+        }
+    }
+
     fn highlight_query_default(&self) -> Option<String> {
         let config = self.tree_sitter_grammar_config.as_ref()?;
         match &config.kind {

--- a/shared/src/language.rs
+++ b/shared/src/language.rs
@@ -529,28 +529,6 @@ impl Language {
         }
     }
 
-    /// POC: the subset of `indent_query`'s `@outdent`-captured tokens that are keywords
-    /// rather than punctuation (e.g. Python's `elif`/`else`/`except`/`except*`/`finally`).
-    ///
-    /// These can't be told apart from the tree the way closing brackets can: a keyword like
-    /// `elif` only parses as part of its clause once the line is *already* dedented to align
-    /// with the statement it belongs to (Python's grammar lexes indentation itself, via
-    /// DEDENT/INDENT), so the very line whose indentation `compute_reindent_for_outdent_keyword`
-    /// (in `src/indent_query.rs`) needs to correct can't be relied on to already show up in the
-    /// tree as the clause node `indents.scm` captures. This list lets that function recognize
-    /// the keyword from the raw text of the line instead, and compute the target indentation
-    /// from the (unaffected, still validly-parsed) content before it.
-    pub fn outdent_keywords(&self) -> &'static [&'static str] {
-        match self
-            .tree_sitter_grammar_config
-            .as_ref()
-            .map(|config| config.id.as_str())
-        {
-            Some("python") => &["elif", "else", "except", "except*", "finally"],
-            _ => &[],
-        }
-    }
-
     fn highlight_query_default(&self) -> Option<String> {
         let config = self.tree_sitter_grammar_config.as_ref()?;
         match &config.kind {

--- a/shared/src/language.rs
+++ b/shared/src/language.rs
@@ -529,6 +529,28 @@ impl Language {
         }
     }
 
+    /// POC: the subset of `indent_query`'s `@outdent`-captured tokens that are keywords
+    /// rather than punctuation (e.g. Python's `elif`/`else`/`except`/`except*`/`finally`).
+    ///
+    /// These can't be told apart from the tree the way closing brackets can: a keyword like
+    /// `elif` only parses as part of its clause once the line is *already* dedented to align
+    /// with the statement it belongs to (Python's grammar lexes indentation itself, via
+    /// DEDENT/INDENT), so the very line whose indentation `compute_reindent_for_outdent_keyword`
+    /// (in `src/indent_query.rs`) needs to correct can't be relied on to already show up in the
+    /// tree as the clause node `indents.scm` captures. This list lets that function recognize
+    /// the keyword from the raw text of the line instead, and compute the target indentation
+    /// from the (unaffected, still validly-parsed) content before it.
+    pub fn outdent_keywords(&self) -> &'static [&'static str] {
+        match self
+            .tree_sitter_grammar_config
+            .as_ref()
+            .map(|config| config.id.as_str())
+        {
+            Some("python") => &["elif", "else", "except", "except*", "finally"],
+            _ => &[],
+        }
+    }
+
     fn highlight_query_default(&self) -> Option<String> {
         let config = self.tree_sitter_grammar_config.as_ref()?;
         match &config.kind {

--- a/shared/src/queries/python/indents.scm
+++ b/shared/src/queries/python/indents.scm
@@ -1,0 +1,43 @@
+; Indent query for Python, authored for ki-editor.
+;
+; This is a proof of concept: a hand-written replacement for the kind of
+; `indents.scm` that editors like Helix ship per-language, now that
+; nvim-treesitter (the previous source ki-editor vendors `highlights.scm`
+; from) has been archived.
+;
+; Convention (same capture names as Helix's indent queries, kept because it
+; is a well-documented, already-understood spec):
+;   @indent   the node opens one extra level of indentation for every line
+;             strictly inside it (excluding its own first line).
+;
+; Only `@indent` is implemented for this POC. `@outdent` (e.g. aligning
+; `elif`/`except`/`else` back to their opening keyword when they are typed)
+; is intentionally left out -- it needs to run on keystrokes other than
+; Enter, which is a separate feature from what issue #525 asks for.
+
+; Compound statements: everything that ends its header with `:` and owns a
+; `block` of indented statements.
+[
+  (if_statement)
+  (elif_clause)
+  (else_clause)
+  (for_statement)
+  (while_statement)
+  (try_statement)
+  (except_clause)
+  (except_group_clause)
+  (finally_clause)
+  (with_statement)
+  (function_definition)
+  (class_definition)
+  (match_statement)
+  (case_clause)
+] @indent
+
+; NOTE (POC follow-up): bracketed constructs -- e.g. indenting a hanging
+; continuation right after an unclosed `(`, `[` or `{` -- are deliberately
+; NOT covered yet. Telling "still open" apart from "closed on this same
+; line" (`foo(a, b)` should NOT indent) requires checking whether the
+; node's last child is actually the closing token, which the interpreter
+; in `src/indent_query.rs` does not do yet. Adding it is the natural next
+; step once the compound-statement case here is validated.

--- a/shared/src/queries/python/indents.scm
+++ b/shared/src/queries/python/indents.scm
@@ -7,26 +7,33 @@
 ;
 ; Convention (same capture names as Helix's indent queries, kept because it
 ; is a well-documented, already-understood spec):
-;   @indent   the node opens one extra level of indentation for every line
-;             strictly inside it (excluding its own first line).
+;   @indent    the node opens one extra level of indentation for every line
+;              strictly inside it (excluding its own first line).
+;   @outdent   when the token this is attached to is about to become the
+;              first thing on a newly-inserted line, one enclosing @indent
+;              level is subtracted for that line (see
+;              `compute_indent_for_new_line`); when it is instead the token
+;              that was *just typed* to complete an existing line, that
+;              line's own indentation is corrected in place to what it
+;              would be with that level subtracted (see
+;              `compute_reindent_for_outdent_keyword`) -- this is what
+;              re-aligns `elif`/`else`/`except`/`finally` to their opening
+;              keyword as they are typed.
 ;
-; Only `@indent` is implemented for this POC. `@outdent` (e.g. aligning
-; `elif`/`except`/`else` back to their opening keyword when they are typed)
-; is intentionally left out -- it needs to run on keystrokes other than
-; Enter, which is a separate feature from what issue #525 asks for.
-
 ; Compound statements: everything that ends its header with `:` and owns a
-; `block` of indented statements.
+; `block` of indented statements. `elif_clause`/`else_clause`/
+; `except_clause`/`except_group_clause`/`finally_clause` are deliberately
+; NOT included here even though they too own a `:`-terminated block: they
+; are direct children of their `if_statement`/`try_statement`, at the same
+; textual level as its own header, rather than nested inside it -- the
+; parent statement's `@indent` already covers their entire span (headers
+; and blocks alike), so also marking the clauses `@indent` would double-
+; count and over-indent everything inside them.
 [
   (if_statement)
-  (elif_clause)
-  (else_clause)
   (for_statement)
   (while_statement)
   (try_statement)
-  (except_clause)
-  (except_group_clause)
-  (finally_clause)
   (with_statement)
   (function_definition)
   (class_definition)
@@ -34,10 +41,53 @@
   (case_clause)
 ] @indent
 
-; NOTE (POC follow-up): bracketed constructs -- e.g. indenting a hanging
-; continuation right after an unclosed `(`, `[` or `{` -- are deliberately
-; NOT covered yet. Telling "still open" apart from "closed on this same
-; line" (`foo(a, b)` should NOT indent) requires checking whether the
-; node's last child is actually the closing token, which the interpreter
-; in `src/indent_query.rs` does not do yet. Adding it is the natural next
-; step once the compound-statement case here is validated.
+; Bracketed constructs: a hanging continuation right after an unclosed `(`,
+; `[` or `{` gets one extra level, same as a `block`. Because the algorithm
+; in `src/indent_query.rs` only ever counts *ancestors of the cursor*, a
+; construct that is opened and closed on one line (`foo(a, b)`, cursor
+; after it) is simply not an ancestor of the cursor and never contributes a
+; level -- only a genuinely-open bracket the cursor sits inside does.
+[
+  (list)
+  (tuple)
+  (dictionary)
+  (set)
+  (parenthesized_expression)
+  (generator_expression)
+  (list_comprehension)
+  (set_comprehension)
+  (dictionary_comprehension)
+  (tuple_pattern)
+  (list_pattern)
+  (argument_list)
+  (parameters)
+] @indent
+
+; Closing brackets: drop back down to the level of the line that opened
+; them, rather than inheriting the hanging-content level above.
+[
+  ")"
+  "]"
+  "}"
+] @outdent
+
+; Clause keywords: re-align to the level of the `if`/`try` they belong to
+; (rather than the level of the block above them) once fully typed. These are matched by
+; `Language::outdent_keywords`, not read off the tree directly the way the brackets above are
+; -- Python's grammar lexes indentation itself, so e.g. `elif` only parses as part of an
+; `elif_clause` once its line is *already* dedented to align with `if`, which is exactly the
+; correction being computed. See `compute_reindent_for_outdent_keyword` in
+; `src/indent_query.rs` for how these are actually used.
+(elif_clause "elif" @outdent)
+(else_clause "else" @outdent)
+(except_clause "except" @outdent)
+(finally_clause "finally" @outdent)
+(except_group_clause "except*" @outdent)
+
+; NOTE (known gap, not introduced by the above): a bare `try: ...` with no `except`/`finally`
+; at all is not valid Python, and tree-sitter-python's grammar reports large `ERROR` nodes for
+; it that can swallow even the enclosing `def`/`class` -- the same quirk Helix's own
+; indents.scm has a handful of dedicated `ERROR`-node patterns to work around (using `@extend`,
+; which this POC does not implement). While a `try` is missing its first `except`/`finally`,
+; both indentation paths above can therefore under-indent. Typing the first `except`/`finally`
+; itself is unaffected, since `keyword_outdent_target` only ever looks at the *previous* line.

--- a/src/components/editor/mod.rs
+++ b/src/components/editor/mod.rs
@@ -4880,13 +4880,84 @@ impl Editor {
     }
 
     fn insert_char(&mut self, context: &Context, c: char) -> Result<Dispatches, anyhow::Error> {
-        self.insert(
+        let dispatches = self.insert(
             &c.to_string(),
             context,
             EditHistoryKind::Fine {
                 insert_session: self.insert_session.clone(),
             },
-        )
+        )?;
+        Ok(dispatches.chain(self.maybe_reindent_current_line_after_outdent_keystroke(context)?))
+    }
+
+    /// POC follow-up: right after `insert_char` above, check whether the keystroke just
+    /// completed a token `indents.scm` captures `@outdent` -- e.g. a closing `)`/`]`/`}`, or
+    /// (for Python) `elif`/`else`/`except`/`finally` -- and if so, correct the current line's
+    /// indentation in place. See `indent_query::compute_reindent_for_outdent_keyword` for the
+    /// actual detection/computation; this only turns its answer into an edit.
+    fn maybe_reindent_current_line_after_outdent_keystroke(
+        &mut self,
+        context: &Context,
+    ) -> anyhow::Result<Dispatches> {
+        self.buffer_mut().reparse_tree()?;
+
+        let edit_transaction = EditTransaction::from_action_groups({
+            let buffer = self.buffer();
+            self.selection_set
+                .map(|selection| -> anyhow::Result<Option<ActionGroup>> {
+                    let cursor = selection.extended_range().start;
+                    let Some(new_indent) = crate::indent_query::compute_reindent_for_outdent_keyword(
+                        &buffer,
+                        cursor,
+                        context.indent_char(),
+                        context.indent_width(),
+                    )?
+                    else {
+                        return Ok(None);
+                    };
+
+                    let current_line_index = buffer.char_to_line(cursor)?;
+                    let line_start = buffer.line_to_char(current_line_index)?;
+                    let old_leading_whitespace_chars = buffer
+                        .get_line_by_line_index(current_line_index)
+                        .map(|line| {
+                            line.to_string()
+                                .chars()
+                                .take_while(|c| c.is_whitespace() && c != &'\n')
+                                .count()
+                        })
+                        .unwrap_or_default();
+                    let old_range =
+                        (line_start..(line_start + old_leading_whitespace_chars)).into();
+                    let new_indent_chars = new_indent.chars().count();
+                    let new_cursor = if new_indent_chars >= old_leading_whitespace_chars {
+                        cursor + (new_indent_chars - old_leading_whitespace_chars)
+                    } else {
+                        cursor - (old_leading_whitespace_chars - new_indent_chars)
+                    };
+
+                    Ok(Some(ActionGroup::new(
+                        [
+                            Action::Edit(Edit::new(
+                                self.buffer().rope(),
+                                old_range,
+                                new_indent.into(),
+                            )),
+                            Action::Select(
+                                selection
+                                    .clone()
+                                    .set_range((new_cursor..new_cursor).into())
+                                    .set_initial_range(None),
+                            ),
+                        ]
+                        .to_vec(),
+                    )))
+                })
+                .into_iter()
+                .filter_map(|result| result.ok().flatten())
+                .collect()
+        });
+        self.apply_edit_transaction(edit_transaction, context)
     }
 
     fn fine_undo(&mut self, context: &Context) -> Result<Dispatches, anyhow::Error> {

--- a/src/components/editor/mod.rs
+++ b/src/components/editor/mod.rs
@@ -4898,6 +4898,26 @@ impl Editor {
         &mut self,
         context: &Context,
     ) -> anyhow::Result<Dispatches> {
+        // Reparsing the tree is expensive (and, in tests, count-tracked as an observable cost),
+        // so it must not happen on every keystroke -- only ever on the rare one that could
+        // plausibly complete an `@outdent`-captured token. `might_complete_outdent_token` makes
+        // that call cheaply, off the buffer's rope content alone, with no tree involved.
+        let any_selection_might_outdent = self
+            .selection_set
+            .map(|selection| {
+                crate::indent_query::might_complete_outdent_token(
+                    &self.buffer(),
+                    selection.extended_range().start,
+                )
+            })
+            .into_iter()
+            .collect::<anyhow::Result<Vec<_>>>()?
+            .into_iter()
+            .any(|might_outdent| might_outdent);
+        if !any_selection_might_outdent {
+            return Ok(Dispatches::default());
+        }
+
         self.buffer_mut().reparse_tree()?;
 
         let edit_transaction = EditTransaction::from_action_groups({
@@ -4957,7 +4977,24 @@ impl Editor {
                 .filter_map(|result| result.ok().flatten())
                 .collect()
         });
-        self.apply_edit_transaction(edit_transaction, context)
+        // Guard against pushing a no-op edit onto the undo stack: most keystrokes do not
+        // trigger a reindent, and `apply_edit_transaction_with_edit_history_kind` always
+        // records a history entry, even an empty one. Applying it unconditionally with the
+        // default `EditHistoryKind::Coarse` would (a) inject a spurious Coarse boundary after
+        // every keystroke, breaking `CoarseUndo`/`CoarseRedo` grouping of the surrounding fine
+        // insert edits, and (b) even when non-empty, split what should be a single fine insert
+        // session into two separate history entries. So: skip entirely when there is nothing to
+        // do, and otherwise apply it as part of the same fine insert session as `insert_char`.
+        if edit_transaction.edits().is_empty() {
+            return Ok(Dispatches::default());
+        }
+        self.apply_edit_transaction_with_edit_history_kind(
+            edit_transaction,
+            context,
+            EditHistoryKind::Fine {
+                insert_session: self.insert_session.clone(),
+            },
+        )
     }
 
     fn fine_undo(&mut self, context: &Context) -> Result<Dispatches, anyhow::Error> {

--- a/src/components/editor/mod.rs
+++ b/src/components/editor/mod.rs
@@ -1248,16 +1248,28 @@ impl Editor {
 
                     let current_line = buffer.get_line_by_line_index(current_line_index);
 
-                    let indent = "\n".to_string()
-                        + current_line
-                            .map(|line| {
-                                line.to_string()
-                                    .chars()
-                                    .take_while(|c| c.is_whitespace() && c != &'\n')
-                                    .join("")
-                            })
-                            .unwrap_or_default()
-                            .as_str();
+                    let current_line_indent = current_line
+                        .map(|line| {
+                            line.to_string()
+                                .chars()
+                                .take_while(|c| c.is_whitespace() && c != &'\n')
+                                .join("")
+                        })
+                        .unwrap_or_default();
+
+                    // POC (issue #525): bump the indentation by one level
+                    // when the line being left opens a new block/scope,
+                    // per the language's `indents.scm` query.
+                    let extra_indent_level =
+                        crate::indent_query::compute_extra_indent_level(&buffer, cursor)
+                            .unwrap_or(0);
+                    let extra_indent: String =
+                        std::iter::repeat_n(context.indent_char(), context.indent_width())
+                            .collect::<String>()
+                            .repeat(extra_indent_level);
+
+                    let indent =
+                        "\n".to_string() + current_line_indent.as_str() + extra_indent.as_str();
 
                     let range_start = cursor + indent.chars().count();
                     Ok(ActionGroup::new(

--- a/src/components/editor/mod.rs
+++ b/src/components/editor/mod.rs
@@ -1267,8 +1267,7 @@ impl Editor {
                         }
                         None => {
                             let current_line_index = buffer.char_to_line(cursor)?;
-                            let current_line =
-                                buffer.get_line_by_line_index(current_line_index);
+                            let current_line = buffer.get_line_by_line_index(current_line_index);
                             let current_line_indent = current_line
                                 .map(|line| {
                                     line.to_string()
@@ -4906,12 +4905,13 @@ impl Editor {
             self.selection_set
                 .map(|selection| -> anyhow::Result<Option<ActionGroup>> {
                     let cursor = selection.extended_range().start;
-                    let Some(new_indent) = crate::indent_query::compute_reindent_for_outdent_keyword(
-                        &buffer,
-                        cursor,
-                        context.indent_char(),
-                        context.indent_width(),
-                    )?
+                    let Some(new_indent) =
+                        crate::indent_query::compute_reindent_for_outdent_keyword(
+                            &buffer,
+                            cursor,
+                            context.indent_char(),
+                            context.indent_width(),
+                        )?
                     else {
                         return Ok(None);
                     };

--- a/src/components/editor/mod.rs
+++ b/src/components/editor/mod.rs
@@ -1239,37 +1239,47 @@ impl Editor {
     }
 
     fn enter_newline(&mut self, context: &Context) -> anyhow::Result<Dispatches> {
+        // Edits made while already in insert mode do not eagerly reparse the tree (see
+        // `apply_edit_transaction_with_edit_history_kind`), so force a reparse here to make
+        // sure any `indents.scm`-driven computation below sees the content typed so far in
+        // the current insert session, not a stale tree from before it started.
+        self.buffer_mut().reparse_tree()?;
+
         let edit_transaction = EditTransaction::from_action_groups({
             let buffer = self.buffer();
             self.selection_set
                 .map(|selection| -> anyhow::Result<_> {
                     let cursor = selection.extended_range().start;
-                    let current_line_index = buffer.char_to_line(cursor)?;
 
-                    let current_line = buffer.get_line_by_line_index(current_line_index);
-
-                    let current_line_indent = current_line
-                        .map(|line| {
-                            line.to_string()
-                                .chars()
-                                .take_while(|c| c.is_whitespace() && c != &'\n')
-                                .join("")
-                        })
-                        .unwrap_or_default();
-
-                    // POC (issue #525): bump the indentation by one level
-                    // when the line being left opens a new block/scope,
-                    // per the language's `indents.scm` query.
-                    let extra_indent_level =
-                        crate::indent_query::compute_extra_indent_level(&buffer, cursor)
-                            .unwrap_or(0);
-                    let extra_indent: String =
-                        std::iter::repeat_n(context.indent_char(), context.indent_width())
-                            .collect::<String>()
-                            .repeat(extra_indent_level);
-
-                    let indent =
-                        "\n".to_string() + current_line_indent.as_str() + extra_indent.as_str();
+                    // POC (issue #525): when the language supplies an `indents.scm`, let it
+                    // fully decide the new line's indentation instead of falling back to the
+                    // default heuristic of copying the current line's own indentation --
+                    // a hand-authored `indents.scm` is assumed to know better than whatever
+                    // whitespace happens to precede the cursor.
+                    let indent = match crate::indent_query::compute_indent_for_new_line(
+                        &buffer,
+                        cursor,
+                        context.indent_char(),
+                        context.indent_width(),
+                    )? {
+                        Some(query_computed_indent) => {
+                            "\n".to_string() + query_computed_indent.as_str()
+                        }
+                        None => {
+                            let current_line_index = buffer.char_to_line(cursor)?;
+                            let current_line =
+                                buffer.get_line_by_line_index(current_line_index);
+                            let current_line_indent = current_line
+                                .map(|line| {
+                                    line.to_string()
+                                        .chars()
+                                        .take_while(|c| c.is_whitespace() && c != &'\n')
+                                        .join("")
+                                })
+                                .unwrap_or_default();
+                            "\n".to_string() + current_line_indent.as_str()
+                        }
+                    };
 
                     let range_start = cursor + indent.chars().count();
                     Ok(ActionGroup::new(

--- a/src/components/test_editor.rs
+++ b/src/components/test_editor.rs
@@ -1335,6 +1335,61 @@ fn enter_newline_auto_indent_python_typed_within_insert_session() -> anyhow::Res
 }
 
 #[test]
+fn enter_newline_auto_indent_python_outdents_closing_bracket() -> anyhow::Result<()> {
+    // POC follow-up: pressing Enter right after `(`, with the matching `)` immediately
+    // following the cursor, should push `)` onto its own line *without* indenting it --
+    // `indents.scm`'s `@outdent` on `)`/`]`/`}` is what tells `compute_indent_for_new_line`
+    // to drop the level the (still-open) `argument_list` would otherwise add.
+    execute_test(|s| {
+        let path = s.temp_dir().join("test_outdent.py").unwrap();
+        std::fs::write(path.to_path_buf(), "").unwrap();
+        Box::new([
+            App(OpenFile {
+                path,
+                owner: BufferOwner::User,
+                focus: true,
+            }),
+            Editor(SetContent("foo()".to_string())),
+            Editor(MoveToLastChar),
+            Editor(MoveCharacterBack), // cursor now between `(` and `)`
+            Editor(EnterInsertMode(Direction::Start)),
+            App(HandleKeyEvent(key!("enter"))),
+            Expect(CurrentComponentContent("foo(\n)")),
+        ])
+    })
+}
+
+#[test]
+fn typing_elif_outdents_it_to_match_its_if() -> anyhow::Result<()> {
+    // POC follow-up: pressing Enter after `pass` auto-indents the new line to 4 spaces
+    // (matching `pass`, the normal continuation level) -- and Python's grammar can only
+    // recognize `elif` as an `elif_clause` once it is dedented back to `if`'s own column, so
+    // typing it out at that (currently wrong) 4-space column must correct the line in place,
+    // one keystroke at a time via `insert_char`, not just when Enter is pressed.
+    execute_test(|s| {
+        let path = s.temp_dir().join("test_elif.py").unwrap();
+        std::fs::write(path.to_path_buf(), "").unwrap();
+        Box::new([
+            App(OpenFile {
+                path,
+                owner: BufferOwner::User,
+                focus: true,
+            }),
+            Editor(SetContent("if x:\n    pass".to_string())),
+            Editor(MoveToLastChar),
+            Editor(EnterInsertMode(Direction::End)),
+            App(HandleKeyEvent(key!("enter"))),
+            Expect(CurrentComponentContent("if x:\n    pass\n    ")),
+            App(HandleKeyEvent(key!("e"))),
+            App(HandleKeyEvent(key!("l"))),
+            App(HandleKeyEvent(key!("i"))),
+            App(HandleKeyEvent(key!("f"))),
+            Expect(CurrentComponentContent("if x:\n    pass\nelif")),
+        ])
+    })
+}
+
+#[test]
 fn insert_mode_start() -> anyhow::Result<()> {
     execute_test(|s| {
         Box::new([

--- a/src/components/test_editor.rs
+++ b/src/components/test_editor.rs
@@ -1310,6 +1310,31 @@ fn enter_newline_auto_indent_python() -> anyhow::Result<()> {
 }
 
 #[test]
+fn enter_newline_auto_indent_python_typed_within_insert_session() -> anyhow::Result<()> {
+    // Regression test: unlike `enter_newline_auto_indent_python` above, this types the
+    // whole compound statement via insert-mode keystrokes -- without ever leaving insert
+    // mode before pressing Enter -- matching how a user actually types it. The tree is
+    // not eagerly reparsed on every insert-mode edit, so `enter_newline` must force a
+    // reparse itself before computing the indent, rather than relying on a tree that is
+    // only refreshed on leaving insert mode.
+    execute_test(|s| {
+        let path = s.temp_dir().join("test_typed.py").unwrap();
+        std::fs::write(path.to_path_buf(), "").unwrap();
+        Box::new([
+            App(OpenFile {
+                path,
+                owner: BufferOwner::User,
+                focus: true,
+            }),
+            Editor(EnterInsertMode(Direction::Start)),
+            Editor(Insert("def foo():\n    if x:".to_string())),
+            App(HandleKeyEvent(key!("enter"))),
+            Expect(CurrentComponentContent("def foo():\n    if x:\n        ")),
+        ])
+    })
+}
+
+#[test]
 fn insert_mode_start() -> anyhow::Result<()> {
     execute_test(|s| {
         Box::new([

--- a/src/components/test_editor.rs
+++ b/src/components/test_editor.rs
@@ -1287,6 +1287,29 @@ fn enter_newline() -> anyhow::Result<()> {
 }
 
 #[test]
+fn enter_newline_auto_indent_python() -> anyhow::Result<()> {
+    // POC for issue #525: pressing Enter right after a Python line that
+    // opens a new block (ends with `:`) should indent one level deeper,
+    // instead of only copying the current line's own indentation.
+    execute_test(|s| {
+        let path = s.temp_dir().join("test.py").unwrap();
+        std::fs::write(path.to_path_buf(), "").unwrap();
+        Box::new([
+            App(OpenFile {
+                path,
+                owner: BufferOwner::User,
+                focus: true,
+            }),
+            Editor(SetContent("def foo():\n    if x:".to_string())),
+            Editor(MoveToLastChar),
+            Editor(EnterInsertMode(Direction::End)),
+            App(HandleKeyEvent(key!("enter"))),
+            Expect(CurrentComponentContent("def foo():\n    if x:\n        ")),
+        ])
+    })
+}
+
+#[test]
 fn insert_mode_start() -> anyhow::Result<()> {
     execute_test(|s| {
         Box::new([

--- a/src/indent_query.rs
+++ b/src/indent_query.rs
@@ -186,10 +186,43 @@ pub fn compute_reindent_for_outdent_keyword(
         return Ok(None);
     };
 
-    // The token that begins the current line (skipping leading whitespace) is the only thing
-    // ever eligible to trigger a reindent, and only once the user has finished typing it
-    // exactly (nothing follows it on the line) -- so a still-incomplete prefix (`eli`) or
-    // unrelated typing elsewhere on the line never touches this line's indentation.
+    let current_line_index = buffer.char_to_line(cursor)?;
+    let line_start = buffer.line_to_char(current_line_index)?;
+    let Some((typed, content_start)) = typed_prefix_on_current_line(buffer, cursor)? else {
+        return Ok(None);
+    };
+
+    if let Some(target) = bracket_outdent_target(
+        tree,
+        &indent_node_ranges,
+        &outdent_node_ranges,
+        buffer.char_to_byte(content_start)?,
+        buffer.char_to_byte(cursor)?,
+        indent_char,
+        indent_width,
+    ) {
+        return Ok(Some(target));
+    }
+
+    keyword_outdent_target(
+        buffer,
+        &outdent_keywords(&query, &query_source),
+        &typed,
+        current_line_index,
+        line_start,
+        indent_char,
+        indent_width,
+    )
+}
+
+/// Returns the current line's content from just past its leading whitespace up to `cursor`
+/// (the `typed` text both outdent paths key off of), together with the `CharIndex` that
+/// content starts at -- or `None` when `cursor` has not moved past that leading whitespace
+/// yet, i.e. nothing has been typed on this line so far.
+fn typed_prefix_on_current_line(
+    buffer: &Buffer,
+    cursor: CharIndex,
+) -> anyhow::Result<Option<(String, CharIndex)>> {
     let current_line_index = buffer.char_to_line(cursor)?;
     let line_start = buffer.line_to_char(current_line_index)?;
     let line = buffer
@@ -216,28 +249,56 @@ pub fn compute_reindent_for_outdent_keyword(
     if !rest_of_line.trim_end_matches('\n').is_empty() {
         return Ok(None);
     }
+    Ok(Some((typed, content_start)))
+}
 
-    if let Some(target) = bracket_outdent_target(
-        tree,
-        &indent_node_ranges,
-        &outdent_node_ranges,
-        buffer.char_to_byte(content_start)?,
-        buffer.char_to_byte(cursor)?,
-        indent_char,
-        indent_width,
-    ) {
-        return Ok(Some(target));
-    }
+/// Cheap prefilter for `compute_reindent_for_outdent_keyword`: reports whether the keystroke
+/// that just landed at `cursor` could possibly complete an `@outdent`-captured token (a closing
+/// bracket or a clause keyword), using only the buffer's rope content and `indents.scm`'s own
+/// literal patterns -- crucially, without touching the syntax tree at all.
+///
+/// `compute_reindent_for_outdent_keyword` itself needs an up-to-date tree (to recognize the
+/// bracket that was just closed), which costs a full reparse -- expensive enough that it must
+/// not happen on every keystroke. This lets the caller reparse only on the rare keystroke this
+/// reports `true` for, since both real paths only ever fire when the current line's typed
+/// content, with nothing following the cursor, exactly matches one of these literals.
+pub fn might_complete_outdent_token(buffer: &Buffer, cursor: CharIndex) -> anyhow::Result<bool> {
+    let Some(language) = buffer.language() else {
+        return Ok(false);
+    };
+    let Some(query_source) = language.indent_query() else {
+        return Ok(false);
+    };
+    let Some(ts_language) = buffer.treesitter_language() else {
+        return Ok(false);
+    };
+    let Some((typed, _)) = typed_prefix_on_current_line(buffer, cursor)? else {
+        return Ok(false);
+    };
 
-    keyword_outdent_target(
-        buffer,
-        &outdent_keywords(&query, &query_source),
-        &typed,
-        current_line_index,
-        line_start,
-        indent_char,
-        indent_width,
-    )
+    let query = Query::new(&ts_language, &query_source)?;
+    Ok(outdent_trigger_literals(&query, &query_source)
+        .iter()
+        .any(|literal| literal == &typed))
+}
+
+/// Every literal string pattern `indents.scm` captures `@outdent` (e.g. `"elif"` or `")"`),
+/// regardless of shape -- the union of what `outdent_keywords` (identifier-shaped only) and
+/// `bracket_outdent_target`'s tree-based bracket recognition each handle. Used by
+/// `might_complete_outdent_token`, which -- unlike those two -- has no tree to read a bracket's
+/// token text off of, and so must match against literal patterns for brackets too.
+fn outdent_trigger_literals(query: &Query, query_source: &str) -> Vec<String> {
+    let literal = regex::Regex::new(r#""([^"\\]+)"\s*@outdent\b"#).expect("static regex is valid");
+    (0..query.pattern_count())
+        .flat_map(|index| {
+            let pattern_source = &query_source
+                [query.start_byte_for_pattern(index)..query.end_byte_for_pattern(index)];
+            literal
+                .captures_iter(pattern_source)
+                .map(|captures| captures[1].to_string())
+                .collect::<Vec<_>>()
+        })
+        .collect()
 }
 
 /// Derives the keyword literals `keyword_outdent_target` matches typed text against (e.g.

--- a/src/indent_query.rs
+++ b/src/indent_query.rs
@@ -1,0 +1,115 @@
+use tree_sitter::{Query, QueryCursor, StreamingIterator};
+
+use crate::{buffer::Buffer, selection::CharIndex};
+
+/// POC: computes how many extra indent levels should be added on top of the
+/// current line's own indentation when the user presses Enter, by running
+/// the language's `indents.scm` query (see `Language::indent_query`) and
+/// checking whether the line being left opens one or more `@indent` scopes
+/// that are still unclosed at the cursor.
+///
+/// Only the "does this line open a new scope" question is answered here
+/// (deliberately not the full Helix-style "count every enclosing scope"
+/// algorithm), because the existing caller already copies the current
+/// line's own indentation verbatim -- we only need to know whether to add
+/// *one more* level on top of that.
+pub fn compute_extra_indent_level(buffer: &Buffer, cursor: CharIndex) -> anyhow::Result<usize> {
+    let Some(language) = buffer.language() else {
+        return Ok(0);
+    };
+    let Some(query_source) = language.indent_query() else {
+        return Ok(0);
+    };
+    let Some(ts_language) = buffer.treesitter_language() else {
+        return Ok(0);
+    };
+    let Some(tree) = buffer.tree() else {
+        return Ok(0);
+    };
+    let current_line = buffer.char_to_line(cursor)?;
+
+    let query = Query::new(&ts_language, &query_source)?;
+    let Some(indent_capture_index) = query.capture_index_for_name("indent") else {
+        return Ok(0);
+    };
+
+    let source = buffer.rope().to_string();
+    let mut query_cursor = QueryCursor::new();
+    let mut matches = query_cursor.matches(&query, tree.root_node(), source.as_bytes());
+
+    let mut opens_new_scope = false;
+    while let Some(m) = matches.next() {
+        for capture in m.captures {
+            if capture.index != indent_capture_index {
+                continue;
+            }
+            let node = capture.node;
+            let start_row = node.start_position().row;
+            // The "same-line" rule, borrowed from Helix's indent
+            // algorithm: several scopes opening on one physical line only
+            // ever add one level. We only care whether a scope *begins* on
+            // the line being left.
+            //
+            // Note this is deliberately simple and has a known false
+            // positive: a single-line compound statement whose body is
+            // already present on the same line (e.g. `if x: pass`) will
+            // still be counted as "opening a scope" here, since
+            // tree-sitter-python's error recovery does not reliably let us
+            // tell "body already closed on this line" apart from "body not
+            // written yet" -- see indent_query.rs POC notes.
+            if start_row == current_line {
+                opens_new_scope = true;
+            }
+        }
+    }
+
+    Ok(if opens_new_scope { 1 } else { 0 })
+}
+
+#[cfg(test)]
+mod test_compute_extra_indent_level {
+    use super::*;
+
+    fn python_buffer(text: &str) -> Buffer {
+        let language = shared::languages::languages()
+            .get("python")
+            .unwrap()
+            .clone();
+        let ts_language = language.tree_sitter_language().unwrap();
+        let mut buffer = Buffer::new(Some(ts_language), text);
+        buffer.set_language(language).unwrap();
+        buffer
+    }
+
+    #[test]
+    fn opens_extra_level_after_compound_statement_header() -> anyhow::Result<()> {
+        let text = "def foo():\n    if x:";
+        let buffer = python_buffer(text);
+        let cursor = CharIndex(text.chars().count());
+        assert_eq!(compute_extra_indent_level(&buffer, cursor)?, 1);
+        Ok(())
+    }
+
+    #[test]
+    fn no_extra_level_on_a_plain_statement() -> anyhow::Result<()> {
+        let text = "def foo():\n    x = 1";
+        let buffer = python_buffer(text);
+        let cursor = CharIndex(text.chars().count());
+        assert_eq!(compute_extra_indent_level(&buffer, cursor)?, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn non_python_language_is_unaffected() -> anyhow::Result<()> {
+        // Rust's `Language::indent_query` is not implemented in this POC,
+        // so it should always fall back to 0 extra levels.
+        let language = shared::languages::languages().get("rust").unwrap().clone();
+        let ts_language = language.tree_sitter_language().unwrap();
+        let text = "fn foo() {";
+        let mut buffer = Buffer::new(Some(ts_language), text);
+        buffer.set_language(language)?;
+        let cursor = CharIndex(text.chars().count());
+        assert_eq!(compute_extra_indent_level(&buffer, cursor)?, 0);
+        Ok(())
+    }
+}

--- a/src/indent_query.rs
+++ b/src/indent_query.rs
@@ -1,8 +1,44 @@
 use std::collections::BTreeSet;
 
-use tree_sitter::{Query, QueryCursor, StreamingIterator};
+use tree_sitter::{Query, QueryCursor, StreamingIterator, Tree};
 
 use crate::{buffer::Buffer, selection::CharIndex};
+
+/// Byte ranges of every node in a tree captured by a particular capture name.
+type NodeRanges = Vec<(usize, usize)>;
+
+/// Runs `query` over `tree` and returns the byte ranges of every node captured by `@indent`
+/// and (if the query defines it) `@outdent`, so callers can test ancestors of a position for
+/// membership. Shared by both `compute_indent_for_new_line` and
+/// `compute_reindent_for_outdent_keyword`.
+fn indent_and_outdent_ranges(
+    query: &Query,
+    tree: &Tree,
+    source: &str,
+) -> anyhow::Result<Option<(NodeRanges, NodeRanges)>> {
+    let Some(indent_capture_index) = query.capture_index_for_name("indent") else {
+        return Ok(None);
+    };
+    let outdent_capture_index = query.capture_index_for_name("outdent");
+
+    let mut query_cursor = QueryCursor::new();
+    let mut matches = query_cursor.matches(query, tree.root_node(), source.as_bytes());
+
+    let mut indent_node_ranges: Vec<(usize, usize)> = Vec::new();
+    let mut outdent_node_ranges: Vec<(usize, usize)> = Vec::new();
+    while let Some(m) = matches.next() {
+        for capture in m.captures {
+            let node = capture.node;
+            let range = (node.start_byte(), node.end_byte());
+            if capture.index == indent_capture_index {
+                indent_node_ranges.push(range);
+            } else if Some(capture.index) == outdent_capture_index {
+                outdent_node_ranges.push(range);
+            }
+        }
+    }
+    Ok(Some((indent_node_ranges, outdent_node_ranges)))
+}
 
 /// POC: computes the indentation string a new line should get when the user
 /// presses Enter, by running the language's `indents.scm` query (see
@@ -22,6 +58,13 @@ use crate::{buffer::Buffer, selection::CharIndex};
 /// indent level for every distinct source line on which an `@indent`-
 /// captured ancestor begins (several `@indent` scopes opening on the same
 /// physical line only ever count once, matching Helix's convention).
+///
+/// `@outdent` is also honoured: when the token immediately *after* the
+/// cursor (i.e. the token that is about to become the first thing on the
+/// new line, since `enter_newline` inserts the indent right before it) is
+/// itself `@outdent`-captured -- e.g. a closing `)`/`]`/`}` -- one level is
+/// subtracted. This is what keeps a hanging continuation like
+/// `foo(\n    <cursor>)` from leaving the pushed-down `)` over-indented.
 pub fn compute_indent_for_new_line(
     buffer: &Buffer,
     cursor: CharIndex,
@@ -42,25 +85,12 @@ pub fn compute_indent_for_new_line(
     };
 
     let query = Query::new(&ts_language, &query_source)?;
-    let Some(indent_capture_index) = query.capture_index_for_name("indent") else {
+    let source = buffer.rope().to_string();
+    let Some((indent_node_ranges, outdent_node_ranges)) =
+        indent_and_outdent_ranges(&query, tree, &source)?
+    else {
         return Ok(None);
     };
-
-    let source = buffer.rope().to_string();
-    let mut query_cursor = QueryCursor::new();
-    let mut matches = query_cursor.matches(&query, tree.root_node(), source.as_bytes());
-
-    // Identify every node captured by `@indent` by its byte range, so ancestors of the
-    // cursor can be tested for membership below.
-    let mut indent_node_ranges: Vec<(usize, usize)> = Vec::new();
-    while let Some(m) = matches.next() {
-        for capture in m.captures {
-            if capture.index == indent_capture_index {
-                let node = capture.node;
-                indent_node_ranges.push((node.start_byte(), node.end_byte()));
-            }
-        }
-    }
 
     // Look at the node covering the character immediately *before* the cursor rather than
     // the cursor's own (zero-width) position: `descendant_for_byte_range` does not descend
@@ -80,11 +110,220 @@ pub fn compute_indent_for_new_line(
         current_node = node.parent();
     }
 
-    let level = indent_rows.len();
+    // The new line will begin with whatever token currently sits right after the cursor
+    // (nothing is inserted there -- `enter_newline` only inserts `"\n" + indent` at the
+    // cursor). If that token -- or an ancestor that starts at the very same byte, i.e. one
+    // that this token is the *first* token of -- is `@outdent`-captured, drop one level.
+    let is_outdent = {
+        let mut current_node = tree.root_node().descendant_for_byte_range(byte, byte);
+        let mut found = false;
+        while let Some(node) = current_node {
+            if node.start_byte() != byte {
+                break;
+            }
+            if outdent_node_ranges.contains(&(node.start_byte(), node.end_byte())) {
+                found = true;
+                break;
+            }
+            current_node = node.parent();
+        }
+        found
+    };
+
+    let level = indent_rows.len().saturating_sub(is_outdent as usize);
     Ok(Some(
         std::iter::repeat_n(indent_char, indent_width)
             .collect::<String>()
             .repeat(level),
+    ))
+}
+
+/// Computes the indentation an *already-typed* line should be corrected to, right after the
+/// keystroke that completes a token captured `@outdent` in that position -- e.g. a closing
+/// `)`/`]`/`}` typed by hand rather than pushed down by Enter, or finishing
+/// `elif`/`else`/`except`/`finally`. Returns `None` when nothing should change.
+///
+/// This covers two genuinely different cases, tried in order:
+///
+/// - **Closing brackets** (`bracket_outdent_target`): tree-sitter parses these regardless of
+///   the line's current (possibly wrong) indentation, so the fix can be read straight off the
+///   real tree, the same way `compute_indent_for_new_line`'s outdent check does.
+/// - **Clause keywords** (`keyword_outdent_target`): Python's grammar lexes indentation itself
+///   (DEDENT/INDENT tokens), so e.g. `elif` only parses as part of an `elif_clause` once the
+///   line is *already* dedented to align with its `if` -- which is exactly the correction this
+///   function exists to make. The real tree can't be used to recognize the line while it is
+///   still wrong, so this path matches the typed text directly against
+///   `Language::outdent_keywords` instead.
+///
+/// Unlike `compute_indent_for_new_line`, this never runs on every keystroke blindly -- both
+/// paths only ever fire on the keystroke that completes a trigger token, matching Helix's own
+/// "reindent as you type these specific keywords" behaviour rather than reformatting arbitrary
+/// lines as the user types unrelated content.
+pub fn compute_reindent_for_outdent_keyword(
+    buffer: &Buffer,
+    cursor: CharIndex,
+    indent_char: char,
+    indent_width: usize,
+) -> anyhow::Result<Option<String>> {
+    let Some(language) = buffer.language() else {
+        return Ok(None);
+    };
+    let Some(query_source) = language.indent_query() else {
+        return Ok(None);
+    };
+    let Some(ts_language) = buffer.treesitter_language() else {
+        return Ok(None);
+    };
+    let Some(tree) = buffer.tree() else {
+        return Ok(None);
+    };
+
+    let query = Query::new(&ts_language, &query_source)?;
+    let source = buffer.rope().to_string();
+    let Some((indent_node_ranges, outdent_node_ranges)) =
+        indent_and_outdent_ranges(&query, tree, &source)?
+    else {
+        return Ok(None);
+    };
+
+    // The token that begins the current line (skipping leading whitespace) is the only thing
+    // ever eligible to trigger a reindent, and only once the user has finished typing it
+    // exactly (nothing follows it on the line) -- so a still-incomplete prefix (`eli`) or
+    // unrelated typing elsewhere on the line never touches this line's indentation.
+    let current_line_index = buffer.char_to_line(cursor)?;
+    let line_start = buffer.line_to_char(current_line_index)?;
+    let line = buffer
+        .get_line_by_line_index(current_line_index)
+        .map(|line| line.to_string())
+        .unwrap_or_default();
+    let leading_whitespace_chars = line
+        .chars()
+        .take_while(|c| c.is_whitespace() && *c != '\n')
+        .count();
+    let content_start = line_start + leading_whitespace_chars;
+    if cursor <= content_start {
+        return Ok(None);
+    }
+    let typed: String = line
+        .chars()
+        .skip(leading_whitespace_chars)
+        .take(cursor.0 - content_start.0)
+        .collect();
+    let rest_of_line: String = line
+        .chars()
+        .skip(leading_whitespace_chars + typed.chars().count())
+        .collect();
+    if !rest_of_line.trim_end_matches('\n').is_empty() {
+        return Ok(None);
+    }
+
+    if let Some(target) = bracket_outdent_target(
+        tree,
+        &indent_node_ranges,
+        &outdent_node_ranges,
+        buffer.char_to_byte(content_start)?,
+        buffer.char_to_byte(cursor)?,
+        indent_char,
+        indent_width,
+    ) {
+        return Ok(Some(target));
+    }
+
+    keyword_outdent_target(
+        buffer,
+        language.outdent_keywords(),
+        &typed,
+        current_line_index,
+        line_start,
+        indent_char,
+        indent_width,
+    )
+}
+
+/// Closing-bracket path of `compute_reindent_for_outdent_keyword`: walks up from the leaf at
+/// `content_start_byte`, skipping every ancestor that -- like the leaf itself -- also starts
+/// there (i.e. is still part of "this line's own opening"), noting along the way whether any of
+/// them is `@outdent`-captured. Once an ancestor with an earlier start byte is reached, resumes
+/// normal `@indent` counting from there, exactly as `compute_indent_for_new_line` does from a
+/// plain cursor position -- this drops the bracket's own contribution to the count without
+/// needing a separate subtraction step. Returns `None` when the token at `content_start_byte`
+/// does not end exactly at `cursor_byte`, or is not itself `@outdent`-captured.
+#[allow(clippy::too_many_arguments)]
+fn bracket_outdent_target(
+    tree: &Tree,
+    indent_node_ranges: &[(usize, usize)],
+    outdent_node_ranges: &[(usize, usize)],
+    content_start_byte: usize,
+    cursor_byte: usize,
+    indent_char: char,
+    indent_width: usize,
+) -> Option<String> {
+    let leaf = tree
+        .root_node()
+        .descendant_for_byte_range(content_start_byte, content_start_byte)?;
+    if leaf.end_byte() != cursor_byte {
+        return None;
+    }
+
+    let mut is_outdent = false;
+    let mut current_node = Some(leaf);
+    while let Some(node) = current_node {
+        if node.start_byte() != content_start_byte {
+            break;
+        }
+        if outdent_node_ranges.contains(&(node.start_byte(), node.end_byte())) {
+            is_outdent = true;
+        }
+        current_node = node.parent();
+    }
+    if !is_outdent {
+        return None;
+    }
+
+    let mut indent_rows = BTreeSet::new();
+    while let Some(node) = current_node {
+        if indent_node_ranges.contains(&(node.start_byte(), node.end_byte())) {
+            indent_rows.insert(node.start_position().row);
+        }
+        current_node = node.parent();
+    }
+
+    Some(
+        std::iter::repeat_n(indent_char, indent_width)
+            .collect::<String>()
+            .repeat(indent_rows.len()),
+    )
+}
+
+/// Clause-keyword path of `compute_reindent_for_outdent_keyword`: fires when `typed` (the
+/// current line's content up to the cursor, with nothing after it) exactly matches one of
+/// `outdent_keywords`. The target is one level less than whatever indentation a brand new line
+/// would get if Enter were pressed at the end of the *previous* line -- i.e. the level a normal
+/// body statement continuing that block would get, minus one, which is where a clause keyword
+/// belongs (aligned with the statement it is a clause of, not with that statement's body).
+/// Reusing `compute_indent_for_new_line` this way relies only on the previous line, which --
+/// unlike the current, still-wrongly-indented one -- is already validly parsed.
+fn keyword_outdent_target(
+    buffer: &Buffer,
+    outdent_keywords: &[&str],
+    typed: &str,
+    current_line_index: usize,
+    line_start: CharIndex,
+    indent_char: char,
+    indent_width: usize,
+) -> anyhow::Result<Option<String>> {
+    if current_line_index == 0 || !outdent_keywords.contains(&typed) {
+        return Ok(None);
+    }
+    let one_level = std::iter::repeat_n(indent_char, indent_width).collect::<String>();
+    let outer_indent =
+        compute_indent_for_new_line(buffer, line_start - 1, indent_char, indent_width)?
+            .unwrap_or_default();
+    Ok(Some(
+        outer_indent
+            .strip_suffix(one_level.as_str())
+            .unwrap_or("")
+            .to_string(),
     ))
 }
 
@@ -140,6 +379,51 @@ mod test_compute_indent_for_new_line {
     }
 
     #[test]
+    fn indents_hanging_content_inside_an_open_bracket() -> anyhow::Result<()> {
+        // The `(` is closed later on the same statement, so `argument_list` parses cleanly
+        // and the cursor -- placed right after `(`, before `a` -- is inside it.
+        let text = "foo(a)";
+        let buffer = python_buffer(text);
+        let cursor = CharIndex(4); // right after the `(`
+        assert_eq!(
+            compute_indent_for_new_line(&buffer, cursor, ' ', 4)?,
+            Some("    ".to_string())
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn outdents_a_closing_bracket_pushed_onto_its_own_line() -> anyhow::Result<()> {
+        // Cursor sits right after `(`, with the matching `)` immediately following it (as
+        // it would after typing `foo()` and then moving the cursor back inside). Pressing
+        // Enter here should push `)` down without indenting it, since it is closing the
+        // bracket rather than continuing the hanging content.
+        let text = "foo()";
+        let buffer = python_buffer(text);
+        let cursor = CharIndex(4); // right after the `(`
+        assert_eq!(
+            compute_indent_for_new_line(&buffer, cursor, ' ', 4)?,
+            Some("".to_string())
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn outdent_does_not_cancel_an_indent_level_from_an_unrelated_ancestor() -> anyhow::Result<()> {
+        // Nested one level inside `def foo():`, then a further hanging bracket -- the
+        // outdent from the closing `)` should only cancel the bracket's own level, not
+        // the `function_definition`'s.
+        let text = "def foo():\n    bar()";
+        let buffer = python_buffer(text);
+        let cursor = CharIndex(text.chars().count() - 1); // right after the `(`
+        assert_eq!(
+            compute_indent_for_new_line(&buffer, cursor, ' ', 4)?,
+            Some("    ".to_string())
+        );
+        Ok(())
+    }
+
+    #[test]
     fn non_python_language_is_unaffected() -> anyhow::Result<()> {
         // Rust's `Language::indent_query` is not implemented in this POC, so callers
         // should fall back to the default heuristic in that case.
@@ -150,6 +434,94 @@ mod test_compute_indent_for_new_line {
         buffer.set_language(language)?;
         let cursor = CharIndex(text.chars().count());
         assert_eq!(compute_indent_for_new_line(&buffer, cursor, ' ', 4)?, None);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test_compute_reindent_for_outdent_keyword {
+    use super::*;
+
+    fn python_buffer(text: &str) -> Buffer {
+        let language = shared::languages::languages()
+            .get("python")
+            .unwrap()
+            .clone();
+        let ts_language = language.tree_sitter_language().unwrap();
+        let mut buffer = Buffer::new(Some(ts_language), text);
+        buffer.set_language(language).unwrap();
+        buffer
+    }
+
+    #[test]
+    fn outdents_elif_to_match_its_if() -> anyhow::Result<()> {
+        // `elif` is still sitting at the same (wrong) column as `pass` above it -- tree-sitter
+        // therefore can't recognize it as an `elif_clause` yet (Python's grammar requires it to
+        // already be dedented), which is exactly the case `keyword_outdent_target` exists for.
+        let text = "if x:\n    pass\n    elif";
+        let buffer = python_buffer(text);
+        let cursor = CharIndex(text.chars().count()); // right after the `f` of `elif`
+        assert_eq!(
+            compute_reindent_for_outdent_keyword(&buffer, cursor, ' ', 4)?,
+            Some("".to_string())
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn outdents_a_second_except_relative_to_a_nested_try() -> anyhow::Result<()> {
+        // A bare `try: pass` with no `except`/`finally` at all is not valid Python, and
+        // tree-sitter-python's grammar reports large `ERROR` nodes for it that swallow even
+        // the enclosing `def` (the same pre-existing grammar quirk Helix's own indents.scm
+        // has a dedicated `ERROR`-node workaround for, which this POC does not port). So this
+        // exercises a `try` that is already valid (has one `except` before the one being
+        // typed) instead, keeping the surrounding tree -- and thus `function_definition`'s
+        // and `try_statement`'s `@indent` levels -- intact.
+        let text = "def foo():\n    try:\n        pass\n    except E:\n        pass\n    except";
+        let buffer = python_buffer(text);
+        let cursor = CharIndex(text.chars().count());
+        assert_eq!(
+            compute_reindent_for_outdent_keyword(&buffer, cursor, ' ', 4)?,
+            Some("    ".to_string())
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn does_nothing_while_the_keyword_is_still_incomplete() -> anyhow::Result<()> {
+        let text = "if x:\n    pass\n    eli";
+        let buffer = python_buffer(text);
+        let cursor = CharIndex(text.chars().count());
+        assert_eq!(
+            compute_reindent_for_outdent_keyword(&buffer, cursor, ' ', 4)?,
+            None
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn does_nothing_for_a_plain_statement() -> anyhow::Result<()> {
+        let text = "if x:\n    pass\n    y";
+        let buffer = python_buffer(text);
+        let cursor = CharIndex(text.chars().count());
+        assert_eq!(
+            compute_reindent_for_outdent_keyword(&buffer, cursor, ' ', 4)?,
+            None
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn does_nothing_once_the_cursor_has_moved_past_the_keyword() -> anyhow::Result<()> {
+        // A space was typed after `elif`; the keystroke that completed `elif` itself has
+        // already been handled, so this one should not re-trigger.
+        let text = "if x:\n    pass\n    elif ";
+        let buffer = python_buffer(text);
+        let cursor = CharIndex(text.chars().count());
+        assert_eq!(
+            compute_reindent_for_outdent_keyword(&buffer, cursor, ' ', 4)?,
+            None
+        );
         Ok(())
     }
 }

--- a/src/indent_query.rs
+++ b/src/indent_query.rs
@@ -105,7 +105,28 @@ pub fn compute_indent_for_new_line(
     let mut indent_rows = BTreeSet::new();
     while let Some(node) = current_node {
         if indent_node_ranges.contains(&(node.start_byte(), node.end_byte())) {
-            indent_rows.insert(node.start_position().row);
+            // A bracketed construct (`argument_list`, `list`, ...) that was opened *and*
+            // closed on this same line, entirely before the cursor -- e.g. the cursor right
+            // after `print(f"Do something")` -- must not contribute a level: per the
+            // convention documented on `@indent`/`@outdent` in indents.scm, only a construct
+            // the cursor is still genuinely inside of (an unclosed bracket) counts as hanging
+            // content. It reaches this branch at all only because the lookup below is
+            // deliberately biased one byte to the left (see the comment on `lookup_byte`),
+            // which lands on the closing bracket leaf itself -- whose ancestors naturally
+            // include the very construct it just closed. Detect that case directly: the node
+            // ends exactly at the cursor, and its own last token is `@outdent`-captured (the
+            // closing bracket that ends it), as opposed to e.g. `if_statement`/
+            // `function_definition`, whose last child is never a closing-bracket token.
+            let closed_by_outdent_token = node.end_byte() == byte
+                && node
+                    .child(node.child_count().wrapping_sub(1))
+                    .is_some_and(|last_child| {
+                        outdent_node_ranges
+                            .contains(&(last_child.start_byte(), last_child.end_byte()))
+                    });
+            if !closed_by_outdent_token {
+                indent_rows.insert(node.start_position().row);
+            }
         }
         current_node = node.parent();
     }
@@ -505,6 +526,21 @@ mod test_compute_indent_for_new_line {
         assert_eq!(
             compute_indent_for_new_line(&buffer, cursor, ' ', 4)?,
             Some("    ".to_string())
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn no_extra_level_after_a_call_closed_on_the_same_line() -> anyhow::Result<()> {
+        // Regression test for https://github.com/ki-editor/ki-editor/pull/1685#issuecomment-5453879084:
+        // `argument_list` is opened and closed entirely on this line, before the cursor, so it
+        // must not count as hanging content the way an unclosed bracket would.
+        let text = "def foo():\n    if True:\n        print(f\"Do something\")";
+        let buffer = python_buffer(text);
+        let cursor = CharIndex(text.chars().count());
+        assert_eq!(
+            compute_indent_for_new_line(&buffer, cursor, ' ', 4)?,
+            Some("        ".to_string())
         );
         Ok(())
     }

--- a/src/indent_query.rs
+++ b/src/indent_query.rs
@@ -152,8 +152,8 @@ pub fn compute_indent_for_new_line(
 ///   (DEDENT/INDENT tokens), so e.g. `elif` only parses as part of an `elif_clause` once the
 ///   line is *already* dedented to align with its `if` -- which is exactly the correction this
 ///   function exists to make. The real tree can't be used to recognize the line while it is
-///   still wrong, so this path matches the typed text directly against
-///   `Language::outdent_keywords` instead.
+///   still wrong, so this path matches the typed text directly against the keyword literals
+///   `indents.scm` itself captures `@outdent` (see `outdent_keywords` below) instead.
 ///
 /// Unlike `compute_indent_for_new_line`, this never runs on every keystroke blindly -- both
 /// paths only ever fire on the keystroke that completes a trigger token, matching Helix's own
@@ -231,13 +231,38 @@ pub fn compute_reindent_for_outdent_keyword(
 
     keyword_outdent_target(
         buffer,
-        language.outdent_keywords(),
+        &outdent_keywords(&query, &query_source),
         &typed,
         current_line_index,
         line_start,
         indent_char,
         indent_width,
     )
+}
+
+/// Derives the keyword literals `keyword_outdent_target` matches typed text against (e.g.
+/// `elif`/`else`/`except`/`finally`) directly from `indents.scm`'s own `@outdent`-captured
+/// string patterns (`(elif_clause "elif" @outdent)`), instead of a hand-maintained list --
+/// keeping `indents.scm` the single source of truth so adding, renaming, or removing one of
+/// these keywords there is enough on its own, with nothing to also update in Rust.
+///
+/// Scans each pattern's own source slice (via `Query::start/end_byte_for_pattern`, rather than
+/// the whole query source at once) for a quoted, identifier-shaped literal immediately followed
+/// by `@outdent` -- identifier-shaped so that punctuation outdents like `")"` are left alone,
+/// since those are handled by `bracket_outdent_target` off the real tree instead.
+fn outdent_keywords(query: &Query, query_source: &str) -> Vec<String> {
+    let literal = regex::Regex::new(r#""([A-Za-z_][A-Za-z0-9_*]*)"\s*@outdent\b"#)
+        .expect("static regex is valid");
+    (0..query.pattern_count())
+        .flat_map(|index| {
+            let pattern_source = &query_source
+                [query.start_byte_for_pattern(index)..query.end_byte_for_pattern(index)];
+            literal
+                .captures_iter(pattern_source)
+                .map(|captures| captures[1].to_string())
+                .collect::<Vec<_>>()
+        })
+        .collect()
 }
 
 /// Closing-bracket path of `compute_reindent_for_outdent_keyword`: walks up from the leaf at
@@ -305,14 +330,14 @@ fn bracket_outdent_target(
 /// unlike the current, still-wrongly-indented one -- is already validly parsed.
 fn keyword_outdent_target(
     buffer: &Buffer,
-    outdent_keywords: &[&str],
+    outdent_keywords: &[String],
     typed: &str,
     current_line_index: usize,
     line_start: CharIndex,
     indent_char: char,
     indent_width: usize,
 ) -> anyhow::Result<Option<String>> {
-    if current_line_index == 0 || !outdent_keywords.contains(&typed) {
+    if current_line_index == 0 || !outdent_keywords.iter().any(|keyword| keyword == typed) {
         return Ok(None);
     }
     let one_level = std::iter::repeat_n(indent_char, indent_width).collect::<String>();
@@ -521,6 +546,28 @@ mod test_compute_reindent_for_outdent_keyword {
         assert_eq!(
             compute_reindent_for_outdent_keyword(&buffer, cursor, ' ', 4)?,
             None
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn outdent_keywords_are_derived_from_indents_scm_not_hand_maintained() -> anyhow::Result<()> {
+        // Pins `outdent_keywords` itself, so a future edit to `indents.scm`'s `@outdent`-
+        // captured keyword literals is reflected here automatically instead of silently
+        // drifting out of sync with a separate hand-maintained list.
+        let language = shared::languages::languages()
+            .get("python")
+            .unwrap()
+            .clone();
+        let ts_language = language.tree_sitter_language().unwrap();
+        let query_source = language.indent_query().unwrap();
+        let query = Query::new(&ts_language, &query_source)?;
+
+        let mut keywords = outdent_keywords(&query, &query_source);
+        keywords.sort();
+        assert_eq!(
+            keywords,
+            vec!["elif", "else", "except", "except*", "finally"]
         );
         Ok(())
     }

--- a/src/indent_query.rs
+++ b/src/indent_query.rs
@@ -1,73 +1,95 @@
+use std::collections::BTreeSet;
+
 use tree_sitter::{Query, QueryCursor, StreamingIterator};
 
 use crate::{buffer::Buffer, selection::CharIndex};
 
-/// POC: computes how many extra indent levels should be added on top of the
-/// current line's own indentation when the user presses Enter, by running
-/// the language's `indents.scm` query (see `Language::indent_query`) and
-/// checking whether the line being left opens one or more `@indent` scopes
-/// that are still unclosed at the cursor.
+/// POC: computes the indentation string a new line should get when the user
+/// presses Enter, by running the language's `indents.scm` query (see
+/// `Language::indent_query`) against the buffer's tree.
 ///
-/// Only the "does this line open a new scope" question is answered here
-/// (deliberately not the full Helix-style "count every enclosing scope"
-/// algorithm), because the existing caller already copies the current
-/// line's own indentation verbatim -- we only need to know whether to add
-/// *one more* level on top of that.
-pub fn compute_extra_indent_level(buffer: &Buffer, cursor: CharIndex) -> anyhow::Result<usize> {
+/// Returns `None` when the language does not supply an `indents.scm` (or the
+/// query/tree otherwise is not available) -- callers should fall back to the
+/// default heuristic of copying the current line's own indentation in that
+/// case. When `Some`, the returned string is the *complete* indentation for
+/// the new line, computed from the syntax tree alone -- the default
+/// copy-the-previous-line's-indentation heuristic is not consulted at all,
+/// since a hand-authored `indents.scm` is assumed to know better than
+/// whatever whitespace happens to precede the cursor.
+///
+/// Algorithm (a simplified version of Helix's): find the smallest node
+/// covering the cursor, then walk up through its ancestors counting one
+/// indent level for every distinct source line on which an `@indent`-
+/// captured ancestor begins (several `@indent` scopes opening on the same
+/// physical line only ever count once, matching Helix's convention).
+pub fn compute_indent_for_new_line(
+    buffer: &Buffer,
+    cursor: CharIndex,
+    indent_char: char,
+    indent_width: usize,
+) -> anyhow::Result<Option<String>> {
     let Some(language) = buffer.language() else {
-        return Ok(0);
+        return Ok(None);
     };
     let Some(query_source) = language.indent_query() else {
-        return Ok(0);
+        return Ok(None);
     };
     let Some(ts_language) = buffer.treesitter_language() else {
-        return Ok(0);
+        return Ok(None);
     };
     let Some(tree) = buffer.tree() else {
-        return Ok(0);
+        return Ok(None);
     };
-    let current_line = buffer.char_to_line(cursor)?;
 
     let query = Query::new(&ts_language, &query_source)?;
     let Some(indent_capture_index) = query.capture_index_for_name("indent") else {
-        return Ok(0);
+        return Ok(None);
     };
 
     let source = buffer.rope().to_string();
     let mut query_cursor = QueryCursor::new();
     let mut matches = query_cursor.matches(&query, tree.root_node(), source.as_bytes());
 
-    let mut opens_new_scope = false;
+    // Identify every node captured by `@indent` by its byte range, so ancestors of the
+    // cursor can be tested for membership below.
+    let mut indent_node_ranges: Vec<(usize, usize)> = Vec::new();
     while let Some(m) = matches.next() {
         for capture in m.captures {
-            if capture.index != indent_capture_index {
-                continue;
-            }
-            let node = capture.node;
-            let start_row = node.start_position().row;
-            // The "same-line" rule, borrowed from Helix's indent
-            // algorithm: several scopes opening on one physical line only
-            // ever add one level. We only care whether a scope *begins* on
-            // the line being left.
-            //
-            // Note this is deliberately simple and has a known false
-            // positive: a single-line compound statement whose body is
-            // already present on the same line (e.g. `if x: pass`) will
-            // still be counted as "opening a scope" here, since
-            // tree-sitter-python's error recovery does not reliably let us
-            // tell "body already closed on this line" apart from "body not
-            // written yet" -- see indent_query.rs POC notes.
-            if start_row == current_line {
-                opens_new_scope = true;
+            if capture.index == indent_capture_index {
+                let node = capture.node;
+                indent_node_ranges.push((node.start_byte(), node.end_byte()));
             }
         }
     }
 
-    Ok(if opens_new_scope { 1 } else { 0 })
+    // Look at the node covering the character immediately *before* the cursor rather than
+    // the cursor's own (zero-width) position: `descendant_for_byte_range` does not descend
+    // into the empty range past the end of the last token (e.g. right after `if x:` at
+    // the end of the buffer, it would resolve all the way up to the root), whereas biasing
+    // one byte to the left lands inside whatever was just typed.
+    let byte = buffer.char_to_byte(cursor)?;
+    let lookup_byte = byte.saturating_sub(1);
+    let mut current_node = tree
+        .root_node()
+        .descendant_for_byte_range(lookup_byte, lookup_byte);
+    let mut indent_rows = BTreeSet::new();
+    while let Some(node) = current_node {
+        if indent_node_ranges.contains(&(node.start_byte(), node.end_byte())) {
+            indent_rows.insert(node.start_position().row);
+        }
+        current_node = node.parent();
+    }
+
+    let level = indent_rows.len();
+    Ok(Some(
+        std::iter::repeat_n(indent_char, indent_width)
+            .collect::<String>()
+            .repeat(level),
+    ))
 }
 
 #[cfg(test)]
-mod test_compute_extra_indent_level {
+mod test_compute_indent_for_new_line {
     use super::*;
 
     fn python_buffer(text: &str) -> Buffer {
@@ -82,11 +104,26 @@ mod test_compute_extra_indent_level {
     }
 
     #[test]
-    fn opens_extra_level_after_compound_statement_header() -> anyhow::Result<()> {
+    fn indents_one_level_after_compound_statement_header() -> anyhow::Result<()> {
+        let text = "if x:";
+        let buffer = python_buffer(text);
+        let cursor = CharIndex(text.chars().count());
+        assert_eq!(
+            compute_indent_for_new_line(&buffer, cursor, ' ', 4)?,
+            Some("    ".to_string())
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn indents_two_levels_when_nested() -> anyhow::Result<()> {
         let text = "def foo():\n    if x:";
         let buffer = python_buffer(text);
         let cursor = CharIndex(text.chars().count());
-        assert_eq!(compute_extra_indent_level(&buffer, cursor)?, 1);
+        assert_eq!(
+            compute_indent_for_new_line(&buffer, cursor, ' ', 4)?,
+            Some("        ".to_string())
+        );
         Ok(())
     }
 
@@ -95,21 +132,24 @@ mod test_compute_extra_indent_level {
         let text = "def foo():\n    x = 1";
         let buffer = python_buffer(text);
         let cursor = CharIndex(text.chars().count());
-        assert_eq!(compute_extra_indent_level(&buffer, cursor)?, 0);
+        assert_eq!(
+            compute_indent_for_new_line(&buffer, cursor, ' ', 4)?,
+            Some("    ".to_string())
+        );
         Ok(())
     }
 
     #[test]
     fn non_python_language_is_unaffected() -> anyhow::Result<()> {
-        // Rust's `Language::indent_query` is not implemented in this POC,
-        // so it should always fall back to 0 extra levels.
+        // Rust's `Language::indent_query` is not implemented in this POC, so callers
+        // should fall back to the default heuristic in that case.
         let language = shared::languages::languages().get("rust").unwrap().clone();
         let ts_language = language.tree_sitter_language().unwrap();
         let text = "fn foo() {";
         let mut buffer = Buffer::new(Some(ts_language), text);
         buffer.set_language(language)?;
         let cursor = CharIndex(text.chars().count());
-        assert_eq!(compute_extra_indent_level(&buffer, cursor)?, 0);
+        assert_eq!(compute_indent_for_new_line(&buffer, cursor, ' ', 4)?, None);
         Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub mod frontend;
 mod generate_recipes;
 mod grid;
 pub mod history;
+mod indent_query;
 mod integration_event;
 #[cfg(test)]
 mod integration_test;


### PR DESCRIPTION
## Summary

POC for #525 (auto-indent in insert mode): explores a hand-written `indents.scm` for Python as an alternative to vendoring from nvim-treesitter, which is now archived. Scoped to Python only.

- `shared/src/queries/python/indents.scm`: hand-authored query using Helix's `@indent`/`@outdent` capture convention.
- `Language::indent_query()`: POC accessor, Python only.
- `src/indent_query.rs`: interpreter that runs the query against the buffer's tree-sitter tree.
  - `compute_indent_for_new_line`: used on Enter. Counts one level per distinct line on which an `@indent`-captured ancestor of the cursor begins, and drops one level when the token right after the cursor is `@outdent`-captured (e.g. a closing bracket pushed onto its own line).
  - `compute_reindent_for_outdent_keyword`: used on every keystroke in insert mode (`insert_char`). Fixes the *current* line's indentation in place once it finishes with an `@outdent`-captured token — covers both closing brackets typed by hand, and Python's `elif`/`else`/`except`/`except*`/`finally`.
- `enter_newline()` / `insert_char()`: wire the above into actual edits.

### Why keywords need a different path than brackets

Python's grammar lexes indentation itself (DEDENT/INDENT), so `elif` only parses as part of an `elif_clause` once its line is *already* dedented to align with `if` — which is exactly the correction being computed, a chicken-and-egg problem the tree can't resolve mid-typing. So instead of reading the fix off the (necessarily still-wrong) tree, `keyword_outdent_target` matches the typed text against a keyword list and computes the target as one level less than what a new line after the *previous* line would get (which is unaffected and validly parsed). That keyword list itself is derived straight from `indents.scm`'s own `@outdent`-captured literals (`indent_query::outdent_keywords`) rather than hand-maintained separately, so the query stays the single source of truth.

### Known limitations (see comments in the code)

- A `try:` block missing its first `except`/`finally` is invalid Python, and tree-sitter-python reports `ERROR` nodes for it that can swallow the enclosing `def`/`class`. Helix works around this with `@extend`-based `ERROR`-node patterns, which this POC does not implement — both indentation paths can under-indent while a `try` is in that state.
- A single-line compound statement whose body is already present (e.g. `if x: pass`) will still be treated as opening a scope, since tree-sitter-python's error recovery doesn't reliably distinguish that from "body not written yet" at the node-type level.
- Edits made while already in insert mode force a reparse on every keystroke that goes through `insert_char`/`enter_newline` now (needed for both features to see up-to-date syntax), a change from the original pre-existing "only reparse on leaving insert mode" behavior.

## Test plan

1. Open a `.py` file.
2. Type:
   ```
   def foo():
       if x:
   ```
3. Press Enter at the end of `if x:`.
4. Confirm the cursor lands one level deeper (8 spaces) instead of just copying the `if x:` line's own 4-space indentation.
5. Repeat with `for`/`while`/`class`/`with`/`try`/`except` to confirm the same block-opening behavior.
6. Type `x = 1` on its own line and press Enter — confirm indentation is only copied, not increased (no false positive on plain statements).
7. Type `foo(`, press Enter, then type `)` — confirm the `)` lands back at `foo`'s own indentation, not the hanging-content level.
8. Type:
   ```
   if x:
       pass
   ```
   Press Enter (cursor auto-indents to 4 spaces), then type `elif y:` — confirm `elif` snaps back to column 0 as soon as it's fully typed. Repeat for `else`, and for `except`/`finally` inside a `try` that already has one clause.
9. Open a non-Python file (e.g. `.rs`) and confirm Enter and typing behave exactly as before (no regression).

