### PR TITLE
fix(replace): use global search pattern for `v m` even without Reveal Selections

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1332,10 +1332,13 @@ impl<T: Frontend> App<T> {
             Dispatch::ToggleRevealSelections => self.toggle_reveal_selections()?,
             Dispatch::SaveFile => self.save()?,
             Dispatch::ReplaceWithPattern => {
-                // When the global multicursor (multi-buffer) is active, the search/replacement
-                // pattern was configured via the Global search prompt (used to populate the
-                // quickfix list), not the Local one, so read the pattern from the matching scope.
-                let scope = if self.multibuffer.is_some() {
+                // When a global search is active — whether still shown as a quickfix list, or
+                // turned into a multi-buffer view via the global multicursor / Reveal Selections
+                // — the search/replacement pattern was configured via the Global search prompt,
+                // not the Local one, so read the pattern from the matching scope.
+                let scope = if self.multibuffer.is_some()
+                    || self.context.mode() == Some(GlobalMode::QuickfixListItem)
+                {
                     Scope::Global
                 } else {
                     Scope::Local

--- a/src/multibuffer/test_global_multicursor.rs
+++ b/src/multibuffer/test_global_multicursor.rs
@@ -785,6 +785,39 @@ fn quickfix_list_should_be_closed_when_global_multicursor_is_activated() -> Resu
 }
 
 #[test]
+fn replace_with_pattern_should_use_global_search_config_without_reveal() -> Result<(), anyhow::Error>
+{
+    execute_test(|s| {
+        Box::new([
+            App(SetFileContent(s.main_rs(), "// quux xxx".to_string())),
+            App(OpenFile {
+                path: s.main_rs(),
+                owner: BufferOwner::User,
+                focus: true,
+            }),
+            App(OpenSearchPrompt {
+                scope: Scope::Global,
+                if_current_not_found: IfCurrentNotFound::LookForward,
+            }),
+            App(HandleKeyEvents(keys!("q u u x enter").to_vec())),
+            WaitForAppMessage(regex!("GlobalSearchFinished")),
+            // Note: neither `AddCursorToAllSelections` nor `ToggleRevealSelections` is
+            // dispatched here, so `self.multibuffer` remains `None`, even though a global
+            // search (with its own replacement pattern) is still active.
+            App(Dispatch::UpdateLocalSearchConfig {
+                update: LocalSearchConfigUpdate::Replacement("bar".to_string()),
+                scope: Scope::Global,
+                if_current_not_found: IfCurrentNotFound::LookForward,
+                run_search_after_config_updated: false,
+            }),
+            App(Dispatch::ReplaceWithPattern),
+            Expect(CurrentComponentPath(Some(s.main_rs()))),
+            Expect(CurrentComponentContent("// bar xxx")),
+        ])
+    })
+}
+
+#[test]
 fn replace_with_pattern_should_work_across_all_files_in_global_multicursor(
 ) -> Result<(), anyhow::Error> {
     execute_test(|s| {


### PR DESCRIPTION
## Problem

`v m` (Replace w/ pattern) worked as expected once a global search's results were turned into a multi-buffer view (via `AddCursorToAllSelections` / Reveal Selections), but did nothing useful right after a plain global search — i.e. while the results were still shown only as a quickfix list.

This was reported by a user in Discord: they noted that Reveal Selections shouldn't be a prerequisite for `v m` to pick up the active search's replacement pattern.

## Cause

`Dispatch::ReplaceWithPattern` decided which search scope (`Local` vs `Global`) to read the pattern from based solely on `self.multibuffer.is_some()`. That field is only populated after the global search results are turned into a multi-buffer (via the global multicursor or Reveal Selections) — a bare global search leaves it `None`, so `v m` fell back to `Scope::Local`, which holds an unrelated/empty pattern.

## Fix

Also treat the scope as `Global` whenever a global search is currently active (`context.mode() == GlobalMode::QuickfixListItem`), not just when `self.multibuffer` is populated.

## Test plan

- Ran a global search for a pattern, set its replacement, and pressed `v m` without first using Reveal Selections / Curs All — the replacement is now applied using the global search's pattern, as it already was after Reveal Selections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)