### PR TITLE
feat(languages): add Gherkin (.feature) language support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2434,6 +2434,7 @@ dependencies = [
  "tree-sitter-elixir",
  "tree-sitter-fish",
  "tree-sitter-fsharp",
+ "tree-sitter-gherkin",
  "tree-sitter-gitcommit",
  "tree-sitter-gleam",
  "tree-sitter-glsl",
@@ -2923,6 +2924,15 @@ name = "tree-sitter-fsharp"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd296b6559884f6c7e78458632337a18b41e19c1c9daa04407ea5b8478372774"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-gherkin"
+version = "0.1.0"
+source = "git+https://github.com/binhtddev/tree-sitter-gherkin?rev=1a709ae#1a709aebeecbe81bd70dfd6ea784894844be1511"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/docs/static/app_config_json_schema.json
+++ b/docs/static/app_config_json_schema.json
@@ -136,7 +136,8 @@
                 "Gitcommit",
                 "Rescript",
                 "Typst",
-                "Php"
+                "Php",
+                "Gherkin"
             ]
         },
         "Command": {

--- a/nvim-treesitter-highlight-queries/build.rs
+++ b/nvim-treesitter-highlight-queries/build.rs
@@ -21,6 +21,7 @@ const INCLUDED_NVIM_TREESITTER_LANGUAGES: &[&str] = &[
     "git_config",
     "git_rebase",
     "gitattributes",
+    "gherkin",
     "gitcommit",
     "gitignore",
     "gleam",
@@ -85,6 +86,7 @@ const MISSING_NVIM_HIGHLIGHTS: &[&str] = &[
     "jj description",
     "gnuplot",
     "qml",
+    "gherkin",
 ];
 
 fn main() {

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -83,6 +83,7 @@ arborium-rescript = "2.18.1"
 arborium-typst = "2.18.1"
 tree-sitter-gitcommit = "0.5.0"
 tree-sitter-php = "0.24.2"
+tree-sitter-gherkin = { git = "https://github.com/binhtddev/tree-sitter-gherkin", rev = "1a709ae" }
 
 [dev-dependencies]
 quickcheck.workspace = true

--- a/shared/queries/gherkin/highlights.scm
+++ b/shared/queries/gherkin/highlights.scm
@@ -1,0 +1,86 @@
+; tree-sitter-gherkin doesn't export `HIGHLIGHTS_QUERY` from its Rust bindings
+; (the constant is commented out upstream), so this file is a vendored copy of
+; its `queries/gherkin/highlights.scm`, included directly instead.
+; See https://github.com/binhtddev/tree-sitter-gherkin
+
+[
+  (background_kw)
+  (examples_kw)
+  (feature_kw)
+  (rule_kw)
+  (scenario_kw)
+  (scenario_outline_kw)
+] @keyword
+
+(given_group
+  [
+    (given_step
+      (given_line
+        (given_kw) @keyword.import))
+    (asterisk_step
+      (asterisk_line
+        "* " @keyword.import))
+    (and_step
+      (and_line
+        (and_kw) @keyword.import))
+    (but_step
+      (but_line
+        (but_kw) @keyword.import))
+  ])
+
+(when_group
+  [
+    (when_step
+      (when_line
+        (when_kw) @function))
+    (asterisk_step
+      (asterisk_line
+        "* " @function))
+    (and_step
+      (and_line
+        (and_kw) @function))
+    (but_step
+      (but_line
+        (but_kw) @function))
+  ])
+
+(then_group
+  [
+    (then_step
+      (then_line
+        (then_kw) @type))
+    (asterisk_step
+      (asterisk_line
+        "* " @type))
+    (and_step
+      (and_line
+        (and_kw) @type))
+    (but_step
+      (but_line
+        (but_kw) @type))
+  ])
+
+(step_param) @variable.parameter
+
+(tag) @type
+
+(table_head_row
+  (table_col
+    (table_cell) @markup.heading))
+
+":" @punctuation.delimiter
+
+"|" @punctuation.special
+
+(doc_string) @string.documentation
+(media_type) @type
+
+"language" @property
+
+(language_name) @string
+(invalid_language_name) @comment.error
+
+[
+  (comment)
+  (language)
+] @comment

--- a/shared/src/language.rs
+++ b/shared/src/language.rs
@@ -128,6 +128,7 @@ pub enum CargoLinkedTreesitterLanguage {
     Rescript,
     Typst,
     Php,
+    Gherkin,
 }
 
 impl CargoLinkedTreesitterLanguage {
@@ -204,6 +205,7 @@ impl CargoLinkedTreesitterLanguage {
             CargoLinkedTreesitterLanguage::Rescript => arborium_rescript::language().into(),
             CargoLinkedTreesitterLanguage::Typst => arborium_typst::language().into(),
             CargoLinkedTreesitterLanguage::Php => tree_sitter_php::LANGUAGE_PHP.into(),
+            CargoLinkedTreesitterLanguage::Gherkin => tree_sitter_gherkin::LANGUAGE.into(),
         }
     }
 
@@ -288,6 +290,13 @@ impl CargoLinkedTreesitterLanguage {
             CargoLinkedTreesitterLanguage::Rescript => Some(arborium_rescript::HIGHLIGHTS_QUERY),
             CargoLinkedTreesitterLanguage::Typst => Some(arborium_typst::HIGHLIGHTS_QUERY),
             CargoLinkedTreesitterLanguage::Php => Some(tree_sitter_php::HIGHLIGHTS_QUERY),
+            // tree-sitter-gherkin doesn't export `HIGHLIGHTS_QUERY` from its Rust bindings
+            // (the constant is commented out upstream), so a vendored copy of its
+            // `queries/gherkin/highlights.scm` lives at `shared/queries/gherkin/highlights.scm`
+            // instead. See https://github.com/binhtddev/tree-sitter-gherkin
+            CargoLinkedTreesitterLanguage::Gherkin => {
+                Some(include_str!("../queries/gherkin/highlights.scm"))
+            }
         }
     }
 }

--- a/shared/src/languages.rs
+++ b/shared/src/languages.rs
@@ -31,6 +31,7 @@ pub fn languages() -> HashMap<String, Language> {
         ("dockerfile", dockerfile()),
         ("elixir", elixir()),
         ("fsharp", fsharp()),
+        ("gherkin", gherkin()),
         ("gitattributes", gitattributes()),
         ("gitcommit", gitcommit()),
         ("gitconfig", gitconfig()),
@@ -1037,6 +1038,21 @@ fn ruby() -> Language {
         tree_sitter_grammar_config: Some(GrammarConfig {
             id: "ruby".to_string(),
             kind: GrammarConfigKind::CargoLinked(CargoLinkedTreesitterLanguage::Ruby),
+        }),
+        line_comment_prefix: Some("#".to_string()),
+        ..Language::new()
+    }
+}
+
+fn gherkin() -> Language {
+    Language {
+        extensions: to_vec(&["feature"]),
+        formatter: None,
+        lsp_command: None,
+        lsp_language_id: Some(LanguageId::new("feature")),
+        tree_sitter_grammar_config: Some(GrammarConfig {
+            id: "gherkin".to_string(),
+            kind: GrammarConfigKind::CargoLinked(CargoLinkedTreesitterLanguage::Gherkin),
         }),
         line_comment_prefix: Some("#".to_string()),
         ..Language::new()

--- a/shared/src/languages.rs
+++ b/shared/src/languages.rs
@@ -1339,7 +1339,7 @@ mod test {
     #[test]
     fn test_languages_match_nvim_treesitter_languages() {
         const MISSING_NVIM_HIGHLIGHTS: &[&str] =
-            &["dune", "ki_quickfix", "tsq", "jj description", "qml"];
+            &["dune", "ki_quickfix", "tsq", "jj description", "qml", "gherkin"];
 
         // This test is a major consistency check.
         // First, we check that all builtin languages were searched for in nvim-treesitter.

--- a/shared/src/languages.rs
+++ b/shared/src/languages.rs
@@ -1338,8 +1338,14 @@ fn glsl() -> Language {
 mod test {
     #[test]
     fn test_languages_match_nvim_treesitter_languages() {
-        const MISSING_NVIM_HIGHLIGHTS: &[&str] =
-            &["dune", "ki_quickfix", "tsq", "jj description", "qml", "gherkin"];
+        const MISSING_NVIM_HIGHLIGHTS: &[&str] = &[
+            "dune",
+            "ki_quickfix",
+            "tsq",
+            "jj description",
+            "qml",
+            "gherkin",
+        ];
 
         // This test is a major consistency check.
         // First, we check that all builtin languages were searched for in nvim-treesitter.


### PR DESCRIPTION
## Summary

Adds Gherkin (`.feature` file, used for Cucumber-style BDD specs) as a supported language, using [tree-sitter-gherkin](https://github.com/binhtddev/tree-sitter-gherkin) for parsing and syntax highlighting.

- Adds `tree-sitter-gherkin` as a git dependency (pinned to a specific commit).
- Registers `gherkin` in the language enum/registry, mapped to the `.feature` extension.
- Vendors the grammar's `highlights.scm` under `shared/queries/gherkin/highlights.scm` (included via `include_str!`), since the crate's Rust bindings don't export `HIGHLIGHTS_QUERY` directly.
- Registers `gherkin` as missing from nvim-treesitter's own query set, matching the existing pattern used for `gnuplot`/`qml`.

No formatter or LSP is wired up for Gherkin yet — this PR only adds syntax highlighting/parsing.

## Test plan

- Opened a `.feature` file in ki-editor and confirmed Gherkin keywords (`Feature`, `Scenario`, `Given`/`When`/`Then`/`And`/`But`, tags, tables, doc strings) are syntax-highlighted correctly.