### PR TITLE
docs: fix several inaccuracies reported by a user

### DIFF
--- a/docs/docs/comparison.md
+++ b/docs/docs/comparison.md
@@ -9,7 +9,7 @@ sidebar_position: 3
 | Mental model                              | Selection mode → Movement → Action | Action → Movement | Movement → Action |
 | Structural editing                        | First-class                        | With plugin       | Second class[^1]  |
 | Multi-cursor                              | Good                               | With plugin       | Extensive         |
-| Built-in file explorer                    | Yes                                | Yes (but buggy)   | No                |
+| Built-in file explorer                    | Yes                                | Yes (but buggy)   | Yes[^2]           |
 | Built-in LSP                              | Yes                                | Require config    | Yes               |
 | Built-in global search & replace          | Yes                                | Require config    | No global replace |
 | Auto-reload when files changed externally | Yes                                | Require config    | No                |
@@ -19,6 +19,8 @@ sidebar_position: 3
 [^1]:
     The default keybindings for structural navigation in Helix are hard to access: `alt+n`, `alt+p`, `alt+i` and `alt+o`.
     Also, there's no easy way to [revert to previous selection](normal-mode/other-movements.md#-selectselect-), which is crucial for structural manipulation.
+
+[^2]: Added in Helix 25.07, accessible via `space e`.
 
 ## Keybindings coherence
 

--- a/docs/docs/momentary-layers/index.md
+++ b/docs/docs/momentary-layers/index.md
@@ -10,7 +10,7 @@ This terminology comes from the keyboard modding community. For more details, se
 
 Momentary Layer is the same as the `⊞ Win` key. You can use it as a modifier, and you can tap it to trigger an action: `⊞ Win` to open Windows menu, `⊞ Win + R` to open the Run dialog.
 
-In ki, for example, tapping `≡ Insert` deletes the current selection and enters Insert mode. Holding `≡ Insert` additionally displays a menu with additional actions like opening new line below.
+In ki, for example, tapping `≡ Open` deletes the current selection and enters Insert mode. Holding `≡ Open` additionally displays a menu with additional actions like opening new line below.
 
 Windows keyboards use `⊞` for Win, MacBook keyboards use e.g., `⌘` for Command, to visually denote modifier keys. The `≡` symbol here mimics that convention by representing layered or "stacked" functionality, similar to a hamburger menu.
 

--- a/docs/docs/normal-mode/search-config.md
+++ b/docs/docs/normal-mode/search-config.md
@@ -66,9 +66,9 @@ Throughout this document, you'll see examples using different separators (like s
 
 For example, in the input `a/hell\o\/`:
 
-- The first backslash before `o` is treated as a literal character (not escaping anything)
-- The second backslash before `/` is escaping the separator
-- The resulting search query is `hello\/` (searching for the text "hello/")
+- The first backslash before `o` is treated as a literal character (not escaping anything), so it is kept as-is in the search query
+- The second backslash before `/` is escaping the separator, so it is consumed and the `/` becomes a literal character in the search query
+- The resulting search query is `hell\o/` (searching for the text `hell\o/`, i.e. `hell`, followed by a literal backslash, followed by `o/`)
 
 ### No Error Policy
 

--- a/docs/docs/normal-mode/selection-modes/secondary.md
+++ b/docs/docs/normal-mode/selection-modes/secondary.md
@@ -28,8 +28,11 @@ Secondary selection modes are nested below the following two keybinds,
 with the exception of Search and Search Current, which are placed on the
 first layer due to their ubiquity.
 
-- `⚲ Local`
-- Global
+- `⚲ Local` (`n` in Normal mode)
+- Global (`space`, i.e. the [Space menu](../space-menu.md); the Global
+  secondary selection modes are merged directly into the left side of that
+  menu, so for example Search is invoked via `space d`, not via a dedicated
+  "Global" key)
 
 Local Find is directional, meaning that if the cursor position does not overlap
 with any selections of the chosen secondary selection mode, the cursor will

--- a/docs/docs/sub-modes/index.md
+++ b/docs/docs/sub-modes/index.md
@@ -9,6 +9,6 @@ import {KeymapFallback} from '@site/src/components/KeymapFallback';
 The following are the submodes in Ki:
 
 1. Swap (`t`)
-2. Multi-cursor (`r`)
-3. Extend (`g`)
-4. Delete (`v`)
+2. Multi-cursor (`b`)
+3. Extend (`f`)
+4. Delete (`r`)


### PR DESCRIPTION
In [this Zulip message](https://ki-editor.zulipchat.com/#narrow/channel/543761-.F0.9F.8C.80-General/topic//near/620015752), a12l relayed several doc inaccuracies that WJH had noticed while reading through the docs (WJH couldn't submit a PR directly at the time). This PR fixes the ones that could be verified against the current source code:

1. **`comparison.md`**: Helix gained a built-in file explorer in release 25.07 (`space e`), so the comparison table is updated from "No" to "Yes" (with a footnote noting when/how).
2. **`sub-modes/index.md`**: the listed submode keybindings were stale — updated to match the current keymap (`src/keymap.rs`): Multi-cursor is `b` (was documented as `r`), Extend is `f` (was documented as `g`), Delete is `r` (was documented as `v`).
3. **`momentary-layers/index.md`**: the example momentary layer referenced `≡ Insert`, which doesn't exist in the codebase — it's actually `≡ Open` (bound to `g`).
4. **`normal-mode/search-config.md`**: fixed the worked escaping example. Per the parsing logic in `src/search.rs`, the input `a/hell\o\/` actually produces the search query `hell\o/` (literal `hell`, backslash, `o/`) — not `hello\/` as previously stated.
5. **`normal-mode/selection-modes/secondary.md`**: clarified that "Global" secondary selection modes aren't behind a dedicated keybind the way `⚲ Local` is — they're merged directly into the [Space menu](https://github.com/ki-editor/ki-editor/blob/master/docs/docs/normal-mode/space-menu.md) (e.g. Search is `space d`).

## Test plan

- Read through each changed page and cross-checked the described behavior/keybindings against `src/keymap.rs` and `src/search.rs` on `master`.
- Verified the new cross-reference link in `secondary.md` (`../space-menu.md`) resolves to an existing file.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGvVapNSAFQ9H7THJRpLdW)_