### PR TITLE
fix(buffer): stop blank lines from leaking an ancestor's line into sticky/parent lines

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1348,6 +1348,47 @@ fn f(
         pretty_assertions::assert_eq!(actual, expected);
     }
 
+    #[test]
+    /// Reproduces https://github.com/ki-editor/ki-editor/issues/1687
+    ///
+    /// The parent lines of a blank line should be identical to the parent
+    /// lines of the text lines immediately surrounding it, because a blank
+    /// line does not introduce (or leave) any scope by itself.
+    fn get_parent_lines_blank_line_should_not_introduce_extra_line() {
+        let buffer = Buffer::new(
+            crate::config::from_extension("py")
+                .unwrap()
+                .tree_sitter_language(),
+            "
+class ObservationSpecification(Base):
+    __tablename__ = \"observation_specifications\"
+
+    is_proposer_modified: Mapped[bool]
+",
+        );
+        let expected = ["class ObservationSpecification(Base):".to_string()].to_vec();
+
+        // Line 4 = `is_proposer_modified: Mapped[bool]` (a text line)
+        let text_line_parent_lines = buffer
+            .get_parent_lines(4)
+            .unwrap()
+            .into_iter()
+            .map(|line| line.content)
+            .collect_vec();
+        pretty_assertions::assert_eq!(text_line_parent_lines, expected);
+
+        // Line 3 = the blank line between `__tablename__` and
+        // `is_proposer_modified`. Its parent lines must match the text
+        // line's, not gain a spurious extra `__tablename__` entry.
+        let blank_line_parent_lines = buffer
+            .get_parent_lines(3)
+            .unwrap()
+            .into_iter()
+            .map(|line| line.content)
+            .collect_vec();
+        pretty_assertions::assert_eq!(blank_line_parent_lines, expected);
+    }
+
     mod replace {
 
         use crate::{

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -236,6 +236,21 @@ impl Buffer {
             &Selection::default().set_range((char_index..char_index + 1).into()),
             false,
         )?;
+        // `char_index` may fall in a byte range not covered by any specific
+        // leaf/statement node — e.g. a blank line sitting between two
+        // sibling statements. In that case `node` resolves to the nearest
+        // enclosing (coarser) ancestor, whose start line is some other,
+        // unrelated line (typically the block's first statement), not
+        // `line_index`. Such a node does not represent `line_index`'s own
+        // line, so it must not be recorded as though it were one — that
+        // would surface as a spurious extra parent/sticky line. Skip it and
+        // start the ancestor walk from its parent instead.
+        let node = match node {
+            Some(node) if self.byte_to_position(node.start_byte())?.line != line_index => {
+                node.parent()
+            }
+            node => node,
+        };
         fn get_parent_lines(
             buffer: &Buffer,
             node: Option<tree_sitter::Node>,


### PR DESCRIPTION
Fixes #1687

## Problem

The sticky/parent lines pinned under the tab bar flicker an extra row in and out as the cursor moves onto a blank line, even though the cursor's enclosing scope hasn't changed — see the issue for the video-derived repro and root-cause walkthrough.

## Root cause

`Buffer::get_parent_lines` locates the syntax node for the queried line by indexing into its first non-whitespace character. For a blank line, that position falls in the byte gap between two sibling statements, so tree-sitter resolves it to the nearest enclosing (coarser) ancestor node instead of a line-specific leaf — and that ancestor's start line is some unrelated line (typically the enclosing block's first statement), not the blank line itself.

The function's existing dedup logic (a column-collision trick plus a final `line.line < line_index` filter) implicitly assumed the resolved node always starts on the queried line. That assumption holds for real content lines but not for blank lines, so the mismatched ancestor line slipped through as though it were the queried line's own entry.

## Fix

Skip recording the resolved node as its own line when its start line doesn't match the queried line, and begin the ancestor walk from its parent instead. This makes blank-line behavior identical to the surrounding text lines', without relying on the incidental column collision and without special-casing "is this line blank" (so it also covers other gap positions consistently).

## Commits

1. A failing regression test reproducing the bug (`get_parent_lines_blank_line_should_not_introduce_extra_line`), asserting the blank line's parent lines match the surrounding text lines'.
2. The fix itself, which makes that test (and the pre-existing `get_parent_lines_1`/`get_parent_lines_2` tests) pass.

## Test plan

- Open a Python (or any tree-sitter-supported) file with a class/function body that has a blank line between two statements.
- Move the cursor between a text line and the adjacent blank line.
- Confirm the sticky/parent line(s) pinned at the top no longer change, and no extra line appears while on the blank line.
