### PR TITLE
fix(search): global search should use unsaved buffer content

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2130,7 +2130,7 @@ impl<T: Frontend> App<T> {
 
         // Buffers with unsaved changes should be searched using their live
         // content instead of what is currently saved on disk.
-        let dirty_buffers = Arc::new(self.layout.get_dirty_buffers(&self.context));
+        let dirty_buffers = self.layout.get_dirty_buffers(&self.context);
 
         // TODO: we need to create a new sender for each global search, so that it can be cancelled, but when?
         // Is it when the quickfix list is closed?

--- a/src/app.rs
+++ b/src/app.rs
@@ -2128,19 +2128,35 @@ impl<T: Frontend> App<T> {
         let send_match =
             crate::thread::batch(send_matches, on_finish, Duration::from_millis(100), limit); // Around 10 ticks per second
 
+        // Buffers with unsaved changes should be searched using their live
+        // content instead of what is currently saved on disk.
+        let dirty_buffers = Arc::new(self.layout.get_dirty_buffers(&self.context));
+
         // TODO: we need to create a new sender for each global search, so that it can be cancelled, but when?
         // Is it when the quickfix list is closed?
         match config.mode {
             LocalSearchConfigMode::Regex(regex) => {
-                list::grep::run(&config.search(), walk_builder_config, regex, send_match)?;
+                list::grep::run(
+                    &config.search(),
+                    walk_builder_config,
+                    regex,
+                    dirty_buffers,
+                    send_match,
+                )?;
             }
             LocalSearchConfigMode::AstGrep => {
-                list::ast_grep::run(config.search().clone(), walk_builder_config, send_match)?;
+                list::ast_grep::run(
+                    config.search().clone(),
+                    walk_builder_config,
+                    dirty_buffers,
+                    send_match,
+                )?;
             }
             LocalSearchConfigMode::NamingConventionAgnostic => {
                 list::naming_convention_agnostic::run(
                     config.search().clone(),
                     walk_builder_config,
+                    dirty_buffers,
                     send_match,
                 )?;
             }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -417,6 +417,22 @@ impl Layout {
             .collect_vec()
     }
 
+    /// Returns the content of every open buffer that has unsaved changes,
+    /// keyed by file path. Used so that global search/replace reflects the
+    /// live buffer content instead of what is currently saved on disk.
+    pub fn get_dirty_buffers(
+        &self,
+        context: &Context,
+    ) -> std::collections::HashMap<AbsolutePath, Buffer> {
+        self.background_suggestive_editors
+            .iter()
+            .filter_map(|(path, editor)| {
+                let buffer = editor.borrow().editor().buffer().clone();
+                buffer.dirty(context).then(|| (path.clone(), buffer))
+            })
+            .collect()
+    }
+
     pub fn reload_buffers(
         &self,
         context: &Context,

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -420,17 +420,16 @@ impl Layout {
     /// Returns the content of every open buffer that has unsaved changes,
     /// keyed by file path. Used so that global search/replace reflects the
     /// live buffer content instead of what is currently saved on disk.
-    pub fn get_dirty_buffers(
-        &self,
-        context: &Context,
-    ) -> std::collections::HashMap<AbsolutePath, Buffer> {
-        self.background_suggestive_editors
-            .iter()
-            .filter_map(|(path, editor)| {
-                let buffer = editor.borrow().editor().buffer().clone();
-                buffer.dirty(context).then(|| (path.clone(), buffer))
-            })
-            .collect()
+    pub fn get_dirty_buffers(&self, context: &Context) -> crate::list::DirtyBuffers {
+        crate::list::DirtyBuffers::new(
+            self.background_suggestive_editors
+                .iter()
+                .filter_map(|(path, editor)| {
+                    let buffer = editor.borrow().editor().buffer().clone();
+                    buffer.dirty(context).then(|| (path.clone(), buffer))
+                })
+                .collect(),
+        )
     }
 
     pub fn reload_buffers(

--- a/src/list/ast_grep.rs
+++ b/src/list/ast_grep.rs
@@ -4,15 +4,17 @@ use crate::{list::Match, selection_mode::AstGrep, thread::SendResult};
 
 use std::sync::Arc;
 
-use super::WalkBuilderConfig;
+use super::{DirtyBuffers, WalkBuilderConfig};
 
 pub fn run(
     pattern: String,
     walk_builder_config: WalkBuilderConfig,
+    dirty_buffers: DirtyBuffers,
     send_match: Arc<dyn Fn(Match) -> SendResult + Send + Sync>,
 ) -> anyhow::Result<()> {
     walk_builder_config.run_with_search(
         true,
+        dirty_buffers,
         send_match,
         Arc::new(move |buffer| {
             AstGrep::new(buffer, &pattern)

--- a/src/list/grep.rs
+++ b/src/list/grep.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 use shared::absolute_path::AbsolutePath;
 
-use super::WalkBuilderConfig;
+use super::{DirtyBuffers, WalkBuilderConfig};
 
 #[derive(Clone, Debug, PartialEq, Eq, Copy)]
 pub struct RegexConfig {
@@ -128,6 +128,7 @@ pub fn run(
     pattern: &str,
     walk_builder_config: WalkBuilderConfig,
     grep_config: RegexConfig,
+    dirty_buffers: DirtyBuffers,
     send_match: Arc<dyn Fn(Match) -> SendResult + Send + Sync>,
 ) -> anyhow::Result<()> {
     let pattern = get_regex(pattern, grep_config)?.as_str().to_string();
@@ -138,13 +139,16 @@ pub fn run(
 
     walk_builder_config.run_async(
         false,
+        dirty_buffers,
         Arc::new(move |path_index, path, buffer| {
             let mut searcher = SearcherBuilder::new().build();
             let mut matches = vec![];
 
-            let _ = searcher.search_path(
+            // Search the buffer's own content (rather than re-reading the
+            // file from disk) so that unsaved changes are reflected.
+            let _ = searcher.search_slice(
                 &matcher,
-                path.clone(),
+                buffer.content().as_bytes(),
                 sinks::UTF8(|line_number, line| {
                     if let Ok(locations) = to_locations(
                         &buffer,

--- a/src/list/mod.rs
+++ b/src/list/mod.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashMap,
     ops::Range,
     path::PathBuf,
     sync::{mpsc::Sender, Arc},
@@ -28,16 +29,23 @@ pub struct WalkBuilderConfig {
 }
 type GetRange = dyn Fn(&Buffer) -> Vec<Range<usize>> + Send + Sync;
 
+/// Buffers that have unsaved changes, keyed by their file path.
+/// Used so that a global search/replace reflects the live buffer content
+/// instead of what is currently saved on disk.
+pub type DirtyBuffers = Arc<HashMap<AbsolutePath, Buffer>>;
+
 impl WalkBuilderConfig {
     pub fn run_with_search(
         self,
         enable_tree_sitter: bool,
+        dirty_buffers: DirtyBuffers,
         send_match: Arc<dyn Fn(Match) -> SendResult + Send + Sync>,
         get_ranges: Arc<GetRange>,
     ) -> anyhow::Result<()> {
         let sender = reorder_batches(send_match);
         self.run_async(
             enable_tree_sitter,
+            dirty_buffers,
             Arc::new(move |path_index, path, buffer| {
                 let matches = get_ranges(&buffer)
                     .into_iter()
@@ -125,6 +133,7 @@ impl WalkBuilderConfig {
     pub fn run_async(
         self,
         enable_tree_sitter: bool,
+        dirty_buffers: DirtyBuffers,
         on_visit_buffer: Arc<
             dyn Fn(/*file index (0 = first file)*/ usize, AbsolutePath, Buffer) + Send + Sync,
         >,
@@ -166,17 +175,19 @@ impl WalkBuilderConfig {
                 })
                 .filter_map(|path| {
                     let path: PathBuf = path.path().into();
-                    if let Ok(path) = path.try_into() {
-                        // Tree-sitter should be disabled whenever possible during
-                        // global search, because it will slow down the operation tremendously
-                        if let Ok(buffer) = Buffer::from_path(&path, enable_tree_sitter) {
-                            if !enable_tree_sitter {
-                                debug_assert!(buffer.tree().is_none());
-                            }
-                            return Some((path, buffer));
-                        }
+                    let path: AbsolutePath = path.try_into().ok()?;
+                    // If this file has an open buffer with unsaved changes, search
+                    // its in-memory content instead of what is saved on disk.
+                    if let Some(buffer) = dirty_buffers.get(&path) {
+                        return Some((path, buffer.clone()));
                     }
-                    None
+                    // Tree-sitter should be disabled whenever possible during
+                    // global search, because it will slow down the operation tremendously
+                    let buffer = Buffer::from_path(&path, enable_tree_sitter).ok()?;
+                    if !enable_tree_sitter {
+                        debug_assert!(buffer.tree().is_none());
+                    }
+                    Some((path, buffer))
                 })
                 .enumerate()
                 .par_bridge()

--- a/src/list/mod.rs
+++ b/src/list/mod.rs
@@ -32,7 +32,18 @@ type GetRange = dyn Fn(&Buffer) -> Vec<Range<usize>> + Send + Sync;
 /// Buffers that have unsaved changes, keyed by their file path.
 /// Used so that a global search/replace reflects the live buffer content
 /// instead of what is currently saved on disk.
-pub type DirtyBuffers = Arc<HashMap<AbsolutePath, Buffer>>;
+#[derive(Clone, Default)]
+pub struct DirtyBuffers(Arc<HashMap<AbsolutePath, Buffer>>);
+
+impl DirtyBuffers {
+    pub fn new(dirty_buffers: HashMap<AbsolutePath, Buffer>) -> Self {
+        Self(Arc::new(dirty_buffers))
+    }
+
+    pub fn get(&self, path: &AbsolutePath) -> Option<&Buffer> {
+        self.0.get(path)
+    }
+}
 
 impl WalkBuilderConfig {
     pub fn run_with_search(

--- a/src/list/naming_convention_agnostic.rs
+++ b/src/list/naming_convention_agnostic.rs
@@ -2,15 +2,17 @@ use std::sync::Arc;
 
 use crate::{list::Match, selection_mode::NamingConventionAgnostic, thread::SendResult};
 
-use super::WalkBuilderConfig;
+use super::{DirtyBuffers, WalkBuilderConfig};
 
 pub fn run(
     pattern: String,
     walk_builder_config: WalkBuilderConfig,
+    dirty_buffers: DirtyBuffers,
     send_match: Arc<dyn Fn(Match) -> SendResult + Send + Sync>,
 ) -> anyhow::Result<()> {
     walk_builder_config.run_with_search(
         false,
+        dirty_buffers,
         send_match,
         Arc::new(move |buffer| {
             let pattern = pattern.clone();

--- a/src/test_app.rs
+++ b/src/test_app.rs
@@ -4383,6 +4383,51 @@ fn global_search_should_not_change_dirty_status() -> anyhow::Result<()> {
 }
 
 #[test]
+fn global_search_should_use_unsaved_buffer_content() -> anyhow::Result<()> {
+    execute_test(|s| {
+        Box::new([
+            App(OpenFile {
+                path: s.main_rs(),
+                owner: BufferOwner::User,
+                focus: true,
+            }),
+            Editor(SetContent("fn main() { call_main() }".to_string())),
+            Editor(Save),
+            App(UpdateLocalSearchConfig {
+                update: LocalSearchConfigUpdate::Search("call_main".to_string()),
+                scope: Scope::Global,
+                if_current_not_found: IfCurrentNotFound::LookForward,
+                run_search_after_config_updated: true,
+            }),
+            WaitForAppMessage(regex!("GlobalSearchFinished")),
+            // Sanity check: the match is found while the file is on disk and unmodified.
+            Expect(Quickfixes(Box::new([QuickfixListItem::new(
+                Location {
+                    path: s.main_rs(),
+                    range: (CharIndex(16)..CharIndex(25)).into(),
+                },
+                None,
+                Some("    call_main()\n".to_string()),
+            )]))),
+            // Modify the buffer without saving, so that "call_main" no longer
+            // appears in the buffer, even though it still appears on disk.
+            Editor(SetContent("fn main() { call_renamed() }".to_string())),
+            Expect(EditorIsDirty()),
+            App(UpdateLocalSearchConfig {
+                update: LocalSearchConfigUpdate::Search("call_main".to_string()),
+                scope: Scope::Global,
+                if_current_not_found: IfCurrentNotFound::LookForward,
+                run_search_after_config_updated: true,
+            }),
+            WaitForAppMessage(regex!("GlobalSearchFinished")),
+            // The global search should use the unsaved buffer content, so it
+            // should no longer find any match for "call_main".
+            Expect(Quickfixes(Box::new([]))),
+        ])
+    })
+}
+
+#[test]
 fn release_open_mol_should_not_close_popups() -> anyhow::Result<()> {
     execute_test(|s| {
         fn signature_help() -> LspNotification {


### PR DESCRIPTION
## Problem

Reported on Zulip by Daniel K Lyons: global search reads file contents from
disk instead of from open, unsaved buffers. After editing a buffer (without
saving) so that a previously-searched term no longer appears in the buffer,
repeating the same global search still highlights a "match" at that
location — because the search re-reads the stale content from disk.

## Root cause

- `WalkBuilderConfig::run_async` always built each file's `Buffer` via
  `Buffer::from_path`, ignoring any already-open buffer with unsaved edits.
- `list::grep::run` additionally bypassed even that buffer entirely for the
  actual text search: it called `grep_searcher`'s `search_path`, which reads
  the file straight from disk, and used the `Buffer` only for byte/char
  offset conversion.

## Fix

- Added `Layout::get_dirty_buffers`, which reuses the existing dirty-buffer
  tracking (`Buffer::dirty` / `Context::file_dirty_status`) to collect the
  in-memory content of every open buffer with unsaved changes, keyed by path.
- Threaded this map (`list::DirtyBuffers`) through `WalkBuilderConfig`,
  `grep::run`, `ast_grep::run`, and `naming_convention_agnostic::run`, so
  that when walking a file with an open, unsaved buffer, that buffer's
  content is used instead of re-reading the file from disk.
- `grep::run` now searches the buffer's content directly
  (`searcher.search_slice`) instead of re-reading the path from disk via
  `search_path`, so its behavior can no longer diverge from what
  `ast_grep`/naming-convention search already did.

## Test plan

- Open a file, save it, and run a global search for a term that exists in
  it — confirm it appears in the quickfix list.
- Without saving, edit the buffer so that term no longer appears in the
  buffer (while the term still exists on disk).
- Repeat the same global search — confirm the quickfix list no longer shows
  a match for that file/location, since the buffer no longer contains it.
- Save the file and confirm the match reappears/disappears as expected
  based on the saved content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Vn79HtywZCjS3k1homkrT