### PR TITLE
feat(languages): add WIT (.wit) language support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2473,6 +2473,7 @@ dependencies = [
  "tree-sitter-swift",
  "tree-sitter-toml-ng",
  "tree-sitter-typescript",
+ "tree-sitter-wit",
  "tree-sitter-xml",
  "tree-sitter-yaml",
  "tree-sitter-zig",
@@ -3328,6 +3329,16 @@ checksum = "6c5f76ed8d947a75cc446d5fccd8b602ebf0cde64ccf2ffa434d873d7a575eff"
 dependencies = [
  "cc",
  "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-wit"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24209abae5617628330744bc186a5f02498693de8f0d8360a2bc50500fde3336"
+dependencies = [
+ "cc",
+ "tree-sitter",
 ]
 
 [[package]]

--- a/docs/static/app_config_json_schema.json
+++ b/docs/static/app_config_json_schema.json
@@ -138,7 +138,8 @@
                 "Rescript",
                 "Typst",
                 "Php",
-                "Gherkin"
+                "Gherkin",
+                "Wit"
             ]
         },
         "Command": {

--- a/nvim-treesitter-highlight-queries/build.rs
+++ b/nvim-treesitter-highlight-queries/build.rs
@@ -78,6 +78,7 @@ const INCLUDED_NVIM_TREESITTER_LANGUAGES: &[&str] = &[
     "zig",
     "jj description",
     "glsl",
+    "wit",
 ];
 
 const MISSING_NVIM_HIGHLIGHTS: &[&str] = &[

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -85,6 +85,7 @@ tree-sitter-gitcommit = "0.5.0"
 tree-sitter-php = "0.24.2"
 tree-sitter-gherkin = { git = "https://github.com/binhtddev/tree-sitter-gherkin", rev = "1a709ae" }
 tree-sitter-java = "0.23.5"
+tree-sitter-wit = "0.2.0"
 
 [dev-dependencies]
 quickcheck.workspace = true

--- a/shared/src/language.rs
+++ b/shared/src/language.rs
@@ -130,6 +130,7 @@ pub enum CargoLinkedTreesitterLanguage {
     Typst,
     Php,
     Gherkin,
+    Wit,
 }
 
 impl CargoLinkedTreesitterLanguage {
@@ -208,6 +209,7 @@ impl CargoLinkedTreesitterLanguage {
             CargoLinkedTreesitterLanguage::Php => tree_sitter_php::LANGUAGE_PHP.into(),
             CargoLinkedTreesitterLanguage::Gherkin => tree_sitter_gherkin::LANGUAGE.into(),
             CargoLinkedTreesitterLanguage::Java => tree_sitter_java::LANGUAGE.into(),
+            CargoLinkedTreesitterLanguage::Wit => tree_sitter_wit::language(),
         }
     }
 
@@ -300,6 +302,7 @@ impl CargoLinkedTreesitterLanguage {
                 Some(include_str!("../queries/gherkin/highlights.scm"))
             }
             CargoLinkedTreesitterLanguage::Java => Some(tree_sitter_java::HIGHLIGHTS_QUERY),
+            CargoLinkedTreesitterLanguage::Wit => Some(tree_sitter_wit::HIGHLIGHTS_QUERY),
         }
     }
 }

--- a/shared/src/languages.rs
+++ b/shared/src/languages.rs
@@ -87,6 +87,7 @@ pub fn languages() -> HashMap<String, Language> {
         ("clojure", clojure()),
         ("scala", scala()),
         ("glsl", glsl()),
+        ("wit", wit()),
     ]
     .into_iter()
     .map(|(str, language)| (str.to_string(), language))
@@ -1346,6 +1347,22 @@ fn glsl() -> Language {
         tree_sitter_grammar_config: Some(GrammarConfig {
             id: "glsl".to_string(),
             kind: GrammarConfigKind::CargoLinked(CargoLinkedTreesitterLanguage::Glsl),
+        }),
+        line_comment_prefix: Some("//".to_string()),
+        block_comment_affixes: Some(("/*".to_string(), "*/".to_string())),
+        ..Language::new()
+    }
+}
+
+fn wit() -> Language {
+    Language {
+        extensions: to_vec(&["wit"]),
+        formatter: None,
+        lsp_command: None,
+        lsp_language_id: Some(LanguageId::new("wit")),
+        tree_sitter_grammar_config: Some(GrammarConfig {
+            id: "wit".to_string(),
+            kind: GrammarConfigKind::CargoLinked(CargoLinkedTreesitterLanguage::Wit),
         }),
         line_comment_prefix: Some("//".to_string()),
         block_comment_affixes: Some(("/*".to_string(), "*/".to_string())),


### PR DESCRIPTION
## Summary
Adds tree-sitter-based syntax highlighting for WebAssembly Interface Type (`.wit`) files, using the published `tree-sitter-wit` crate (from the [wit-lsp](https://github.com/Michael-F-Bryan/wit-lsp) project). Follows the same pattern used for the recent Gherkin/Java language additions.

- `shared/Cargo.toml`: add `tree-sitter-wit = "0.2.0"`
- `shared/src/language.rs`: new `CargoLinkedTreesitterLanguage::Wit` variant + grammar/highlight query wiring
- `shared/src/languages.rs`: register `wit()` language (`.wit` extension, `//` line comments, `/* */` block comments; no formatter/LSP configured since none is commonly available)
- `nvim-treesitter-highlight-queries/build.rs`: include `"wit"` (a vendored `wit-highlights.scm` already exists there)
- `docs/static/app_config_json_schema.json`: add `"Wit"` to the language enum

## Test plan
- Open a `.wit` file in ki-editor and confirm syntax highlighting is applied.
- Confirm line-comment (`//`) and block-comment (`/* */`) toggling works on `.wit` files.

Note: `master` currently fails to build independent of this change (`schemars` derive needs syn's `"full"` feature — unrelated pre-existing issue), so CI may need that fixed separately before this can be verified/merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Y27S4LaioTmn2xzw8RWR4