### PR TITLE
feat(keymap): support dead-key layouts via base-layout-key, plus docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,9 +210,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base64"
-version = "0.22.1"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "baz-tree-sitter-traversal"
@@ -397,7 +397,7 @@ version = "7.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
 dependencies = [
- "crossterm",
+ "crossterm 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -505,11 +505,23 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
+ "bitflags 2.9.1",
+ "crossterm_winapi",
+ "document-features",
+ "parking_lot",
+ "rustix 1.0.8",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "git+https://github.com/vshylov/crossterm.git?rev=0f086ab06bf6d577cdc0972d450d8a2c0dfe9363#0f086ab06bf6d577cdc0972d450d8a2c0dfe9363"
+dependencies = [
  "base64",
  "bitflags 2.9.1",
  "crossterm_winapi",
  "derive_more",
- "document-features",
  "filedescriptor",
  "mio",
  "parking_lot",
@@ -753,7 +765,7 @@ dependencies = [
 name = "event"
 version = "0.1.0"
 dependencies = [
- "crossterm",
+ "crossterm 0.29.0 (git+https://github.com/vshylov/crossterm.git?rev=0f086ab06bf6d577cdc0972d450d8a2c0dfe9363)",
  "pretty_assertions",
 ]
 
@@ -1373,7 +1385,7 @@ dependencies = [
  "convert_case 0.6.0",
  "crc32fast",
  "crossbeam-channel",
- "crossterm",
+ "crossterm 0.29.0 (git+https://github.com/vshylov/crossterm.git?rev=0f086ab06bf6d577cdc0972d450d8a2c0dfe9363)",
  "debounce",
  "diffy",
  "event",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,18 @@ exclude = ['mock_repos/rust1']
 # See:
 # - https://github.com/crossterm-rs/crossterm/pull/956
 # - https://github.com/crossterm-rs/crossterm/issues/828
-crossterm = { version = "0.29.0", features = ["osc52", "use-dev-tty"] }
+#
+# Pinned to a fork carrying the Kitty Keyboard Protocol's `base-layout-key`
+# support (`KeyEvent::base_layout_code`, `REPORT_ALTERNATE_KEYS`), which
+# hasn't landed upstream yet. This is what lets Ki dispatch normal-mode
+# commands positionally on dead-key layouts (Ergo-L, Bépo, ...) — see
+# https://github.com/ki-editor/ki-editor/issues/719. Track the upstream PR
+# at https://github.com/crossterm-rs/crossterm/pull/1074 and switch back to
+# a released `crossterm` once it merges.
+crossterm = { git = "https://github.com/vshylov/crossterm.git", rev = "0f086ab06bf6d577cdc0972d450d8a2c0dfe9363", features = [
+  "osc52",
+  "use-dev-tty",
+] }
 convert_case = "0.6.0"
 regex = "1.8.1"
 fancy-regex = "0.14.0"

--- a/docs/docs/configuration.mdx
+++ b/docs/docs/configuration.mdx
@@ -22,6 +22,52 @@ Note: Workspace config overrides Global config.
 
 <AppConfigSchemaViewerFallback/>
 
+## Keyboard Layouts
+
+Ki's normal-mode keybindings are positional: they are defined against QWERTY
+key positions, then remapped to whichever `keyboard_layout` you select, so
+the same physical action stays reachable regardless of layout.
+
+Besides the built-in layouts (see the config schema above for the full
+list), you can define your own via `custom_keyboard_layouts`, then select it
+with `keyboard_layout`:
+
+```json
+{
+  "keyboard_layout": "ergol",
+  "custom_keyboard_layouts": {
+    "ergol": [
+      ["q", "c", "o", "p", "w", "j", "m", "d", "'", "y"],
+      ["a", "s", "e", "n", "f", "l", "r", "t", "i", "u"],
+      ["z", "x", "-", "v", "b", ".", "h", "g", ",", "k"]
+    ]
+  }
+}
+```
+
+Each entry must be a 3x10 grid of characters, laid out the same way as the
+built-in layouts: row 1 is `q w e r t y u i o p` on QWERTY, row 2 is
+`a s d f g h j k l ;`, and row 3 is `z x c v b n m , . /`.
+
+### Dead keys
+
+Some layouts (e.g. [Ergo-L](https://github.com/Nuclear-Squid/ErgoL),
+[Bépo](https://bepo.fr)) place a "dead key" — a key that doesn't produce a
+character by itself, but combines with the next keypress to produce an
+accented one — inside that 3x10 grid. Dead-key composition happens below
+the terminal (in the OS/driver layer), so terminal apps like Ki never see a
+"dead key was pressed" event; they only see the final composed character,
+if anything reaches the terminal at all. This means Ki cannot bind a
+command to a dead key's physical slot today. See
+[#719](https://github.com/ki-editor/ki-editor/issues/719) for the ongoing
+discussion and possible layout-agnostic fixes.
+
+As a workaround, set the dead key's slot to whichever character it actually
+composes when pressed on its own (typically an accent mark, e.g. `'` for
+Ergo-L's dead key). This won't bind a Ki command to that physical key, but
+it keeps the rest of the layout's positional mapping correct and lets Ki
+run.
+
 ## Scripting
 
 You can define up to 30 custom actions that can execute arbitrary scripts and interact with Ki's state.

--- a/event/src/event.rs
+++ b/event/src/event.rs
@@ -45,15 +45,44 @@ impl From<crossterm::event::KeyEventKind> for KeyEventKind {
 /// The `crossterm` crate does not support this out of the box.
 ///
 /// It also replaces Repeat events with Press events
-#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone)]
 pub struct KeyEvent {
     pub code: crossterm::event::KeyCode,
     pub modifiers: KeyModifiers,
     pub kind: KeyEventKind,
+    /// The key at the same physical position on a standard PC-101 keyboard,
+    /// independent of the active OS/keyboard layout.
+    ///
+    /// Only populated when the terminal implements the Kitty Keyboard
+    /// Protocol's `REPORT_ALTERNATE_KEYS` flag (see
+    /// `src/frontend/crossterm.rs`). This is what lets Ki dispatch
+    /// normal-mode commands positionally even for dead-key layouts, whose
+    /// composed output character otherwise can't be looked up in
+    /// `KeyboardLayout` (see `KeyboardLayout::make_combined_key_event`) —
+    /// see https://github.com/ki-editor/ki-editor/issues/719.
+    ///
+    /// Deliberately excluded from `PartialEq`/`Hash` below, mirroring
+    /// crossterm's own `KeyEvent`, so that key events built without live
+    /// terminal data (tests, the `key!`/`keys!` macros, etc.) keep comparing
+    /// equal regardless of this field.
+    pub base_layout_code: Option<crossterm::event::KeyCode>,
 }
 impl fmt::Debug for KeyEvent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.display())
+    }
+}
+impl PartialEq for KeyEvent {
+    fn eq(&self, other: &Self) -> bool {
+        self.code == other.code && self.modifiers == other.modifiers && self.kind == other.kind
+    }
+}
+impl Eq for KeyEvent {}
+impl std::hash::Hash for KeyEvent {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.code.hash(state);
+        self.modifiers.hash(state);
+        self.kind.hash(state);
     }
 }
 impl KeyEvent {
@@ -62,6 +91,7 @@ impl KeyEvent {
             code: key,
             modifiers,
             kind: KeyEventKind::Press,
+            base_layout_code: None,
         }
     }
 
@@ -70,12 +100,13 @@ impl KeyEvent {
             code: key,
             modifiers,
             kind: KeyEventKind::Release,
+            base_layout_code: None,
         }
     }
 
     pub fn to_rust_code(&self) -> String {
         format!(
-            "event::KeyEvent {{ code: crossterm::event::KeyCode::{:#?}, modifiers: event::{:#?}, kind: event::KeyEventKind::{:#?} }}",
+            "event::KeyEvent {{ code: crossterm::event::KeyCode::{:#?}, modifiers: event::{:#?}, kind: event::KeyEventKind::{:#?}, base_layout_code: None }}",
             self.code, self.modifiers, self.kind
         )
     }
@@ -135,6 +166,7 @@ impl From<crossterm::event::KeyEvent> for KeyEvent {
             code: value.code,
             modifiers: value.modifiers.into(),
             kind: value.kind.into(),
+            base_layout_code: value.base_layout_code,
         }
     }
 }

--- a/src/components/editor_keymap.rs
+++ b/src/components/editor_keymap.rs
@@ -215,12 +215,33 @@ impl KeyboardLayout {
     pub fn make_combined_key_event(&self, event: KeyEvent) -> CombinedKeyEvent {
         let qwerty = match event.code {
             KeyCode::Char(pressed_char) => {
-                let translated_char = self.translate_char_to_qwerty(pressed_char);
+                // Dead keys compose below the terminal (OS/XKB/IME layer), so
+                // the terminal only ever reports the final composed
+                // character — never "this physical slot was pressed". That
+                // breaks Ki's positional lookup below for any layout whose
+                // dead key composes to a character absent from the layout
+                // table (see https://github.com/ki-editor/ki-editor/issues/719).
+                //
+                // `base_layout_code`, when the terminal implements the Kitty
+                // Keyboard Protocol's `REPORT_ALTERNATE_KEYS` (see
+                // `src/frontend/crossterm.rs`), reports the physical PC-101
+                // slot independent of composition/layout — exactly the
+                // layout-agnostic signal positional dispatch needs. Prefer
+                // it over the literal composed character here, for
+                // normal-mode dispatch only; insert mode keeps inserting
+                // whatever text the terminal actually sends, since it never
+                // goes through this translation.
+                let effective_char = match event.base_layout_code {
+                    Some(KeyCode::Char(base_char)) => base_char,
+                    _ => pressed_char,
+                };
+                let translated_char = self.translate_char_to_qwerty(effective_char);
                 let shift = translated_char.is_uppercase();
                 KeyEvent {
                     code: KeyCode::Char(translated_char),
                     modifiers: event.modifiers.set_shift(shift),
                     kind: event.kind,
+                    base_layout_code: None,
                 }
             }
             _ => event,
@@ -329,4 +350,38 @@ pub fn possibly_alted(key_event: KeyEvent, is_alted: bool) -> KeyEvent {
 pub fn alted(mut key_event: KeyEvent) -> KeyEvent {
     key_event.modifiers.alt = true;
     key_event
+}
+
+#[cfg(test)]
+mod test_make_combined_key_event {
+    use super::*;
+
+    #[test]
+    fn prefers_composed_char_when_base_layout_code_is_absent() {
+        // No `base_layout_code` (e.g. terminal doesn't implement the Kitty
+        // Keyboard Protocol's `REPORT_ALTERNATE_KEYS`): fall back to the
+        // literal composed character, same as before this existed.
+        let layout = KeyboardLayout::new("QWERTY".to_string(), QWERTY);
+        let event = KeyEvent::pressed(KeyCode::Char('j'), event::KeyModifiers::default());
+        let combined = layout.make_combined_key_event(event);
+        assert_eq!(combined.translated.code, KeyCode::Char('j'));
+    }
+
+    #[test]
+    fn prefers_base_layout_code_over_composed_char_when_present() {
+        // Simulates a dead-key layout: the physical slot that QWERTY calls
+        // `j` composes, on this layout, to a character absent from the
+        // layout table (e.g. an apostrophe produced by a dead key). Without
+        // `base_layout_code`, positional dispatch for that slot would be
+        // impossible to look up. With it, the physical slot ('j') is used
+        // regardless of what character it actually composed to.
+        let layout = KeyboardLayout::new("QWERTY".to_string(), QWERTY);
+        let mut event =
+            KeyEvent::pressed(KeyCode::Char('\u{2019}'), event::KeyModifiers::default());
+        event.base_layout_code = Some(KeyCode::Char('j'));
+        let combined = layout.make_combined_key_event(event);
+        assert_eq!(combined.translated.code, KeyCode::Char('j'));
+        // The untranslated original event is passed through unchanged.
+        assert_eq!(combined.original.code, KeyCode::Char('\u{2019}'));
+    }
 }

--- a/src/frontend/crossterm.rs
+++ b/src/frontend/crossterm.rs
@@ -92,7 +92,15 @@ impl Frontend for Crossterm {
         #[cfg(not(windows))]
         self.stdout.execute(PushKeyboardEnhancementFlags(
             KeyboardEnhancementFlags::REPORT_EVENT_TYPES
-                | KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES,
+                | KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
+                // Reports `base_layout_code`: the physical PC-101 slot
+                // pressed, independent of the active OS keyboard layout or
+                // dead-key composition. Ki's positional keybindings use this
+                // (see `KeyboardLayout::make_combined_key_event`) to keep
+                // working on dead-key layouts, whose composed characters
+                // otherwise can't be looked up positionally.
+                // See https://github.com/ki-editor/ki-editor/issues/719.
+                | KeyboardEnhancementFlags::REPORT_ALTERNATE_KEYS,
             // DISAMBIGUATE_ESCAPE_CODES is necessary for preventing an Esc tap to be captured as a double esc presses
         ))?;
         Ok(())


### PR DESCRIPTION
## What

Adds a "Keyboard Layouts" section to the configuration docs
(`docs/docs/configuration.mdx`), and implements the real, layout-agnostic
fix proposed in the [latest issue comment](https://github.com/ki-editor/ki-editor/issues/719#issuecomment-4106358310).

**Docs:**

- How `custom_keyboard_layouts` works and how to select a custom layout via
  `keyboard_layout`, with an example (using the Ergo-L layout from #719).
- Why Ki historically couldn't bind a command to a dead key's physical slot:
  dead-key composition happens below the terminal (OS/driver layer), so
  terminal apps only ever see the final composed character, never a
  "dead key was pressed" event.
- The existing workaround (previously only documented in an issue
  comment): map the dead key's slot to whichever character it composes
  when pressed alone.
- A link to #719 for readers who want to follow/contribute to the fix.

**Implementation — layout-agnostic keybinding via Kitty protocol's `base-layout-key`:**

- Pins `crossterm` to [vshylov/crossterm#feat/base-layout-key](https://github.com/vshylov/crossterm/tree/feat/base-layout-key)
  (unmerged upstream at [crossterm-rs/crossterm#1074](https://github.com/crossterm-rs/crossterm/pull/1074)),
  which reports the Kitty Keyboard Protocol's `base-layout-key`: the
  physical PC-101 slot pressed, independent of the active OS layout or
  dead-key composition.
- Requests `KeyboardEnhancementFlags::REPORT_ALTERNATE_KEYS` alongside the
  flags Ki already enables (`src/frontend/crossterm.rs`).
- Threads `base_layout_code` through `event::KeyEvent`, deliberately
  excluded from its `PartialEq`/`Hash` (mirroring crossterm's own choice)
  so key events built without live terminal data — tests, the `key!`/`keys!`
  macros — keep comparing equal.
- In `KeyboardLayout::make_combined_key_event`, prefers `base_layout_code`
  over the literal composed character for **normal-mode dispatch only**;
  insert mode is untouched, since it never goes through this translation
  and keeps inserting whatever text the terminal actually sends (so
  composed characters like é, ê still type correctly).

**Known limits:**

- Requires an MSRV bump (crossterm main is on 1.85; Ki is currently 1.83) —
  not bumped in this PR since the fork still builds against Ki's current
  MSRV.
- Unix-only — doesn't touch Windows, where KKP is already disabled in Ki.
- Only helps on terminals implementing KKP's alternate-key reporting
  (kitty, foot, wezterm). Alacritty, xterm, tmux passthrough, and similar
  stay unaffected — those users still need the composed-character
  workaround documented above.
- Depends on an unmerged, unreleased upstream crossterm PR — worth
  tracking #1074's progress rather than vendoring the fork long-term.

## Why

#719 asks Ki to support keyboard layouts that use dead keys (e.g. Ergo-L,
Bépo). Investigation in the issue thread found the root cause (dead-key
composition is invisible to the terminal) and a real fix: Kitty Keyboard
Protocol's `base-layout-key`, once crossterm exposes it. This PR both
documents the interim workaround (discoverable where users actually look
for keyboard layout configuration) and lands the actual positional-dispatch
fix behind that upstream field, gated to terminals that support it.

## Test plan

- Read through the rendered Markdown/MDX by eye to confirm formatting,
  code fences, and links are correct.
- Confirmed no other docs page already covered `custom_keyboard_layouts`
  or dead keys (only the JSON schema mentioned the field).
- Added unit tests in `src/components/editor_keymap.rs` covering
  `make_combined_key_event` with and without `base_layout_code` present.
- `cargo build` and `cargo test` pass against the pinned crossterm fork.

---
_Generated by [Claude Code](https://claude.ai/code/session_0135suFU1soxk2QnPJEHG885)_
