### PR TITLE
feat(lsp): add commands to restart LSP server(s)

### DIFF
--- a/docs/docs/normal-mode/space-menu.md
+++ b/docs/docs/normal-mode/space-menu.md
@@ -165,10 +165,6 @@ Save all files.
 
 Restart the LSP server for the current file's language.
 
-### `Restart All LSPs`
-
-Restart every currently running LSP server.
-
 ### `Reload File`
 
 Reload the current file. A prompt will be shown if there are conflicts.

--- a/docs/docs/normal-mode/space-menu.md
+++ b/docs/docs/normal-mode/space-menu.md
@@ -161,6 +161,14 @@ Quit Ki without saving any unsaved files.
 
 Save all files.
 
+### `Restart LSP`
+
+Restart the LSP server for the current file's language.
+
+### `Restart All LSPs`
+
+Restart every currently running LSP server.
+
 ### `Reload File`
 
 Reload the current file. A prompt will be shown if there are conflicts.

--- a/src/app.rs
+++ b/src/app.rs
@@ -1157,7 +1157,6 @@ impl<T: Frontend> App<T> {
             Dispatch::GetRepoGitHunks(diff_mode) => self.get_repo_git_hunks(diff_mode)?,
             Dispatch::SaveAll => self.save_all()?,
             Dispatch::RestartLsp => self.restart_lsp()?,
-            Dispatch::RestartAllLsps => self.restart_all_lsps()?,
             #[cfg(test)]
             Dispatch::TerminalDimensionChanged(dimension) => self.resize(dimension),
             #[cfg(test)]
@@ -2187,14 +2186,6 @@ impl<T: Frontend> App<T> {
             return Ok(());
         };
         self.lsp_manager().restart_language(&language)
-    }
-
-    /// Restarts every currently running LSP server.
-    fn restart_all_lsps(&mut self) -> anyhow::Result<()> {
-        let languages = self.lsp_manager().running_languages();
-        languages
-            .iter()
-            .try_for_each(|language| self.lsp_manager().restart_language(language))
     }
 
     fn open_yes_no_prompt(&mut self, prompt: YesNoPrompt) -> anyhow::Result<()> {
@@ -4002,8 +3993,6 @@ pub enum Dispatch {
     SaveAll,
     /// Restarts the LSP server for the current buffer's language.
     RestartLsp,
-    /// Restarts every currently running LSP server.
-    RestartAllLsps,
     #[cfg(test)]
     TerminalDimensionChanged(Dimension),
     #[cfg(test)]

--- a/src/app.rs
+++ b/src/app.rs
@@ -1156,6 +1156,8 @@ impl<T: Frontend> App<T> {
             }
             Dispatch::GetRepoGitHunks(diff_mode) => self.get_repo_git_hunks(diff_mode)?,
             Dispatch::SaveAll => self.save_all()?,
+            Dispatch::RestartLsp => self.restart_lsp()?,
+            Dispatch::RestartAllLsps => self.restart_all_lsps()?,
             #[cfg(test)]
             Dispatch::TerminalDimensionChanged(dimension) => self.resize(dimension),
             #[cfg(test)]
@@ -2174,6 +2176,25 @@ impl<T: Frontend> App<T> {
     fn save_all(&mut self) -> anyhow::Result<()> {
         let dispatches = self.layout.save_all(&self.context)?;
         self.handle_dispatches(dispatches)
+    }
+
+    /// Restarts the LSP server responsible for the current buffer's language, if any.
+    fn restart_lsp(&mut self) -> anyhow::Result<()> {
+        let Some(language) = self
+            .get_current_file_path()
+            .and_then(|path| crate::config::from_path(&path))
+        else {
+            return Ok(());
+        };
+        self.lsp_manager().restart_language(&language)
+    }
+
+    /// Restarts every currently running LSP server.
+    fn restart_all_lsps(&mut self) -> anyhow::Result<()> {
+        let languages = self.lsp_manager().running_languages();
+        languages
+            .iter()
+            .try_for_each(|language| self.lsp_manager().restart_language(language))
     }
 
     fn open_yes_no_prompt(&mut self, prompt: YesNoPrompt) -> anyhow::Result<()> {
@@ -3979,6 +4000,10 @@ pub enum Dispatch {
     HandleKeyEvents(Vec<event::KeyEvent>),
     GetRepoGitHunks(git::DiffMode),
     SaveAll,
+    /// Restarts the LSP server for the current buffer's language.
+    RestartLsp,
+    /// Restarts every currently running LSP server.
+    RestartAllLsps,
     #[cfg(test)]
     TerminalDimensionChanged(Dimension),
     #[cfg(test)]

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -512,11 +512,6 @@ pub fn space_editor_keymap_legend_config() -> KeymapLegendConfig {
             ),
             Keybinding::new_undocumented(key!("r"), "Restart LSP", Dispatch::RestartLsp),
             Keybinding::new_undocumented(
-                key!("shift+r"),
-                "Restart All LSPs",
-                Dispatch::RestartAllLsps,
-            ),
-            Keybinding::new_undocumented(
                 key!("d"),
                 "Reload File",
                 Dispatch::ToEditor(ReloadFile { force: false }),

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -510,6 +510,12 @@ pub fn space_editor_keymap_legend_config() -> KeymapLegendConfig {
                 "Change Work Dir",
                 Dispatch::OpenChangeWorkingDirectoryPrompt,
             ),
+            Keybinding::new_undocumented(key!("e"), "Restart LSP", Dispatch::RestartLsp),
+            Keybinding::new_undocumented(
+                key!("shift+e"),
+                "Restart All LSPs",
+                Dispatch::RestartAllLsps,
+            ),
             Keybinding::new_undocumented(
                 key!("d"),
                 "Reload File",

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -510,9 +510,9 @@ pub fn space_editor_keymap_legend_config() -> KeymapLegendConfig {
                 "Change Work Dir",
                 Dispatch::OpenChangeWorkingDirectoryPrompt,
             ),
-            Keybinding::new_undocumented(key!("e"), "Restart LSP", Dispatch::RestartLsp),
+            Keybinding::new_undocumented(key!("r"), "Restart LSP", Dispatch::RestartLsp),
             Keybinding::new_undocumented(
-                key!("shift+e"),
+                key!("shift+r"),
                 "Restart All LSPs",
                 Dispatch::RestartAllLsps,
             ),

--- a/src/lsp/manager.rs
+++ b/src/lsp/manager.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use crate::app::AppMessage;
 
-use super::process::{FromEditor, LspServerProcessChannel};
+use super::process::{FromEditor, LspNotification, LspServerProcessChannel};
 use shared::{
     absolute_path::AbsolutePath,
     language::{Language, LanguageId},
@@ -131,6 +131,52 @@ impl LspManager {
                 .shutdown()
                 .unwrap_or_else(|error| log::error!("{error:?}"));
         }
+    }
+
+    /// Restarts the LSP server process for the given `language`, if one is running.
+    ///
+    /// The existing process (if any) is shut down and a fresh one is spawned.
+    /// Once the new process reports that it is initialized, `documents_did_open`
+    /// will be replayed for currently open buffers (see `App::handle_lsp_notification`),
+    /// so callers do not need to re-open any documents themselves.
+    pub fn restart_language(&mut self, language: &Language) -> anyhow::Result<()> {
+        let Some(language_id) = language.id() else {
+            return Ok(());
+        };
+
+        if let Some(channel) = self.lsp_server_process_channels.remove(&language_id) {
+            // `shutdown` blocks until the old process has actually stopped (or failed
+            // to), so a failure is reported here before the replacement process is
+            // spawned below, rather than racing with it. Success is not reported —
+            // it's the expected outcome and not worth surfacing to the user.
+            if let Err(error) = channel.shutdown() {
+                let _ = self.sender.send(AppMessage::LspNotification(Box::new(
+                    LspNotification::Error(format!(
+                        "LSP server for {language_id} failed to shut down cleanly: {error:?}"
+                    )),
+                )));
+            }
+        }
+
+        LspServerProcessChannel::new(
+            language.clone(),
+            self.sender.clone(),
+            self.current_working_directory.clone(),
+        )
+        .map(|channel| {
+            if let Some(channel) = channel {
+                self.lsp_server_process_channels
+                    .insert(language_id, channel);
+            }
+        })
+    }
+
+    /// Returns the distinct `Language`s that currently have a running LSP server process.
+    pub fn running_languages(&self) -> Vec<Language> {
+        self.lsp_server_process_channels
+            .values()
+            .map(|channel| channel.language().clone())
+            .collect()
     }
 
     #[cfg(test)]

--- a/src/lsp/manager.rs
+++ b/src/lsp/manager.rs
@@ -171,14 +171,6 @@ impl LspManager {
         })
     }
 
-    /// Returns the distinct `Language`s that currently have a running LSP server process.
-    pub fn running_languages(&self) -> Vec<Language> {
-        self.lsp_server_process_channels
-            .values()
-            .map(|channel| channel.language().clone())
-            .collect()
-    }
-
     #[cfg(test)]
     pub fn lsp_request_sent(&self, from_editor: &FromEditor) -> bool {
         self.history.get(from_editor.variant()) == Some(from_editor)

--- a/src/lsp/process.rs
+++ b/src/lsp/process.rs
@@ -131,10 +131,12 @@ enum LspServerProcessMessage {
     FromEditor(FromEditor),
     /// Throttled message should be executed immediately
     Throttled(FromEditor),
-    /// Carries a sender for reporting back whether the shutdown succeeded, so that
-    /// the caller can wait for (and surface) the outcome before doing anything else,
-    /// e.g. spawning a replacement process during a restart.
-    Shutdown(Sender<anyhow::Result<()>>),
+    /// Carries an optional sender for reporting back whether the shutdown succeeded.
+    /// `Some` when the caller wants to wait for (and surface) the outcome before doing
+    /// anything else, e.g. spawning a replacement process during a restart. `None` for
+    /// a fire-and-forget shutdown, e.g. one triggered internally after too many
+    /// consecutive read errors, where nobody is waiting on the result.
+    Shutdown(Option<Sender<anyhow::Result<()>>>),
 }
 
 #[derive(Debug, NamedVariant, Clone, PartialEq)]
@@ -229,7 +231,7 @@ impl LspServerProcessChannel {
         }
         let (result_sender, result_receiver) = std::sync::mpsc::channel();
         self.sender
-            .send(LspServerProcessMessage::Shutdown(result_sender))
+            .send(LspServerProcessMessage::Shutdown(Some(result_sender)))
             .map_err(|err| anyhow::anyhow!("Unable to send request: {}", err))?;
         result_receiver
             .recv_timeout(Duration::from_secs(5))
@@ -597,9 +599,8 @@ impl LspServerProcess {
                                         "[LspServerProcess] Error sending error to app: {error:?}"
                                     );
                                 });
-                            let (result_sender, _) = std::sync::mpsc::channel();
                             sender
-                            .send(LspServerProcessMessage::Shutdown(result_sender))
+                            .send(LspServerProcessMessage::Shutdown(None))
                             .unwrap_or_else(|error| {
                                 lsp_error!(
                                     lsp_command,
@@ -673,7 +674,9 @@ impl LspServerProcess {
                             "LspServerProcess::process_messages: failed to shutdown due to {err:?}"
                         );
                     }
-                    let _ = result_sender.send(result);
+                    if let Some(result_sender) = result_sender {
+                        let _ = result_sender.send(result);
+                    }
                     break;
                 }
             }

--- a/src/lsp/process.rs
+++ b/src/lsp/process.rs
@@ -16,6 +16,7 @@ use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Read, Write};
 
 use std::process::{self};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{Receiver, Sender};
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
@@ -47,11 +48,20 @@ macro_rules! lsp_error {
 }
 struct LspServerProcess {
     language: Language,
-    stdin: process::ChildStdin,
+    /// `None` once the shutdown sequence has closed the pipe to the LSP server,
+    /// so that the server observes EOF on its stdin.
+    stdin: Option<process::ChildStdin>,
 
     /// This is hacky, but we need to keep the stdout around so that it doesn't get dropped
     stdout: Option<process::ChildStdout>,
     stderr: Option<process::ChildStderr>,
+
+    /// The underlying OS process, kept so that a graceful shutdown can wait for
+    /// (or, failing that, forcefully terminate) the actual process.
+    child: process::Child,
+    /// Set to `true` for the duration of a deliberate shutdown, so that the stdout
+    /// reader thread can tell an expected pipe closure apart from a genuine error.
+    shutting_down: Arc<AtomicBool>,
 
     server_capabilities: Option<ServerCapabilities>,
     current_working_directory: AbsolutePath,
@@ -121,7 +131,10 @@ enum LspServerProcessMessage {
     FromEditor(FromEditor),
     /// Throttled message should be executed immediately
     Throttled(FromEditor),
-    Shutdown,
+    /// Carries a sender for reporting back whether the shutdown succeeded, so that
+    /// the caller can wait for (and surface) the outcome before doing anything else,
+    /// e.g. spawning a replacement process during a restart.
+    Shutdown(Sender<anyhow::Result<()>>),
 }
 
 #[derive(Debug, NamedVariant, Clone, PartialEq)]
@@ -207,8 +220,24 @@ impl LspServerProcessChannel {
         LspServerProcess::start(language, screen_message_sender, current_working_directory)
     }
 
+    /// Shuts down the underlying LSP server process and blocks until the outcome
+    /// (success or error) is known, so that callers can rely on the shutdown having
+    /// actually finished — e.g. before spawning a replacement process on restart.
     pub fn shutdown(self) -> anyhow::Result<()> {
-        self.send(LspServerProcessMessage::Shutdown)
+        if !self.is_initialized {
+            return Ok(());
+        }
+        let (result_sender, result_receiver) = std::sync::mpsc::channel();
+        self.sender
+            .send(LspServerProcessMessage::Shutdown(result_sender))
+            .map_err(|err| anyhow::anyhow!("Unable to send request: {}", err))?;
+        result_receiver
+            .recv_timeout(Duration::from_secs(5))
+            .unwrap_or_else(|_| {
+                Err(anyhow::anyhow!(
+                    "Timed out waiting for confirmation that the LSP server shut down"
+                ))
+            })
     }
 
     fn send(&self, message: LspServerProcessMessage) -> anyhow::Result<()> {
@@ -249,6 +278,10 @@ impl LspServerProcessChannel {
         self.is_initialized
     }
 
+    pub fn language(&self) -> &Language {
+        &self.language
+    }
+
     pub fn initialized(&mut self) {
         self.is_initialized = true;
     }
@@ -287,9 +320,11 @@ impl LspServerProcess {
         let (sender, receiver) = std::sync::mpsc::channel::<LspServerProcessMessage>();
         let mut lsp_server_process = LspServerProcess {
             language: language.clone(),
-            stdin,
+            stdin: Some(stdin),
             stdout: Some(stdout),
             stderr: Some(stderr),
+            child: process,
+            shutting_down: Arc::new(AtomicBool::new(false)),
             current_working_directory,
             next_request_id: 0,
             pending_response_requests: HashMap::new(),
@@ -486,6 +521,7 @@ impl LspServerProcess {
             sender.clone(),
             app_message_sender.clone(),
             lsp_command,
+            self.shutting_down.clone(),
         );
 
         // Start the message processor loop in the main thread
@@ -512,6 +548,7 @@ impl LspServerProcess {
         sender: Sender<LspServerProcessMessage>,
         app_message_sender: crossbeam_channel::Sender<AppMessage>,
         lsp_command: String,
+        shutting_down: Arc<AtomicBool>,
     ) -> JoinHandle<()> {
         thread::spawn(move || {
             let mut error_tracker = ErrorTracker::new(lsp_command.clone());
@@ -521,6 +558,17 @@ impl LspServerProcess {
                 match Self::read_response(&mut stdout_reader, &sender) {
                     Ok(()) => error_tracker.handle_success(),
                     Err(error) => {
+                        // A deliberate shutdown closes the server's stdin/stdout, which
+                        // surfaces here as read errors. That is expected, not a fault of
+                        // the LSP server, so it is reported (elsewhere) as a shutdown
+                        // outcome rather than as this alarming error path.
+                        if shutting_down.load(Ordering::SeqCst) {
+                            lsp_info!(
+                                lsp_command,
+                                "[LspServerProcess] stdout closed as part of a deliberate shutdown: {error:?}"
+                            );
+                            break;
+                        }
                         lsp_error!(
                             lsp_command,
                             "[LspServerProcess] read_response error = {error:?}"
@@ -549,8 +597,9 @@ impl LspServerProcess {
                                         "[LspServerProcess] Error sending error to app: {error:?}"
                                     );
                                 });
+                            let (result_sender, _) = std::sync::mpsc::channel();
                             sender
-                            .send(LspServerProcessMessage::Shutdown)
+                            .send(LspServerProcessMessage::Shutdown(result_sender))
                             .unwrap_or_else(|error| {
                                 lsp_error!(
                                     lsp_command,
@@ -616,13 +665,15 @@ impl LspServerProcess {
                 LspServerProcessMessage::Throttled(from_editor) => {
                     self.handle_from_editor(from_editor);
                 }
-                LspServerProcessMessage::Shutdown => {
-                    if let Err(err) = self.shutdown() {
+                LspServerProcessMessage::Shutdown(result_sender) => {
+                    let result = self.shutdown_process();
+                    if let Err(err) = &result {
                         lsp_error!(
                             self.lsp_command(),
                             "LspServerProcess::process_messages: failed to shutdown due to {err:?}"
                         );
                     }
+                    let _ = result_sender.send(result);
                     break;
                 }
             }
@@ -1110,6 +1161,64 @@ impl LspServerProcess {
         Ok(())
     }
 
+    /// Performs a full graceful shutdown of the LSP server process: sends the LSP
+    /// `shutdown` request followed by the `exit` notification, then closes stdin so
+    /// the server observes EOF even if it does not react to `exit`, then waits for
+    /// the underlying OS process to actually terminate — force-killing it if it
+    /// does not, within a bounded timeout.
+    ///
+    /// While this runs, `shutting_down` is set so the stdout reader thread can tell
+    /// this expected pipe closure apart from a genuine communication error.
+    fn shutdown_process(&mut self) -> anyhow::Result<()> {
+        self.shutting_down.store(true, Ordering::SeqCst);
+
+        // Best-effort: the server may already be gone or unresponsive.
+        if let Err(err) = self.shutdown() {
+            lsp_error!(
+                self.lsp_command(),
+                "Failed to send `shutdown` request: {err:?}"
+            );
+        }
+        if let Err(err) = self.send_notification::<lsp_types::notification::Exit>(()) {
+            lsp_error!(
+                self.lsp_command(),
+                "Failed to send `exit` notification: {err:?}"
+            );
+        }
+
+        // Close our end of stdin so the server sees EOF even if it ignores `exit`.
+        self.stdin = None;
+
+        const TIMEOUT: Duration = Duration::from_secs(3);
+        let started_at = Instant::now();
+        loop {
+            match self.child.try_wait() {
+                Ok(Some(status)) => {
+                    lsp_info!(
+                        self.lsp_command(),
+                        "LSP server process exited with status: {status}"
+                    );
+                    return Ok(());
+                }
+                Ok(None) => {
+                    if started_at.elapsed() >= TIMEOUT {
+                        let _ = self.child.kill();
+                        let _ = self.child.wait();
+                        return Err(anyhow::anyhow!(
+                            "LSP server did not exit within {TIMEOUT:?} after being asked to shut down; the process was force-killed"
+                        ));
+                    }
+                    thread::sleep(Duration::from_millis(50));
+                }
+                Err(err) => {
+                    return Err(anyhow::anyhow!(
+                        "Failed to wait on LSP server process: {err}"
+                    ));
+                }
+            }
+        }
+    }
+
     fn send_notification<N: Notification>(&mut self, params: N::Params) -> anyhow::Result<()> {
         let notification = json_rpc_types::Request {
             id: None,
@@ -1156,14 +1265,13 @@ impl LspServerProcess {
     /// Send JSON to the LSP server by writing to the server's stdin
     fn send_json<T: serde::Serialize>(&mut self, value: T) -> anyhow::Result<()> {
         let json = serde_json::to_string(&value)?;
+        let stdin = self
+            .stdin
+            .as_mut()
+            .ok_or_else(|| anyhow::anyhow!("Cannot write to stdin: LSP server is shutting down"))?;
 
         // The message format is according to https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#contentPart
-        write!(
-            &mut self.stdin,
-            "Content-Length: {}\r\n\r\n{}",
-            json.len(),
-            json
-        )?;
+        write!(stdin, "Content-Length: {}\r\n\r\n{}", json.len(), json)?;
         Ok(())
     }
 
@@ -1894,9 +2002,14 @@ mod test_lsp_server_process {
 
         let lsp_process = LspServerProcess {
             language: Language::default(),
-            stdin,
+            stdin: Some(stdin),
             stdout: Some(stdout),
             stderr: Some(stderr),
+            // Ownership of the child moves here; it exits on its own once the
+            // shell script above finishes, which is what drives the stdout
+            // reader into the error path below.
+            child: process,
+            shutting_down: Arc::new(AtomicBool::new(false)),
             server_capabilities: None,
             current_working_directory: std::env::current_dir()?.try_into()?,
             next_request_id: 0,
@@ -1912,10 +2025,6 @@ mod test_lsp_server_process {
 
         // Start listening in a separate thread
         let handle = lsp_process.listen(receiver, app_sender)?;
-
-        // Kill the process before checking for error
-        process.kill()?;
-        process.wait()?;
 
         // We expect an error message after max consecutive errors
         match app_receiver.recv_timeout(Duration::from_secs(1)) {

--- a/src/lsp/process.rs
+++ b/src/lsp/process.rs
@@ -280,10 +280,6 @@ impl LspServerProcessChannel {
         self.is_initialized
     }
 
-    pub fn language(&self) -> &Language {
-        &self.language
-    }
-
     pub fn initialized(&mut self) {
         self.is_initialized = true;
     }

--- a/src/test_lsp.rs
+++ b/src/test_lsp.rs
@@ -139,38 +139,6 @@ fn typescript_lsp_restart() -> Result<(), anyhow::Error> {
 }
 
 #[test]
-fn typescript_lsp_restart_all() -> Result<(), anyhow::Error> {
-    let options = RunTestOptions {
-        enable_lsp: true,
-        enable_syntax_highlighting: false,
-        enable_file_watcher: false,
-    };
-    execute_test_custom(options, |s| {
-        Box::new([
-            App(AddPath(s.new_path("hello.ts").display().to_string())),
-            App(HandleKeyEvent(key!("enter"))),
-            Editor(SetContent("export function hello() {}".to_string())),
-            WaitForAppMessage(lazy_regex::regex!("LspNotification.*Initialized")),
-            App(Dispatch::RestartAllLsps),
-            WaitForAppMessage(lazy_regex::regex!("LspNotification.*Initialized")),
-            Editor(Save),
-            Editor(MatchLiteral("hello".to_string())),
-            App(Dispatch::RequestHover),
-            Expect(AppMessageIsReceived {
-                matches: regex!("LspNotification.*Hover"),
-                timeout: Duration::from_secs(5),
-            }),
-            App(Dispatch::OpenWorkspaceSymbolsPicker),
-            App(HandleKeyEvents(keys!("h e").to_vec())),
-            Expect(AppMessageIsReceived {
-                matches: regex!("LspNotification.*WorkspaceSymbols"),
-                timeout: Duration::from_secs(5),
-            }),
-        ])
-    })
-}
-
-#[test]
 fn typescript_lsp_references() -> Result<(), anyhow::Error> {
     let options = RunTestOptions {
         enable_lsp: true,

--- a/src/test_lsp.rs
+++ b/src/test_lsp.rs
@@ -101,6 +101,76 @@ fn typescript_lsp_workspace_symbols() -> Result<(), anyhow::Error> {
 }
 
 #[test]
+fn typescript_lsp_restart() -> Result<(), anyhow::Error> {
+    let options = RunTestOptions {
+        enable_lsp: true,
+        enable_syntax_highlighting: false,
+        enable_file_watcher: false,
+    };
+    execute_test_custom(options, |s| {
+        Box::new([
+            App(AddPath(s.new_path("hello.ts").display().to_string())),
+            App(HandleKeyEvent(key!("enter"))),
+            Editor(SetContent("export function hello() {}".to_string())),
+            WaitForAppMessage(lazy_regex::regex!("LspNotification.*Initialized")),
+            // Restarting should kill the current server and spawn a fresh one,
+            // which reports `Initialized` again once ready.
+            App(Dispatch::RestartLsp),
+            WaitForAppMessage(lazy_regex::regex!("LspNotification.*Initialized")),
+            // The restarted server should have `hello.ts` re-opened automatically
+            // (via the replayed `documents_did_open`), so basic requests should
+            // still work, e.g. Hover...
+            Editor(Save),
+            Editor(MatchLiteral("hello".to_string())),
+            App(Dispatch::RequestHover),
+            Expect(AppMessageIsReceived {
+                matches: regex!("LspNotification.*Hover"),
+                timeout: Duration::from_secs(5),
+            }),
+            // ...and Workspace Symbols.
+            App(Dispatch::OpenWorkspaceSymbolsPicker),
+            App(HandleKeyEvents(keys!("h e").to_vec())),
+            Expect(AppMessageIsReceived {
+                matches: regex!("LspNotification.*WorkspaceSymbols"),
+                timeout: Duration::from_secs(5),
+            }),
+        ])
+    })
+}
+
+#[test]
+fn typescript_lsp_restart_all() -> Result<(), anyhow::Error> {
+    let options = RunTestOptions {
+        enable_lsp: true,
+        enable_syntax_highlighting: false,
+        enable_file_watcher: false,
+    };
+    execute_test_custom(options, |s| {
+        Box::new([
+            App(AddPath(s.new_path("hello.ts").display().to_string())),
+            App(HandleKeyEvent(key!("enter"))),
+            Editor(SetContent("export function hello() {}".to_string())),
+            WaitForAppMessage(lazy_regex::regex!("LspNotification.*Initialized")),
+            App(Dispatch::RestartAllLsps),
+            WaitForAppMessage(lazy_regex::regex!("LspNotification.*Initialized")),
+            Editor(Save),
+            Editor(MatchLiteral("hello".to_string())),
+            App(Dispatch::RequestHover),
+            Expect(AppMessageIsReceived {
+                matches: regex!("LspNotification.*Hover"),
+                timeout: Duration::from_secs(5),
+            }),
+            App(Dispatch::OpenWorkspaceSymbolsPicker),
+            App(HandleKeyEvents(keys!("h e").to_vec())),
+            Expect(AppMessageIsReceived {
+                matches: regex!("LspNotification.*WorkspaceSymbols"),
+                timeout: Duration::from_secs(5),
+            }),
+        ])
+    })
+}
+
+#[test]
 fn typescript_lsp_references() -> Result<(), anyhow::Error> {
     let options = RunTestOptions {
         enable_lsp: true,


### PR DESCRIPTION
## Summary

Adds a Space-menu command to restart the current file's LSP server, and fixes a bug where restarting could misreport a false error.

- **`feat(lsp)`**: New Space-menu command — "Restart LSP" (`r`, restart the current file's language server). Open buffers are automatically re-synced once the restarted server reports `Initialized`.
- **`fix(lsp)`**: Restart now waits for the old server process to fully shut down (LSP `shutdown`/`exit`, stdin close, process wait/kill) before spawning the replacement, and a `shutting_down` flag prevents the reader thread from misreporting the expected pipe closure as a "Too many consecutive errors" failure.
- **`refactor(lsp)`**: The internal `Shutdown` message's result sender is now `Option<Sender<...>>`, so a fire-and-forget shutdown (e.g. one triggered internally after too many consecutive read errors) can pass `None` instead of constructing and immediately discarding a channel.
- **`test(lsp)`**: Integration test covering LSP restart.

Split out of this PR into its own PR: "Reload All Files" (see #1697).

## Test plan

- [x] Run "Restart LSP" on the current file's language and confirm LSP features (hover, diagnostics, etc.) keep working afterward with no error notification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
