### PR TITLE
feat(skills): add zulip-fetch skill for fetching Zulip messages

### DIFF
--- a/.claude/skills/zulip-fetch/SKILL.md
+++ b/.claude/skills/zulip-fetch/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: zulip-fetch
+description: Fetch the most recent messages from the ki-editor Zulip organization. Use when the user asks to check, read, or fetch Zulip messages/notifications.
+---
+
+# Zulip Fetch
+
+Fetches the N most recent messages (default 10) from the ki-editor Zulip
+organization via the Zulip REST API.
+
+## Prerequisites
+
+A `.env` file at the repo root (gitignored) with:
+
+```
+ZULIP_SITE=https://ki-editor.zulipchat.com
+ZULIP_EMAIL=<account email>
+ZULIP_API_KEY=<api key>
+```
+
+Get the API key from `https://ki-editor.zulipchat.com/#settings/account-and-privacy`
+(personal key) or `https://ki-editor.zulipchat.com/#settings/your-bots` (bot key).
+
+Requires `curl` and `jq` on PATH.
+
+## Usage
+
+```bash
+bash .claude/skills/zulip-fetch/scripts/zulip_fetch.sh [N]
+```
+
+- `N` — number of most recent messages to fetch (default: 10).
+
+Prints each message as:
+
+```
+[YYYY-MM-DD HH:MM] Sender Name (stream / topic or DM recipients):
+message content (HTML tags stripped)
+```
+
+## Notes
+
+- Never print or log the contents of `.env` (it holds a live API key).
+- If the request fails, check that `ZULIP_API_KEY` is actually populated in
+  `.env` and that `ZULIP_SITE` matches the org's real URL.

--- a/.claude/skills/zulip-fetch/scripts/zulip_fetch.sh
+++ b/.claude/skills/zulip-fetch/scripts/zulip_fetch.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Fetch the N most recent Zulip messages using credentials from .env
+set -euo pipefail
+
+REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+set -a
+source .env
+set +a
+
+NUM="${1:-10}"
+
+curl -s \
+  -u "${ZULIP_EMAIL}:${ZULIP_API_KEY}" \
+  --get "${ZULIP_SITE}/api/v1/messages" \
+  --data-urlencode "anchor=newest" \
+  --data-urlencode "num_before=${NUM}" \
+  --data-urlencode "num_after=0" \
+  --data-urlencode 'narrow=[]' \
+  | jq -r '.messages[] | . as $m
+      | (if ($m.display_recipient | type) == "array"
+           then ($m.display_recipient | map(.full_name) | join(", "))
+           else $m.display_recipient
+         end) as $recipient
+      | "[\($m.timestamp | gmtime | strftime("%Y-%m-%d %H:%M"))] \($m.sender_full_name) (\($recipient)\(if $m.subject != "" then " / " + $m.subject else "" end)):\n\($m.content | gsub("<[^>]*>";""))\n"'

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ docs/assets/recipes.json
 .roomodes
 .ruru
 node_modules
+.env


### PR DESCRIPTION
## Summary
- Adds a `zulip-fetch` Claude Code skill (`.claude/skills/zulip-fetch/`) that fetches the N most recent messages from the ki-editor Zulip organization via the Zulip REST API.
- Adds `.env` to `.gitignore` so local Zulip credentials (site URL, email, API key) never get committed.

## Test plan
- [x] Populate a `.env` at repo root with `ZULIP_SITE`, `ZULIP_EMAIL`, `ZULIP_API_KEY`.
- [x] Run `bash .claude/skills/zulip-fetch/scripts/zulip_fetch.sh 10` and confirm the 10 most recent Zulip messages print with timestamp, sender, stream/topic, and content.
- [x] Invoke the skill via `/zulip-fetch` in Claude Code and confirm it runs the same script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)