### PR TITLE
fix(multibuffer): make v m (Replace w/ pattern) use the correct search scope

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1331,6 +1331,17 @@ impl<T: Frontend> App<T> {
             }
             Dispatch::ToggleRevealSelections => self.toggle_reveal_selections()?,
             Dispatch::SaveFile => self.save()?,
+            Dispatch::ReplaceWithPattern => {
+                // When the global multicursor (multi-buffer) is active, the search/replacement
+                // pattern was configured via the Global search prompt (used to populate the
+                // quickfix list), not the Local one, so read the pattern from the matching scope.
+                let scope = if self.multibuffer.is_some() {
+                    Scope::Global
+                } else {
+                    Scope::Local
+                };
+                self.handle_dispatch_editor(DispatchEditor::ReplaceWithPattern(scope))?;
+            }
         }
         Ok(())
     }
@@ -4096,6 +4107,7 @@ pub enum Dispatch {
     },
     ToggleRevealSelections,
     SaveFile,
+    ReplaceWithPattern,
 }
 
 /// Used to send notify host app about changes

--- a/src/components/editor/mod.rs
+++ b/src/components/editor/mod.rs
@@ -341,7 +341,7 @@ impl Component for Editor {
             }
             DeleteSurround(enclosure) => return self.delete_surround(enclosure, context),
             ChangeSurround { from, to } => return self.change_surround(from, Some(to), context),
-            ReplaceWithPattern => return self.replace_with_pattern(context),
+            ReplaceWithPattern(scope) => return self.replace_with_pattern(scope, context),
             Eat(movement) => return self.eat(&movement, context),
             ApplyPositionalEdits(edits) => {
                 return self.apply_positional_edits(
@@ -3610,8 +3610,12 @@ impl Editor {
         self.apply_edit_transaction(edit_transaction, context)
     }
 
-    fn replace_with_pattern(&mut self, context: &Context) -> Result<Dispatches, anyhow::Error> {
-        let config = context.local_search_config(Scope::Local);
+    fn replace_with_pattern(
+        &mut self,
+        scope: Scope,
+        context: &Context,
+    ) -> Result<Dispatches, anyhow::Error> {
+        let config = context.local_search_config(scope);
         match config.mode {
             LocalSearchConfigMode::AstGrep => {
                 let edits = if let Some(language) = self.buffer().treesitter_language() {
@@ -4931,7 +4935,7 @@ pub enum DispatchEditor {
     ReplaceWithCopiedText {
         cut: bool,
     },
-    ReplaceWithPattern,
+    ReplaceWithPattern(Scope),
     SelectLine(Movement),
     Backspace,
     Insert(String),

--- a/src/components/test_editor.rs
+++ b/src/components/test_editor.rs
@@ -3013,7 +3013,7 @@ fn replace_with_pattern() -> Result<(), anyhow::Error> {
                         if_current_not_found: IfCurrentNotFound::LookForward,
                         run_search_after_config_updated: true,
                     }),
-                    Editor(ReplaceWithPattern),
+                    Editor(DispatchEditor::ReplaceWithPattern(Scope::Local)),
                     Expect(CurrentComponentContent(expected_content)),
                     Expect(CurrentSelectedTexts(expected_selected_text)),
                 ])

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -1694,7 +1694,7 @@ pub fn paste_keymap() -> Keymap {
             Keybinding::new_undocumented(
                 key!("m"),
                 "Replace w/ pattern",
-                Dispatch::ToEditor(ReplaceWithPattern),
+                Dispatch::ReplaceWithPattern,
             ),
             Keybinding::new_undocumented(
                 key!("y"),

--- a/src/multibuffer/test_global_multicursor.rs
+++ b/src/multibuffer/test_global_multicursor.rs
@@ -5,7 +5,7 @@ use crate::{
     app::{
         Dimension,
         Dispatch::{self, *},
-        Scope,
+        LocalSearchConfigUpdate, Scope,
     },
     buffer::BufferOwner,
     components::editor::{Direction, DispatchEditor::*, IfCurrentNotFound, Mode},
@@ -780,6 +780,41 @@ fn quickfix_list_should_be_closed_when_global_multicursor_is_activated() -> Resu
             )),
             App(AddCursorToAllSelections),
             Expect(ComponentsOrder([ComponentKind::SuggestiveEditor].to_vec())),
+        ])
+    })
+}
+
+#[test]
+fn replace_with_pattern_should_work_across_all_files_in_global_multicursor(
+) -> Result<(), anyhow::Error> {
+    execute_test(|s| {
+        Box::new([
+            App(SetFileContent(s.main_rs(), "// foo xxx".to_string())),
+            App(SetFileContent(s.foo_rs(), "// foo yyy".to_string())),
+            App(OpenSearchPrompt {
+                scope: Scope::Global,
+                if_current_not_found: IfCurrentNotFound::LookForward,
+            }),
+            App(HandleKeyEvents(keys!("f o o enter").to_vec())),
+            WaitForAppMessage(regex!("GlobalSearchFinished")),
+            App(AddCursorToAllSelections),
+            // The replacement pattern is configured under `Scope::Global`, since that is the
+            // scope under which the search that seeded this global multicursor was performed.
+            App(Dispatch::UpdateLocalSearchConfig {
+                update: LocalSearchConfigUpdate::Replacement("bar".to_string()),
+                scope: Scope::Global,
+                if_current_not_found: IfCurrentNotFound::LookForward,
+                run_search_after_config_updated: false,
+            }),
+            App(Dispatch::ReplaceWithPattern),
+            Expect(ExpectKind::FileContent(
+                s.main_rs(),
+                "// bar xxx".to_string(),
+            )),
+            Expect(ExpectKind::FileContent(
+                s.foo_rs(),
+                "// bar yyy".to_string(),
+            )),
         ])
     })
 }


### PR DESCRIPTION
## Problem

In global multicursor / multi-buffer mode, this replace flow doesn't work:

1. Global search for a pattern
2. `space u` to enter multi-buffer mode
3. `space b j` to add cursor to all selections ("Curs All")
4. `v m` ("Replace w/ pattern") — does nothing

## Root cause

`v m` (`DispatchEditor::ReplaceWithPattern`) always read the search/replacement
pattern from the **Local** search config. But when the global multicursor is
seeded from a global search, the pattern you typed lives in the **Global**
search config instead — a separate field. So `v m` was reading an empty/stale
pattern.

## Fix

- `DispatchEditor::ReplaceWithPattern` now carries a `Scope`.
- A new top-level `Dispatch::ReplaceWithPattern` decides the scope at the
  `App` level: `Scope::Global` when the global multicursor (multi-buffer) is
  active, `Scope::Local` otherwise — then forwards to the editor(s), which are
  already multiplexed across all files in multicursor mode.
- Updated the `v m` keybinding and existing tests accordingly.
- Added a regression test reproducing the reported flow (global search →
  Curs All → set replacement → `ReplaceWithPattern` → both files updated).

## Test plan

1. Open a project with the same string appearing in multiple files.
2. Global search for that string (`space` → search prompt, `Scope::Global`).
3. `space u` to enter multi-buffer mode.
4. `space b j` ("Curs All") to add a cursor to every match.
5. Open the replace-with-pattern prompt and set a replacement.
6. Press `v m`.
7. Confirm the replacement is applied across all matches in all open files.
8. Confirm `v m` still works as before for a plain (non-multi-buffer) local search & replace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TP3FVenNzCwFACmctbJZys